### PR TITLE
Move data processing into work queue and support pure polling mode

### DIFF
--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -169,7 +169,6 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct A
          }
       }
       hwData->readIndex = ((hwData->readIndex+1) % hwData->addrCount);
-      if ( handleCount > 1000 ) break;
    }
 
    // Process transmit software queue
@@ -239,8 +238,6 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct A
 
       // Update index
       hwData->writeIndex = ((hwData->writeIndex+1) % hwData->addrCount);
-
-      if ( handleCount > 2000 ) break;
    }
 
    // Unlock

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -246,7 +246,7 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg reg, struct Ax
    // Unlock
    spin_unlock(&dev->maskLock);
 
-   // Get (write / receive) return buffer list, get rid of this malloc!
+   // Get (write / receive) return buffer list
    if ( hwData->desc128En ) {
       do {
          rCnt = ((hwData->addrCount-1) - hwData->hwWrBuffCnt);

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -430,6 +430,8 @@ void AxisG2_Enable(struct DmaDevice *dev) {
       if ( ! dev->cfgIrqDis ) {
          INIT_DELAYED_WORK(&(hwData->dlyWork), AxisG2_WqTask_IrqForce);
          queue_delayed_work(hwData->wq,&(hwData->dlyWork),10);
+
+         // Init processing work, called from IRQ
          INIT_WORK(&(hwData->irqWork), AxisG2_WqTask_Service);
       }
 
@@ -620,7 +622,7 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
 }
 
 
-// Work queue task
+// Work queue task to force periodic IRQ
 void AxisG2_WqTask_IrqForce ( struct work_struct *work ) {
    struct AxisG2Reg *reg;
    struct AxisG2Data * hwData;
@@ -637,7 +639,7 @@ void AxisG2_WqTask_IrqForce ( struct work_struct *work ) {
 }
 
 
-// Work queue task
+// Work queue task to run a poll loop
 void AxisG2_WqTask_Poll ( struct work_struct *work ) {
    struct AxisG2Reg *reg;
    struct DmaDevice *dev;
@@ -655,7 +657,7 @@ void AxisG2_WqTask_Poll ( struct work_struct *work ) {
 }
 
 
-// Work queue task
+// Work queue task to handle IRQ processing
 void AxisG2_WqTask_Service ( struct work_struct *work ) {
    uint32_t handleCount;
 

--- a/common/driver/axis_gen2.h
+++ b/common/driver/axis_gen2.h
@@ -154,13 +154,13 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev);
 // Set functions for gen2 card
 extern struct hardware_functions AxisG2_functions;
 
-// Work queue task
+// Work queue task to force periodic IRQ
 void AxisG2_WqTask_IrqForce ( struct work_struct *work );
 
-// Work queue task
+// Work queue task to run a poll loop
 void AxisG2_WqTask_Poll ( struct work_struct *work );
 
-// Work queue task
+// Work queue task to handle IRQ processing
 void AxisG2_WqTask_Service ( struct work_struct *work );
 
 #endif

--- a/common/driver/axis_gen2.h
+++ b/common/driver/axis_gen2.h
@@ -110,6 +110,7 @@ struct AxisG2Data {
 
    struct workqueue_struct *wq;
    struct delayed_work dlyWork;
+   struct work_struct  irqWork;
 
    struct DmaBuffer  ** buffList;
 };
@@ -124,7 +125,7 @@ inline void AxisG2_WriteFree ( struct DmaBuffer *buff, struct AxisG2Reg *reg, ui
 inline void AxisG2_WriteTx ( struct DmaBuffer *buff, struct AxisG2Reg *reg, uint32_t desc128En );
 
 // Process receive and transmit data
-uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg reg, struct AxisG2Data *hwData );
+uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct AxisG2Data *hwData );
 
 // Interrupt handler
 irqreturn_t AxisG2_Irq(int irq, void *dev_id);
@@ -154,7 +155,13 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev);
 extern struct hardware_functions AxisG2_functions;
 
 // Work queue task
-void AxisG2_WqTask ( struct work_struct *work );
+void AxisG2_WqTask_IrqForce ( struct work_struct *work );
+
+// Work queue task
+void AxisG2_WqTask_Poll ( struct work_struct *work );
+
+// Work queue task
+void AxisG2_WqTask_Service ( struct work_struct *work );
 
 #endif
 

--- a/common/driver/axis_gen2.h
+++ b/common/driver/axis_gen2.h
@@ -26,6 +26,7 @@
 #include <linux/workqueue.h>
 
 #define AXIS2_RING_ACP 0x10
+#define BUFF_LIST_SIZE 1000
 
 struct AxisG2Reg {
    uint32_t enableVer;       // 0x0000
@@ -109,6 +110,8 @@ struct AxisG2Data {
 
    struct workqueue_struct *wq;
    struct delayed_work dlyWork;
+
+   struct DmaBuffer  ** buffList;
 };
 
 // Map return
@@ -119,6 +122,9 @@ inline void AxisG2_WriteFree ( struct DmaBuffer *buff, struct AxisG2Reg *reg, ui
 
 // Add buffer to tx list
 inline void AxisG2_WriteTx ( struct DmaBuffer *buff, struct AxisG2Reg *reg, uint32_t desc128En );
+
+// Process receive and transmit data
+uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg reg, struct AxisG2Data *hwData );
 
 // Interrupt handler
 irqreturn_t AxisG2_Irq(int irq, void *dev_id);

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -62,6 +62,7 @@ struct DmaDevice {
    uint32_t cfgCont;
    uint32_t cfgIrqHold;
    uint32_t cfgBgThold[8];
+   uint32_t cfgIrqDis;
 
    // Device tracking
    uint32_t        index;

--- a/data_dev/driver/src/data_dev_top.c
+++ b/data_dev/driver/src/data_dev_top.c
@@ -38,6 +38,7 @@ int cfgSize     = 0x20000; // 128kB
 int cfgMode     = BUFF_COHERENT;
 int cfgCont     = 1;
 int cfgIrqHold  = 10000;
+int cfgIrqDis   = 0;
 int cfgBgThold0 = 0;
 int cfgBgThold1 = 0;
 int cfgBgThold2 = 0;
@@ -159,6 +160,7 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    dev->cfgMode       = cfgMode;
    dev->cfgCont       = cfgCont;
    dev->cfgIrqHold    = cfgIrqHold;
+   dev->cfgIrqDis     = cfgIrqDis;
    dev->cfgBgThold[0] = cfgBgThold0;
    dev->cfgBgThold[1] = cfgBgThold1;
    dev->cfgBgThold[2] = cfgBgThold2;
@@ -298,6 +300,9 @@ MODULE_PARM_DESC(cfgCont, "RX continue enable");
 
 module_param(cfgIrqHold,int,0);
 MODULE_PARM_DESC(cfgIrqHold, "IRQ Holdoff");
+
+module_param(cfgIrqDis,int,0);
+MODULE_PARM_DESC(cfgIrqDis, "IRQ Disable");
 
 module_param(cfgBgThold0,int,0);
 MODULE_PARM_DESC(cfgBgThold0, "Buff Group Threshold 0");


### PR DESCRIPTION
This PR has two key changes.

The first change is to move most of the DMA handling out of the IRQ context and into a work queue thread which is queued in the interrupt processor. The IRQ handler will disable interrupts in the card and add a processing function onto the work queue. This function will then process the dma buffers and re-enable interrupts upon completion.

The second change is to support a pure polling mode where a polling function is repeatedly placed on a work queue in order to monitor the state of the dma buffers. In this mode interrupts on the card are never enabled.

I also removed a kmalloc and kfree which were occurring in the irq processing routine.

I am posting this PR for initial review. I will also need to perform high rate tests in both IRQ and polling mode to see how this impacts 1Mhz operation. 

