### PR TITLE
Add generic load script with success checking, fix for kernels > 5.18

### DIFF
--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -203,7 +203,7 @@ int Dma_Init(struct DmaDevice *dev) {
    dev_info(dev->device,"Init: Created  %i out of %i TX Buffers. %llu Bytes.\n", res,dev->cfgTxCount,tot);
 
    // Bad buffer allocation
-   if ( dev->cfgTxCount > 0 && res == 0 ) 
+   if ( dev->cfgTxCount > 0 && res == 0 )
       goto cleanup_dma_mapreg;
 
    // Init transmit queue
@@ -226,7 +226,7 @@ int Dma_Init(struct DmaDevice *dev) {
    dev_info(dev->device,"Init: Created  %i out of %i RX Buffers. %llu Bytes.\n", res,dev->cfgRxCount,tot);
 
    // Bad buffer allocation
-   if ( dev->cfgRxCount > 0 && res == 0 ) 
+   if ( dev->cfgRxCount > 0 && res == 0 )
       goto cleanup_dma_queue;
 
    // Call card specific init
@@ -272,13 +272,13 @@ cleanup_proc_create_data:
    remove_proc_entry(dev->devName,NULL);
 
 cleanup_device_create:
-   if ( gCl != NULL ) device_destroy(gCl, dev->devNum);   
-      
+   if ( gCl != NULL ) device_destroy(gCl, dev->devNum);
+
 cleanup_class_create:
    if (gDmaDevCount == 0 && gCl != NULL) {
       class_destroy(gCl);
       gCl = NULL;
-   }         
+   }
 
 cleanup_cdev_add:
    cdev_del(&(dev->charDev));
@@ -286,7 +286,7 @@ cleanup_cdev_add:
 cleanup_alloc_chrdev_region:
    unregister_chrdev_region(dev->devNum, 1);
 
-   return -1;   
+   return -1;
 }
 
 
@@ -969,7 +969,9 @@ int Dma_ProcOpen(struct inode *inode, struct file *file) {
    struct seq_file *sf;
    struct DmaDevice *dev;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+   dev = (struct DmaDevice *)pde_data(inode);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
    dev = (struct DmaDevice *)PDE_DATA(inode);
 #else
    dev = (struct DmaDevice *)PDE(inode)->data;

--- a/data_dev/app/src/test.cpp
+++ b/data_dev/app/src/test.cpp
@@ -1,0 +1,87 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Description:
+ * This program will open up a AXIS DMA port and attempt to write data.
+ * ----------------------------------------------------------------------------
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+    * https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+
+#include <sys/types.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdlib.h>
+#include <argp.h>
+#include <DmaDriver.h>
+using namespace std;
+
+int main (int argc, char **argv) {
+   int32_t       s;
+   int32_t       ret;
+   uint32_t      count;
+   void *        txData=NULL;
+   uint32_t      dmaSize;
+   uint32_t      dmaCount;
+   struct timeval startTime;
+   struct timeval endTime;
+   struct timeval diffTime;
+
+   //dmaSize = 2097150;
+   //dmaSize = 655360*10;
+   //dmaSize = 655360*2;
+   //dmaSize = 655360;
+   //dmaSize = 655360/2;
+   //dmaSize = 655360/10;
+   dmaSize = 100;
+   dmaCount = 10000;
+
+
+   if ( (s = open("/dev/datadev_0", O_RDWR)) <= 0 ) {
+      printf("Error opening\n");
+      return(1);
+   }
+
+   if ((txData = malloc(dmaSize)) == NULL ) {
+      printf("Failed to allocate rxData!\n");
+      return(0);
+   }
+   count = 0;
+
+   gettimeofday(&startTime, NULL);
+   do {
+
+      while ( (ret = dmaWrite(s,txData,dmaSize,0,0) ) == 0 );
+
+      if ( ret < 0 ) {
+         printf("Got write error\n");
+         return(0);
+      }
+
+   } while ( ++count < dmaCount );
+   gettimeofday(&endTime, NULL);
+
+   free(txData);
+
+   timersub(&endTime, &startTime, &diffTime);
+
+   float duration = (float)diffTime.tv_sec + (float)diffTime.tv_usec / 1000000.0;
+   float rate = count / duration;
+   float period = 1.0 / rate;
+   float bw = ((float)dmaCount * (float)dmaSize) / duration;
+
+   printf("Wrote %i events of size %i in %f seconds, rate = %f hz, period = %f s, bw = %e B/s\n",dmaCount, dmaSize, duration, rate, period, bw);
+
+   close(s);
+   return(0);
+}
+

--- a/data_dev/scripts/load_datadev.sh
+++ b/data_dev/scripts/load_datadev.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/bash
+
+# Location of the driver
+DRV="$PWD/../driver/datadev.ko"
+
+# Size of the buffer, 128K default
+BUFF_SIZE=131072
+
+# Number of receive buffers
+BUFF_RX=1024
+
+# Number of transmit buffers
+BUFF_TX=1024
+
+# Buffer Mode
+# BUFF_COHERENT  1
+# BUFF_STREAM    2
+# BUFF_ARM_ACP   4
+BUFF_MODE=1
+
+# Receive Continue Enable
+RX_CONT=1
+
+# IRQ Holdoiff Value
+RX_CONT=10000
+
+# IRQ Disable, poll thread CPU
+IRQ_DIS=0
+
+# Buffer Group Threshold 0
+BG_THOLD0=0
+
+# Buffer Group Threshold 1
+BG_THOLD1=0
+
+# Buffer Group Threshold 2
+BG_THOLD2=0
+
+# Buffer Group Threshold 3
+BG_THOLD3=0
+
+# Buffer Group Threshold 4
+BG_THOLD4=0
+
+# Buffer Group Threshold 5
+BG_THOLD5=0
+
+# Buffer Group Threshold 6
+BG_THOLD6=0
+
+# Buffer Group Threshold 7
+BG_THOLD7=0
+
+# Attempt to load the driver
+/usr/bin/insmod $DRV cfgSize=$BUFF_SIZE \
+                     cfgRxCount=$BUFF_RX \
+                     cfgTxCount=$BUFF_TX \
+                     cfgMode=$BUFF_MODE \
+                     cfgCont=$RX_CONT \
+                     cfgIrqDis=$IRQ_DIS \
+                     cfgBgThold0=$BG_THOLD0 \
+                     cfgBgThold1=$BG_THOLD1 \
+                     cfgBgThold2=$BG_THOLD2 \
+                     cfgBgThold3=$BG_THOLD3 \
+                     cfgBgThold4=$BG_THOLD4 \
+                     cfgBgThold5=$BG_THOLD5 \
+                     cfgBgThold6=$BG_THOLD6 \
+                     cfgBgThold7=$BG_THOLD7
+
+# Check results
+if [ $? -eq 0 ]
+then
+
+   if [ -f "/dev/datadev_0" ]
+   then
+      echo "Found /dev/datadev_0"
+   else
+      echo "ERROR: Failed to find any hardware devices!"
+      exit 1
+   fi
+else
+   echo "ERROR: Driver failed to load!"
+   exit 1
+fi
+


### PR DESCRIPTION
The first change is the addition of a load_datadev.sh script which can be used to load the driver with configuration values as well as check the success of the load and determine if hardware was properly found.

This is mean to address ESROGUE-596.

This PR also includes a fix which addresses issues with kernels > 5.18.

DmaWrite has a few updates plus there is a new test.cpp script.

