### PR TITLE
Implement proper driver cleanup mechanism

### DIFF
--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -169,6 +169,7 @@ cleanup_lists:
          kfree(list->indexed[x]);
    if ( list->indexed != NULL ) kfree(list->indexed);
 
+// Return 0 as no buffers were allocated
 cleanup_forced_exit:
    return 0;
 }
@@ -446,17 +447,17 @@ size_t dmaQueueInit ( struct DmaQueue *queue, uint32_t count ) {
    queue->write    = 0;
 
    queue->queue = (struct DmaBuffer ***)kmalloc(queue->subCount * sizeof(struct DmaBuffer **),GFP_KERNEL);
-   //if (queue->queue != NULL) {
-   //   goto cleanup_force_exit;
-   //}
+   if (queue->queue == NULL) {
+      goto cleanup_force_exit;
+   }
 
    for(x=0; x < queue->subCount; x++) {
       queue->queue[x] = (struct DmaBuffer **)kmalloc(BUFFERS_PER_LIST * sizeof(struct DmaBuffer *),GFP_KERNEL);
-   //   if (queue->queue[x] == NULL) {
-   //      goto cleanup_sub_queue;
-   //   }
+      if (queue->queue[x] == NULL) {
+         goto cleanup_sub_queue;
+      }
    }
-
+   
    spin_lock_init(&(queue->lock));
    init_waitqueue_head(&(queue->wait));
    return(count);

--- a/common/driver/dma_buffer.h
+++ b/common/driver/dma_buffer.h
@@ -115,7 +115,10 @@ struct DmaQueue {
 size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
                          uint32_t count, uint32_t baseIdx, enum dma_data_direction direction);
 
-// Free a list of buffer
+// Free a list of buffers
+void dmaFreeBuffersList(struct DmaBufferList *list);
+
+// Free a list of buffers including heads
 void dmaFreeBuffers ( struct DmaBufferList *list );
 
 // Binary search

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -250,13 +250,13 @@ int Dma_Init(struct DmaDevice *dev) {
 
    /* Clean mess on failure */
 
-cleanup_request_irq:
+// Free requested IRQ
    if ( dev->irq != 0 ) free_irq(dev->irq, dev);
 
 cleanup_card_clear:
    dev->hwFunc->clear(dev);
 
-cleanup_rx_buffers:
+// Clean RX buffers
    dmaFreeBuffers(&(dev->rxBuffers));
 
 cleanup_dma_queue:

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -165,7 +165,6 @@ int Dma_Init(struct DmaDevice *dev) {
          goto cleanup_cdev_add;
       }
       gCl->devnode = (void *)Dma_DevNode;
-      dev_info(dev->device,"Init: Created device class\n");
    }
 
    // Attempt to create the device
@@ -283,11 +282,9 @@ cleanup_class_create:
 
 cleanup_cdev_add:
    cdev_del(&(dev->charDev));
-   dev_err(dev->device,"cleanup: cdev_del.\n");
 
 cleanup_alloc_chrdev_region:
-      unregister_chrdev_region(dev->devNum, 1);
-      dev_err(dev->device,"cleanup: unregister_chrdev_region.\n");
+   unregister_chrdev_region(dev->devNum, 1);
 
    return -1;   
 }

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -88,6 +88,16 @@ char *Dma_DevNode(struct device *dev, umode_t *mode){
    return(NULL);
 }
 
