### PR TITLE
polishing the /proc/datadev_0 dump

### DIFF
--- a/common/driver/axi_version.c
+++ b/common/driver/axi_version.c
@@ -64,8 +64,9 @@ void AxiVersion_Read(struct DmaDevice *dev, void * base, struct AxiVersion *aVer
 // AXI Version Show
 void AxiVersion_Show(struct seq_file *s, struct DmaDevice *dev, struct AxiVersion *aVer) {
    int32_t x;
+   bool gitDirty = true;
 
-   seq_printf(s,"-------------- Axi Version ----------------\n");
+   seq_printf(s,"---------- Firmware Axi Version -----------\n");
    seq_printf(s,"     Firmware Version : 0x%x\n",aVer->firmwareVersion);
    seq_printf(s,"           ScratchPad : 0x%x\n",aVer->scratchPad);
    seq_printf(s,"        Up Time Count : %u\n",aVer->upTimeCount);
@@ -78,10 +79,17 @@ void AxiVersion_Show(struct seq_file *s, struct DmaDevice *dev, struct AxiVersio
    // for (x=0; x < 64; x++)
    // seq_printf(s,"          User Values : 0x%x\n",aVer->userValues[x]);
 
-   seq_printf(s,"            Device ID : 0x%x\n",aVer->deviceId);
+   // seq_printf(s,"            Device ID : 0x%x\n",aVer->deviceId);
 
    seq_printf(s,"             Git Hash : ");
-   for (x=0; x < 20; x++) seq_printf(s,"%.02x",aVer->gitHash[19-x]);
+   for (x=0; x < 20; x++) {
+      if ( aVer->gitHash[19-x] != 0 ) gitDirty = false;
+   }
+   if ( gitDirty ) {
+      seq_printf(s,"dirty (uncommitted code)");
+   } else {
+      for (x=0; x < 20; x++) seq_printf(s,"%.02x",aVer->gitHash[19-x]);
+   }
    seq_printf(s,"\n");
 
    seq_printf(s,"            DNA Value : 0x");

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -601,7 +601,7 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
    hwData = (struct AxisG2Data *)dev->hwData;
 
    seq_printf(s,"\n");
-   seq_printf(s,"-------------- General HW -----------------\n");
+   seq_printf(s,"---------- DMA Firmware General ----------\n");
    seq_printf(s,"          Int Req Count : %u\n",(ioread32(&(reg->intReqCount))));
    seq_printf(s,"        Hw Dma Wr Index : %u\n",(ioread32(&(reg->hwWrIndex))));
    seq_printf(s,"        Sw Dma Wr Index : %u\n",hwData->writeIndex);

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -1024,17 +1024,18 @@ int Dma_SeqShow(struct seq_file *s, void *v) {
    dev->hwFunc->seqShow(s,dev);
 
    seq_printf(s,"\n");
-   seq_printf(s,"-------------- General --------------------\n");
-   seq_printf(s,"          Dma Version : 0x%x\n",DMA_VERSION);
-   seq_printf(s,"          Git Version : " GITV "\n\n");
-   seq_printf(s,"-------------- Read Buffers ---------------\n");
+   seq_printf(s,"-------- DMA Kernel Driver General --------\n");
+   seq_printf(s," DMA Driver's Git Version : " GITV "\n");
+   seq_printf(s," DMA Driver's API Version : 0x%x\n",DMA_VERSION);
+   seq_printf(s,"\n");
+   seq_printf(s,"---- Read Buffers (Firmware->Software) ----\n");
    seq_printf(s,"         Buffer Count : %u\n",dev->rxBuffers.count);
    seq_printf(s,"          Buffer Size : %u\n",dev->cfgSize);
    seq_printf(s,"          Buffer Mode : %u\n",dev->cfgMode);
 
    userCnt = 0;
    hwCnt   = 0;
-   hwQCnt   = 0;
+   hwQCnt  = 0;
    qCnt    = 0;
    miss    = 0;
    max     = 0;
@@ -1072,7 +1073,7 @@ int Dma_SeqShow(struct seq_file *s, void *v) {
    seq_printf(s,"       Tot Buffer Use : %u\n",sum);
 
    seq_printf(s,"\n");
-   seq_printf(s,"-------------- Write Buffers ---------------\n");
+   seq_printf(s,"---- Write Buffers (Software->Firmware) ---\n");
    seq_printf(s,"         Buffer Count : %u\n",dev->txBuffers.count);
    seq_printf(s,"          Buffer Size : %u\n",dev->cfgSize);
    seq_printf(s,"          Buffer Mode : %u\n",dev->cfgMode);


### PR DESCRIPTION
### Description
- [adding dirty (uncommitted code) print support to AxiVersion](https://github.com/slaclab/aes-stream-drivers/commit/5a6165477fa83bd785ff6ec3fce3661dcf0e8366)
- [polishing the /proc/datadev_0 dump](https://github.com/slaclab/aes-stream-drivers/commit/a4d54459371597b029a6d5e7a9b5719aef27a008)
  - This should help clear up some of the confusion and vagueness of some of the dump values