### PR TITLE
Fix kernel v5  compilation

### DIFF
--- a/rce_memmap/driver/Makefile
+++ b/rce_memmap/driver/Makefile
@@ -24,7 +24,7 @@ HOME := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 COMP ?= arm-xilinx-linux-gnueabi-
 ARCH ?= arm
 KDIR ?= /afs/slac/g/cci/volumes/vol1/xilinx/linux-xlnx
-KVER := $(shell make -C $(KDIR) -s kernelversion).arm
+KVER := $(shell make -C $(KDIR) ARCH=$(ARCH) -s kernelversion).$(ARCH)
 SRCS := $(wildcard src/*.c)
 OBJS := $(patsubst %.c,%.o,$(SRCS))
 GCC  := $(COMP)gcc

--- a/rce_stream/driver/Makefile
+++ b/rce_stream/driver/Makefile
@@ -24,7 +24,7 @@ HOME := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 COMP ?= arm-xilinx-linux-gnueabi-
 ARCH ?= arm
 KDIR ?= /afs/slac/g/cci/volumes/vol1/xilinx/linux-xlnx
-KVER := $(shell make -C $(KDIR) -s kernelversion).arm
+KVER := $(shell make -C $(KDIR) ARCH=$(ARCH) -s kernelversion).$(ARCH)
 SRCS := $(wildcard src/*.c)
 OBJS := $(patsubst %.c,%.o,$(SRCS))
 GCC  := $(COMP)gcc

--- a/rce_stream/driver/src/rce_top.c
+++ b/rce_stream/driver/src/rce_top.c
@@ -35,6 +35,7 @@
 #include <linux/of_platform.h>
 #include <linux/of_address.h>
 #include <linux/of_irq.h>
+#include <linux/dma-map-ops.h>
 
 // Init Configuration values
 int cfgTxCount0 = 8;


### PR DESCRIPTION

### Fix compilation for Xilinx kernel release 2022.2 (kernel 5.15)

### Details
* one missing header added
* fixed RCE drivers Makefile for cross compilation