### PR TITLE
Remote unused alignment check

### DIFF
--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -328,11 +328,6 @@ void AxisG2_Init(struct DmaDevice *dev) {
    dev_info(dev->device,"Init: Read  ring at: sw 0x%llx -> hw 0x%llx.\n",(uint64_t)hwData->readAddr,(uint64_t)hwData->readHandle);
    dev_info(dev->device,"Init: Write ring at: sw 0x%llx -> hw 0x%llx.\n",(uint64_t)hwData->writeAddr,(uint64_t)hwData->writeHandle);
 
-   if ( (dev->cfgAlign != 0) && ( ((hwData->readHandle % dev->cfgAlign) != 0) || ((hwData->writeHandle % dev->cfgAlign) != 0) ) ) {
-      dev_warn(dev->device,"Init: Detected bad ring buffer alignment\n");
-      return;
-   }
-
    // Init and set ring address
    iowrite32(hwData->readHandle&0xFFFFFFFF,&(reg->rdBaseAddrLow));
    iowrite32((hwData->readHandle >> 32)&0xFFFFFFFF,&(reg->rdBaseAddrHigh));

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -120,12 +120,6 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
          break; 
       }
 
-      // Check buffer alignment
-      if ( (dev->cfgAlign != 0) && (((uint64_t)buff->buffAddr % dev->cfgAlign) != 0) ) {
-         dev_warn(dev->device,"dmaAllocBuffers: Found nonzero shift. sw=0x%llx, hw=0x%llx.\n",(uint64_t)buff->buffAddr,(uint64_t)buff->buffHandle);
-         break;
-      }
-
       // Set index
       buff->index = x + list->baseIdx;
       list->indexed[sl][sli] = buff;

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -60,7 +60,6 @@ struct DmaDevice {
    uint32_t cfgRxCount;
    uint32_t cfgMode;
    uint32_t cfgCont;
-   uint32_t cfgAlign;
 
    // Device tracking
    uint32_t        index;


### PR DESCRIPTION
The unused alignment check was causing problems running on 32-bit arm.