### PR TITLE
ref count to prevent premature driver unload

### DIFF
--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -31,6 +31,7 @@
 
 // Define interface routines
 struct file_operations DmaFunctions = {
+   owner:          THIS_MODULE,
    read:           Dma_Read,
    write:          Dma_Write,
    open:           Dma_Open,


### PR DESCRIPTION
ref count to prevent premature driver unload. kernel has this facility, here we use it.