### PR TITLE
Changed inline to constexpr

### DIFF
--- a/include/AxisDriver.h
+++ b/include/AxisDriver.h
@@ -30,13 +30,8 @@
 #ifndef DMA_IN_KERNEL
 
 // Set flags
-static inline uint32_t axisSetFlags(uint32_t fuser, uint32_t luser, uint32_t cont) {
-   uint32_t flags;
-
-   flags  = fuser & 0xFF;
-   flags += (luser << 8) & 0xFF00;
-   flags += (cont  << 16) & 0x10000;
-   return(flags);
+static constexpr inline uint32_t axisSetFlags(uint32_t fuser, uint32_t luser, uint32_t cont) {
+   return ( ((cont & 0x1) << 16)  | ((luser & 0xFF) << 8) | ((fuser & 0xFF) << 0) );
 }
 
 static inline uint32_t axisGetFuser(uint32_t flags) {


### PR DESCRIPTION
`````
static constexpr inline uint32_t axisSetFlags(uint32_t fuser, uint32_t luser, uint32_t cont) {
   return ( ((cont & 0x1) << 16)  | ((luser & 0xFF) << 8) | ((fuser & 0xFF) << 0) );
}
`````

The constexpr also this routine to be used at compile time so compile time constants/enumerations can be defined.   The rules of constexpr methods are strict; basically one line with only a return