### PR TITLE
add some checking functions for DMA driver Tx Buff in Queues, and AXIS Driver Write_ReqMissied

### DIFF
--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -534,6 +534,11 @@ int32_t AxisG2_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
          return(0);
          break;
 
+      // Write Req Missed
+      case AXIS_Write_ReqMissed:
+         return(ioread32(&(reg->wrReqMissed)));
+         break;
+
       default:
          dev_warn(dev->device,"Command: Invalid command=%i\n",cmd);
          return(-1);

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -569,6 +569,7 @@ ssize_t Dma_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
    uint32_t   x;
    uint32_t   cnt;
    uint32_t   bCnt;
+   uint32_t   qCnt;
    uint32_t * indexes;
 
    desc = (struct DmaDesc *)filp->private_data;
@@ -590,6 +591,16 @@ ssize_t Dma_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
       // Get tx buffer count
       case DMA_Get_TxBuff_Count:
          return(dev->txBuffers.count);
+         break;
+
+      // Get tx buffer in SW Queue count
+      case DMA_Get_TxBuffinSWQ_Count:
+         qCnt    = 0;
+         for (x=dev->txBuffers.baseIdx; x < (dev->txBuffers.baseIdx + dev->txBuffers.count); x++) {
+            buff = dmaGetBufferList(&(dev->txBuffers),x);
+            if ( (!buff->inHw) &&  buff->inQ   ) qCnt++;
+         }
+         return(qCnt);
          break;
 
       // Get buffer size, same size for rx and tx

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -569,7 +569,11 @@ ssize_t Dma_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
    uint32_t   x;
    uint32_t   cnt;
    uint32_t   bCnt;
+   uint32_t   userCnt;
+   uint32_t   hwCnt;
+   uint32_t   hwQCnt;
    uint32_t   qCnt;
+   uint32_t   miss;
    uint32_t * indexes;
 
    desc = (struct DmaDesc *)filp->private_data;
@@ -593,6 +597,36 @@ ssize_t Dma_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
          return(dev->txBuffers.count);
          break;
 
+      // Get tx buffer in User count
+      case DMA_Get_TxBuffinUser_Count:
+         userCnt    = 0;
+         for (x=dev->txBuffers.baseIdx; x < (dev->txBuffers.baseIdx + dev->txBuffers.count); x++) {
+            buff = dmaGetBufferList(&(dev->txBuffers),x);
+            if (  buff->userHas   ) userCnt++;
+         }
+         return(userCnt);
+         break;
+
+      // Get tx buffer in HW count
+      case DMA_Get_TxBuffinHW_Count:
+         hwCnt    = 0;
+         for (x=dev->txBuffers.baseIdx; x < (dev->txBuffers.baseIdx + dev->txBuffers.count); x++) {
+            buff = dmaGetBufferList(&(dev->txBuffers),x);
+            if ( buff->inHw &&  (!buff->inQ)   ) hwCnt++;
+         }
+         return(hwCnt);
+         break;
+
+      // Get tx buffer in Pre-HW Queue count
+      case DMA_Get_TxBuffinPreHWQ_Count:
+         hwQCnt    = 0;
+         for (x=dev->txBuffers.baseIdx; x < (dev->txBuffers.baseIdx + dev->txBuffers.count); x++) {
+            buff = dmaGetBufferList(&(dev->txBuffers),x);
+            if ( buff->inHw &&  buff->inQ   ) hwQCnt++;
+         }
+         return(hwQCnt);
+         break;
+
       // Get tx buffer in SW Queue count
       case DMA_Get_TxBuffinSWQ_Count:
          qCnt    = 0;
@@ -601,6 +635,16 @@ ssize_t Dma_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
             if ( (!buff->inHw) &&  buff->inQ   ) qCnt++;
          }
          return(qCnt);
+         break;
+
+      // Get tx buffer missing count
+      case DMA_Get_TxBuffMiss_Count:
+         miss    = 0;
+         for (x=dev->txBuffers.baseIdx; x < (dev->txBuffers.baseIdx + dev->txBuffers.count); x++) {
+            buff = dmaGetBufferList(&(dev->txBuffers),x);
+            if ( (buff->userHas==NULL) && (buff->inHw==0) &&  (buff->inQ==0)   ) miss++;
+         }
+         return(miss);
          break;
 
       // Get buffer size, same size for rx and tx

--- a/include/AxisDriver.h
+++ b/include/AxisDriver.h
@@ -62,7 +62,7 @@ static inline void axisReadAck (int32_t fd) {
 }
 
 // Write Req Missed
-static inline void axisReadAck (int32_t fd) {
+static inline void axisWriteReqMissed (int32_t fd) {
    ioctl(fd,AXIS_Write_ReqMissed,0);
 }
 

--- a/include/AxisDriver.h
+++ b/include/AxisDriver.h
@@ -25,6 +25,7 @@
 
 // Commands
 #define AXIS_Read_Ack 0x2001
+#define AXIS_Write_ReqMissed 0x2002
 
 // Everything below is hidden during kernel module compile
 #ifndef DMA_IN_KERNEL
@@ -58,6 +59,11 @@ static inline uint32_t axisGetCont(uint32_t flags) {
 // Read ACK
 static inline void axisReadAck (int32_t fd) {
    ioctl(fd,AXIS_Read_Ack,0);
+}
+
+// Write Req Missed
+static inline void axisReadAck (int32_t fd) {
+   ioctl(fd,AXIS_Write_ReqMissed,0);
 }
 
 #endif

--- a/include/DmaDriver.h
+++ b/include/DmaDriver.h
@@ -49,7 +49,11 @@
 #define DMA_Read_Register    0x100B
 #define DMA_Get_RxBuff_Count 0x100C
 #define DMA_Get_TxBuff_Count 0x100D
-#define DMA_Get_TxBuffinSWQ_Count 0x100F
+#define DMA_Get_TxBuffinUser_Count 0x100F
+#define DMA_Get_TxBuffinHW_Count 0x1010
+#define DMA_Get_TxBuffinPreHWQ_Count 0x1011
+#define DMA_Get_TxBuffinSWQ_Count 0x1012
+#define DMA_Get_TxBuffMiss_Count 0x1013
 
 // Mask size
 #define DMA_MASK_SIZE 512

--- a/include/DmaDriver.h
+++ b/include/DmaDriver.h
@@ -49,6 +49,7 @@
 #define DMA_Read_Register    0x100B
 #define DMA_Get_RxBuff_Count 0x100C
 #define DMA_Get_TxBuff_Count 0x100D
+#define DMA_Get_TxBuffinSWQ_Count 0x100F
 
 // Mask size
 #define DMA_MASK_SIZE 512


### PR DESCRIPTION
JIRA ticket: 
https://jira.slac.stanford.edu/projects/ESROGUE/issues/ESROGUE-486?filter=allopenissues

1) DMA Driver: 
add Tx Buff checking for several queues into ioctl func:
#define DMA_Get_TxBuffinUser_Count 0x100F
#define DMA_Get_TxBuffinHW_Count 0x1010
#define DMA_Get_TxBuffinPreHWQ_Count 0x1011
#define DMA_Get_TxBuffinSWQ_Count 0x1012
#define DMA_Get_TxBuffMiss_Count 0x1013

2) AXIS Driver:
add Write_ReqMissed checking to AXIS_gen2
#define AXIS_Write_ReqMissed 0x2002