### PR TITLE
Fixes the buffer mapping calculation for offsets > 4GB

### DIFF
--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -83,7 +83,7 @@ inline void AxisG2_WriteFree ( struct DmaBuffer *buff, struct AxisG2Reg *reg, ui
    wrData[0] = buff->index & 0x0FFFFFFF;
 
    if ( desc128En ) {
-      wrData[0] |= (buff->buffHandle << 24) & 0x0FFFFFFF; // Addr bits 7:4 
+      wrData[0] |= (buff->buffHandle << 24) & 0xF0000000; // Addr bits 7:4 
       wrData[1]  = (buff->buffHandle >>  8) & 0xFFFFFFFF; // Addr bits 39:8
 
       iowrite32(wrData[1],&(reg->writeFifoB));

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -717,8 +717,8 @@ int Dma_Mmap(struct file *filp, struct vm_area_struct *vma) {
    struct DmaDevice * dev;
    struct DmaBuffer * buff;
 
-   uint32_t offset;
-   uint32_t vsize;
+   off_t    offset;
+   off_t    vsize;
    uint32_t idx;
    uint32_t ret;
 
@@ -734,7 +734,7 @@ int Dma_Mmap(struct file *filp, struct vm_area_struct *vma) {
    vma->vm_pgoff = 0;
 
    // Compute index, rx and tx buffers are the same size
-   idx = offset / dev->cfgSize;
+   idx = (uint32_t)(offset / (off_t)dev->cfgSize);
 
    // Attempt to find buffer
    if ( (buff = dmaGetBuffer(dev,idx)) == NULL ) {
@@ -744,7 +744,7 @@ int Dma_Mmap(struct file *filp, struct vm_area_struct *vma) {
 
    // Size must match the buffer size and offset must be size aligned
    if ( (vsize < dev->cfgSize) || (offset % dev->cfgSize) != 0 ) {
-      dev_warn(dev->device,"map: Invalid map size (%i) and offset (%i). cfgSize=%i\n",
+      dev_warn(dev->device,"map: Invalid map size (%li) and offset (%li). cfgSize=%i\n",
             vsize,offset,dev->cfgSize);
       return(-1);
    }
@@ -774,8 +774,8 @@ int Dma_Mmap(struct file *filp, struct vm_area_struct *vma) {
    else ret = -1;
 
    if ( ret < 0 )
-      dev_warn(dev->device,"map: Failed to map. start 0x%.8x, end 0x%.8x, offset %i, size %i, index %i, Ret=%i.\n",
-            (uint32_t)vma->vm_start,(uint32_t)vma->vm_end,offset,vsize,idx,ret);
+      dev_warn(dev->device,"map: Failed to map. start 0x%.8lx, end 0x%.8lx, offset %li, size %li, index %i, Ret=%i.\n",
+            vma->vm_start,vma->vm_end,offset,vsize,idx,ret);
 
    return (ret);
 }


### PR DESCRIPTION
This fixes an error in passing the buffer offset between user space and the kernel driver. The passed offset was computed using 32-bit values which resulted in an error mapping buffers above the 4GB boundary.

This fix requires both the driver and user space application be re-compiled. A parallel PR is being merged into the Rogue pre-release branch.