### PR TITLE
Fixes to make datadev unloadable

### DIFF
--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -225,6 +225,28 @@ int Dma_Init(struct DmaDevice *dev) {
 void  Dma_Clean(struct DmaDevice *dev) {
    uint32_t x;
 
+   // Call card specific CLear
+   dev->hwFunc->clear(dev);
+
+   // Release IRQ
+   if ( dev->irq != 0 ) free_irq(dev->irq, dev);
+
+   // Free buffers
+   dmaFreeBuffers (&(dev->rxBuffers));
+   dmaFreeBuffers (&(dev->txBuffers));
+
+   // CLear tx queue
+   dmaQueueFree(&(dev->tq));
+
+   // Clear descriptors if they exist
+   for (x=0; x < DMA_MAX_DEST; x++) dev->desc[x] = NULL;
+
+   // Release memory region
+   release_mem_region(dev->baseAddr, dev->baseSize);
+
+   // Unmap
+   iounmap(dev->base);
+
    // Cleanup proc
    remove_proc_entry(dev->devName,NULL);
    cdev_del(&(dev->charDev));
@@ -234,28 +256,6 @@ void  Dma_Clean(struct DmaDevice *dev) {
    else dev_warn(dev->device,"Clean: gCl is already NULL.\n");
 
    unregister_chrdev_region(dev->devNum, 1);
-
-   // Call card specific CLear
-   dev->hwFunc->clear(dev);
-
-   // CLear tx queue
-   dmaQueueFree(&(dev->tq));
-
-   // Free buffers
-   dmaFreeBuffers (&(dev->txBuffers));
-   dmaFreeBuffers (&(dev->rxBuffers));
-
-   // Clear descriptors if they exist
-   for (x=0; x < DMA_MAX_DEST; x++) dev->desc[x] = NULL;
-
-   // Release memory region
-   release_mem_region(dev->baseAddr, dev->baseSize);
-
-   // Release IRQ
-   if ( dev->irq != 0 ) free_irq(dev->irq, dev);
-
-   // Unmap
-   iounmap(dev->base);
 
    if (gDmaDevCount == 0 && gCl != NULL) {
       dev_info(dev->device,"Clean: Destroying device class\n");

--- a/data_dev/driver/src/data_dev_top.c
+++ b/data_dev/driver/src/data_dev_top.c
@@ -236,11 +236,12 @@ void  DataDev_Remove(struct pci_dev *pcidev) {
    // Decrement count
    gDmaDevCount--;
 
+   // Call common dma clean function
+   Dma_Clean(dev);
+
    // Disable device
    pci_disable_device(pcidev);
 
-   // Call common dma init function
-   Dma_Clean(dev);
    pr_info("%s: Remove: Driver is unloaded.\n",MOD_NAME);
 }
 


### PR DESCRIPTION
### Description
The set of modifications associated with this pull request rearranges the tear down code in 3 different areas to be in reverse order of the set up code.  It also waits for the work queue to be empty before attempting to destroy it.  With these changes, the devmod driver appears to be reliably unloadable without tracebacks or other complaints.