### PR TITLE
Arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # ----------------------------------------------------------------------------
 # 
 MAKE_HOME := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-
+ARCH ?= arm
 LOC_VERS := $(wildcard /lib/modules/*/build)
 LOC_VERS := $(patsubst %/,%,$(dir $(LOC_VERS)))
 LOC_VERS := $(notdir $(LOC_VERS))
@@ -57,12 +57,12 @@ driver:
 rce:
 	@mkdir -p $(MAKE_HOME)/install;
 	@ $(foreach d,$(RCE_DIRS), \
-		mkdir -p $(MAKE_HOME)/install/$(shell make -C $(d) -s kernelversion).arm; \
+		mkdir -p $(MAKE_HOME)/install/$(shell make -C $(d) -s kernelversion).$(ARCH); \
 		make -C $(MAKE_HOME)/rce_stream/driver KDIR=$(d) clean; \
 		make -C $(MAKE_HOME)/rce_stream/driver KDIR=$(d); \
-		scp $(MAKE_HOME)/rce_stream/driver/*.ko $(MAKE_HOME)/install/$(shell make -C $(d) -s kernelversion).arm/; \
+		scp $(MAKE_HOME)/rce_stream/driver/*.ko $(MAKE_HOME)/install/$(shell make -C $(d) -s kernelversion).$(ARCH)/; \
 		make -C $(MAKE_HOME)/rce_memmap/driver KDIR=$(d) clean; \
 		make -C $(MAKE_HOME)/rce_memmap/driver KDIR=$(d); \
-		scp $(MAKE_HOME)/rce_memmap/driver/*.ko $(MAKE_HOME)/install/$(shell make -C $(d) -s kernelversion).arm/; \
+		scp $(MAKE_HOME)/rce_memmap/driver/*.ko $(MAKE_HOME)/install/$(shell make -C $(d) -s kernelversion).$(ARCH)/; \
 	)
 

--- a/rce_hp_buffers/driver/Makefile
+++ b/rce_hp_buffers/driver/Makefile
@@ -18,7 +18,7 @@
 NAME := rce_hp
 HOME := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 COMP ?= arm-xilinx-linux-gnueabi-
-ARCH := arm
+ARCH ?= arm
 KDIR ?= /afs/slac/g/cci/volumes/vol1/xilinx/linux-xlnx
 KVER := $(shell make -C $(KDIR) -s kernelversion).arm
 SRCS := $(wildcard src/*.c)

--- a/rce_memmap/driver/Makefile
+++ b/rce_memmap/driver/Makefile
@@ -22,7 +22,7 @@
 NAME := rce_memmap
 HOME := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 COMP ?= arm-xilinx-linux-gnueabi-
-ARCH := arm
+ARCH ?= arm
 KDIR ?= /afs/slac/g/cci/volumes/vol1/xilinx/linux-xlnx
 KVER := $(shell make -C $(KDIR) -s kernelversion).arm
 SRCS := $(wildcard src/*.c)

--- a/rce_stream/driver/Makefile
+++ b/rce_stream/driver/Makefile
@@ -22,7 +22,7 @@
 NAME := rcestream
 HOME := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 COMP ?= arm-xilinx-linux-gnueabi-
-ARCH := arm
+ARCH ?= arm
 KDIR ?= /afs/slac/g/cci/volumes/vol1/xilinx/linux-xlnx
 KVER := $(shell make -C $(KDIR) -s kernelversion).arm
 SRCS := $(wildcard src/*.c)

--- a/rce_stream/driver/src/rce_top.c
+++ b/rce_stream/driver/src/rce_top.c
@@ -193,11 +193,13 @@ int Rce_Probe(struct platform_device *pdev) {
    }
 
    // Coherent
+   /* not available on arm64 */
+#if ! defined( __aarch64__)
    if( (dev->cfgMode & BUFF_ARM_ACP) || (dev->cfgMode & AXIS2_RING_ACP) ) {
        set_dma_ops(&pdev->dev,&arm_coherent_dma_ops);
        dev_info(dev->device,"Probe: Set COHERENT DMA =%i\n",dev->cfgMode);
    }
-
+#endif
    // Call common dma init function
    return(Dma_Init(dev));
 }


### PR DESCRIPTION
Allow override of CPU architecture in Makefiles. Don't enable coherent DMA mode for arm64, all arm64 DMA is coherent.