### PR TITLE
Generate a ~20hz interrupt using a software task

### DIFF
--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -424,7 +424,7 @@ void AxisG2_Enable(struct DmaDevice *dev) {
    // Start workqueue
    DECLARE_WORK(hwData->task, AxisG2_Task, dev);
    hwData->wqEnable = 1;
-   queue_delayed_work(hwData->wq,&(hwData->task),100);
+   queue_delayed_work(hwData->wq,&(hwData->task),1);
 
 }
 
@@ -609,6 +609,6 @@ void AxisG2_Task ( void *ptr ) {
 
    iowrite32(0x1,&(reg->forceInt));
 
-   if ( hwData->wqEnable ) queue_delayed_work(hwData->wq,&(hwData->task),100);
+   if ( hwData->wqEnable ) queue_delayed_work(hwData->wq,&(hwData->task),1);
 }
 

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -422,7 +422,7 @@ void AxisG2_Enable(struct DmaDevice *dev) {
    // Start workqueue
    hwData->wqEnable = 1;
    INIT_DELAYED_WORK(&(hwData->dlyWork), AxisG2_WqTask);
-   queue_delayed_work(hwData->wq,&(hwData->dlyWork),1);
+   queue_delayed_work(hwData->wq,&(hwData->dlyWork),10);
 
 }
 
@@ -608,6 +608,6 @@ void AxisG2_WqTask ( struct work_struct *work ) {
 
    iowrite32(0x1,&(reg->forceInt));
 
-   if ( hwData->wqEnable ) queue_delayed_work(hwData->wq,&(hwData->dlyWork),1);
+   if ( hwData->wqEnable ) queue_delayed_work(hwData->wq,&(hwData->dlyWork),10);
 }
 

--- a/common/driver/axis_gen2.h
+++ b/common/driver/axis_gen2.h
@@ -81,6 +81,8 @@ struct AxisG2Return {
 };
 
 struct AxisG2Data {
+   struct DmaDevice *dev;
+
    uint32_t    desc128En;
 
    uint32_t  * readAddr;
@@ -105,8 +107,8 @@ struct AxisG2Data {
    uint32_t    bgEnable;
    uint32_t    wqEnable;
 
-   struct work_struct task;
    struct workqueue_struct *wq;
+   struct delayed_work dlyWork;
 };
 
 // Map return
@@ -146,7 +148,7 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev);
 extern struct hardware_functions AxisG2_functions;
 
 // Work queue task
-static void AxisG2_Task ( void *ptr );
+void AxisG2_WqTask ( struct work_struct *work );
 
 #endif
 

--- a/common/driver/axis_gen2.h
+++ b/common/driver/axis_gen2.h
@@ -23,6 +23,7 @@
 #include <dma_common.h>
 #include <dma_buffer.h>
 #include <linux/interrupt.h>
+#include <linux/workqueue.h>
 
 #define AXIS2_RING_ACP 0x10
 
@@ -102,6 +103,10 @@ struct AxisG2Data {
    uint32_t    contCount;
 
    uint32_t    bgEnable;
+   uint32_t    wqEnable;
+
+   struct work_struct task;
+   struct workqueue_struct *wq;
 };
 
 // Map return
@@ -139,6 +144,9 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev);
 
 // Set functions for gen2 card
 extern struct hardware_functions AxisG2_functions;
+
+// Work queue task
+static void AxisG2_Task ( void *ptr );
 
 #endif
 


### PR DESCRIPTION
This PR implements a sw task which will trigger an interrupt at roughly ~20hz. This will ensure any stale buffers lingering in the write queue are pushed to hardware. This should address ESROGUE-444 where I theorize that a race condition stalls a write packet in the outbound queue without any interrupts to transfer it to the outbound hardware buffer.