+void Dma_UnmapReg ( struct DmaDevice *dev ) {
+
+   // Release memory region
+   release_mem_region(dev->baseAddr, dev->baseSize);
+
+   // Unmap
+   iounmap(dev->base);
+
+}
+
 // Map address space in buffer
 int Dma_MapReg ( struct DmaDevice *dev ) {
    if ( dev->base == NULL ) {
@@ -109,10 +119,15 @@ int Dma_MapReg ( struct DmaDevice *dev ) {
       // Hold memory region
       if ( request_mem_region(dev->baseAddr, dev->baseSize, dev->devName) == NULL ) {
          dev_err(dev->device,"Init: Memory in use.\n");
-         return -1;
+         goto cleanup_ioremap;
       }
    }
    return(0);
+
+   /* Cleanup */
+cleanup_ioremap:
+   iounmap(dev->base);
+   return -1;
 }
 
 // Create and init device, called from top level probe function
@@ -132,22 +147,6 @@ int Dma_Init(struct DmaDevice *dev) {
       return(-1);
    }
 
-   // Create class struct if it does not already exist
-   if (gCl == NULL) {
-      dev_info(dev->device,"Init: Creating device class\n");
-      if ((gCl = class_create(THIS_MODULE, dev->devName)) == NULL) {
-         dev_err(dev->device,"Init: Failed to create device class\n");
-         return(-1);
-      }
-      gCl->devnode = (void *)Dma_DevNode;
-   }
-
-   // Attempt to create the device
-   if (device_create(gCl, NULL, dev->devNum, NULL, dev->devName) == NULL) {
-      dev_err(dev->device,"Init: Failed to create device file\n");
-      return -1;
-   }
-
    // Init the device
    cdev_init(&(dev->charDev), &DmaFunctions);
    dev->major = MAJOR(dev->devNum);
@@ -155,14 +154,38 @@ int Dma_Init(struct DmaDevice *dev) {
    // Add the charactor device
    if (cdev_add(&(dev->charDev), dev->devNum, 1) == -1) {
       dev_err(dev->device,"Init: Failed to add device file.\n");
-      return -1;
+      goto cleanup_alloc_chrdev_region;
    }
 
+   // Create class struct if it does not already exist
+   if (gCl == NULL) {
+      dev_info(dev->device,"Init: Creating device class\n");
+      if ((gCl = class_create(THIS_MODULE, dev->devName)) == NULL) {
+         dev_err(dev->device,"Init: Failed to create device class\n");
+         goto cleanup_cdev_add;
+      }
+      gCl->devnode = (void *)Dma_DevNode;
+      dev_info(dev->device,"Init: Created device class\n");
+   }
+
+   // Attempt to create the device
+   if (device_create(gCl, NULL, dev->devNum, NULL, dev->devName) == NULL) {
+      dev_err(dev->device,"Init: Failed to create device file\n");
+      goto cleanup_class_create;
+   }
+
+
    // Setup /proc
-   proc_create_data(dev->devName, 0, NULL, &DmaProcOps, dev);
+   if ( NULL == proc_create_data(dev->devName, 0, NULL, &DmaProcOps, dev)) {
+      dev_err(dev->device,"Init: Failed to create proc entry.\n");
+      goto cleanup_device_create;
+   }
 
    // Remap the I/O register block so that it can be safely accessed.
-   if ( Dma_MapReg(dev) < 0 ) return(-1);
+   if ( Dma_MapReg(dev) < 0 ){
+      dev_err(dev->device,"Init: Failed to map register block.\n");
+      goto cleanup_proc_create_data;
+   }
 
    // Init descriptors
    for (x=0; x < DMA_MAX_DEST; x++) dev->desc[x] = NULL;
@@ -181,10 +204,15 @@ int Dma_Init(struct DmaDevice *dev) {
    dev_info(dev->device,"Init: Created  %i out of %i TX Buffers. %llu Bytes.\n", res,dev->cfgTxCount,tot);
 
    // Bad buffer allocation
-   if ( dev->cfgTxCount > 0 && res == 0 ) return(-1);
+   if ( dev->cfgTxCount > 0 && res == 0 ) 
+      goto cleanup_dma_mapreg;
 
    // Init transmit queue
-   dmaQueueInit(&(dev->tq),dev->txBuffers.count);
+   res = dmaQueueInit(&(dev->tq),dev->txBuffers.count);
+   if (res == 0 && dev->txBuffers.count > 0) {
+      dev_err(dev->device,"dmaQueueInit: Failed to initialize DMA queues.\n");
+      goto cleanup_tx_buffers;
+   }
 
    // Populate transmit queue
    for (x=dev->txBuffers.baseIdx; x < (dev->txBuffers.baseIdx + dev->txBuffers.count); x++)
@@ -199,7 +227,8 @@ int Dma_Init(struct DmaDevice *dev) {
    dev_info(dev->device,"Init: Created  %i out of %i RX Buffers. %llu Bytes.\n", res,dev->cfgRxCount,tot);
 
    // Bad buffer allocation
-   if ( dev->cfgRxCount > 0 && res == 0 ) return(-1);
+   if ( dev->cfgRxCount > 0 && res == 0 ) 
+      goto cleanup_dma_queue;
 
    // Call card specific init
    dev->hwFunc->init(dev);
@@ -212,13 +241,55 @@ int Dma_Init(struct DmaDevice *dev) {
       // Result of request IRQ from OS.
       if (res < 0) {
          dev_err(dev->device,"Init: Unable to allocate IRQ.");
-         return -1;
+         goto cleanup_card_clear;
       }
    }
 
    // Enable card
    dev->hwFunc->enable(dev);
    return 0;
+
+   /* Clean mess on failure */
+
+cleanup_request_irq:
+   if ( dev->irq != 0 ) free_irq(dev->irq, dev);
+
+cleanup_card_clear:
+   dev->hwFunc->clear(dev);
+
+cleanup_rx_buffers:
+   dmaFreeBuffers(&(dev->rxBuffers));
+
+cleanup_dma_queue:
+   dmaQueueFree(&(dev->tq));
+
+cleanup_tx_buffers:
+   dmaFreeBuffers(&(dev->txBuffers));
+
+cleanup_dma_mapreg:
+   Dma_UnmapReg(dev);
+
+cleanup_proc_create_data:
+   remove_proc_entry(dev->devName,NULL);
+
+cleanup_device_create:
+   if ( gCl != NULL ) device_destroy(gCl, dev->devNum);   
+      
+cleanup_class_create:
+   if (gDmaDevCount == 0 && gCl != NULL) {
+      class_destroy(gCl);
+      gCl = NULL;
+   }         
+
+cleanup_cdev_add:
+   cdev_del(&(dev->charDev));
+   dev_err(dev->device,"cleanup: cdev_del.\n");
+
+cleanup_alloc_chrdev_region:
+      unregister_chrdev_region(dev->devNum, 1);
+      dev_err(dev->device,"cleanup: unregister_chrdev_region.\n");
+
+   return -1;   
 }
 
 
@@ -242,11 +313,7 @@ void  Dma_Clean(struct DmaDevice *dev) {
    // Clear descriptors if they exist
    for (x=0; x < DMA_MAX_DEST; x++) dev->desc[x] = NULL;
 
-   // Release memory region
-   release_mem_region(dev->baseAddr, dev->baseSize);
-
-   // Unmap
-   iounmap(dev->base);
+   Dma_UnmapReg ( dev ) ;
 
    // Cleanup proc
    remove_proc_entry(dev->devName,NULL);

--- a/petalinux/axistreamdma/files/axistreamdma.c
+++ b/petalinux/axistreamdma/files/axistreamdma.c
@@ -128,9 +128,6 @@ int Rce_Probe(struct platform_device *pdev) {
    memset(dev,0,sizeof(struct DmaDevice));
    dev->index = tmpIdx;
 
-   // Increment count
-   gDmaDevCount++;
-
    // Create a device name
    strcpy(dev->devName,tmpName);
 
@@ -200,8 +197,21 @@ int Rce_Probe(struct platform_device *pdev) {
        dev_info(dev->device,"Probe: Set COHERENT DMA =%i\n",dev->cfgMode);
    }
 #endif
+
    // Call common dma init function
-   return(Dma_Init(dev));
+   if ( Dma_Init(dev) < 0 ) 
+      goto cleanup_force_exit;
+
+   // Increment count only after DMA is initialized successfully
+   gDmaDevCount++;
+
+   return 0;
+
+   /* Cleanup after probe failure */
+cleanup_force_exit:
+   return -1;
+
+   
 }
 
 


### PR DESCRIPTION
### Fix description
A proper driver cleanup mechanism was set up to perform cleanup upon memory allocation failures, where the driver now exits gracefully ([ESROGUE-562](https://jira.slac.stanford.edu/browse/ESROGUE-562)). As a plus, in the datadev driver, the driver unloads itself if the device probing fails (i.e. `rmmod datadev` is no longer necessary). While in the case of the axistreamdma driver, the driver must still be unloaded manually using the `rmmod axistreamdma` command if the device probing fails. The reason is that some effort is required (but may not be deemed necessary or relevant to this issue) to substitute the `module_platform_driver `(general macro with no special module init/exit functionalities) and implement the automatic unloading fix. Both drivers should be able to be loaded and unloaded as many time as necessary.

### Tests
Tests were done using an **x86_64** workstation only and using the datadev driver. Allocation failures were induced by altering the code and forcing errors. The driver loading and unloading tests were also performed successfully.