### PR TITLE
Update DmaDriver.h

### DIFF
--- a/include/DmaDriver.h
+++ b/include/DmaDriver.h
@@ -27,7 +27,7 @@
 #endif
 
 // API Version
-#define DMA_VERSION  0x05
+#define DMA_VERSION  0x06
 
 // Error values
 #define DMA_ERR_FIFO 0x01


### PR DESCRIPTION
### Description
- Version bump because API has changed for the address
- It was 32-bit and now 64-bit address for API interfaces