### PR TITLE
more polishing of the /proc/datadev_0 dump

### DIFF
--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -604,12 +604,12 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
    seq_printf(s,"\n");
    seq_printf(s,"---------- DMA Firmware General ----------\n");
    seq_printf(s,"          Int Req Count : %u\n",(ioread32(&(reg->intReqCount))));
-   seq_printf(s,"        Hw Dma Wr Index : %u\n",(ioread32(&(reg->hwWrIndex))));
-   seq_printf(s,"        Sw Dma Wr Index : %u\n",hwData->writeIndex);
-   seq_printf(s,"        Hw Dma Rd Index : %u\n",(ioread32(&(reg->hwRdIndex))));
-   seq_printf(s,"        Sw Dma Rd Index : %u\n",hwData->readIndex);
-   seq_printf(s,"     Missed Wr Requests : %u\n",(ioread32(&(reg->wrReqMissed))));
-   seq_printf(s,"       Missed IRQ Count : %u\n",hwData->missedIrq);
+// seq_printf(s,"        Hw Dma Wr Index : %u\n",(ioread32(&(reg->hwWrIndex))));
+// seq_printf(s,"        Sw Dma Wr Index : %u\n",hwData->writeIndex);
+// seq_printf(s,"        Hw Dma Rd Index : %u\n",(ioread32(&(reg->hwRdIndex))));
+// seq_printf(s,"        Sw Dma Rd Index : %u\n",hwData->readIndex);
+// seq_printf(s,"     Missed Wr Requests : %u\n",(ioread32(&(reg->wrReqMissed))));
+// seq_printf(s,"       Missed IRQ Count : %u\n",hwData->missedIrq);
    seq_printf(s,"         Continue Count : %u\n",hwData->contCount);
    seq_printf(s,"          Address Count : %i\n",hwData->addrCount);
    seq_printf(s,"    Hw Write Buff Count : %i\n",hwData->hwWrBuffCnt);

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -1068,11 +1068,11 @@ int Dma_SeqShow(struct seq_file *s, void *v) {
    seq_printf(s,"        Buffers In Hw : %u\n",hwCnt);
    seq_printf(s,"  Buffers In Pre-Hw Q : %u\n",hwQCnt);
    seq_printf(s,"  Buffers In Rx Queue : %u\n",qCnt);
-   seq_printf(s,"      Missing Buffers : %u\n",miss);
-   seq_printf(s,"       Min Buffer Use : %u\n",min);
-   seq_printf(s,"       Max Buffer Use : %u\n",max);
-   seq_printf(s,"       Avg Buffer Use : %u\n",avg);
-   seq_printf(s,"       Tot Buffer Use : %u\n",sum);
+// seq_printf(s,"      Missing Buffers : %u\n",miss);
+// seq_printf(s,"       Min Buffer Use : %u\n",min);
+// seq_printf(s,"       Max Buffer Use : %u\n",max);
+// seq_printf(s,"       Avg Buffer Use : %u\n",avg);
+// seq_printf(s,"       Tot Buffer Use : %u\n",sum);
 
    seq_printf(s,"\n");
    seq_printf(s,"---- Write Buffers (Software->Firmware) ---\n");
@@ -1113,11 +1113,11 @@ int Dma_SeqShow(struct seq_file *s, void *v) {
    seq_printf(s,"        Buffers In Hw : %u\n",hwCnt);
    seq_printf(s,"  Buffers In Pre-Hw Q : %u\n",hwQCnt);
    seq_printf(s,"  Buffers In Sw Queue : %u\n",qCnt);
-   seq_printf(s,"      Missing Buffers : %u\n",miss);
-   seq_printf(s,"       Min Buffer Use : %u\n",min);
-   seq_printf(s,"       Max Buffer Use : %u\n",max);
-   seq_printf(s,"       Avg Buffer Use : %u\n",avg);
-   seq_printf(s,"       Tot Buffer Use : %u\n",sum);
+// seq_printf(s,"      Missing Buffers : %u\n",miss);
+// seq_printf(s,"       Min Buffer Use : %u\n",min);
+// seq_printf(s,"       Max Buffer Use : %u\n",max);
+// seq_printf(s,"       Avg Buffer Use : %u\n",avg);
+// seq_printf(s,"       Tot Buffer Use : %u\n",sum);
    seq_printf(s,"\n");
 
    return 0;


### PR DESCRIPTION
### Description
- commented out the "advance prints" that typical users do NOT need 
- Only used by kernel driver develop, which is what I commented out to make easy to find

### New Dump Format
```bash
$ cat /proc/datadev_0
---------- Firmware Axi Version -----------
     Firmware Version : 0x3020000
           ScratchPad : 0x0
        Up Time Count : 773
             Git Hash : 45147a5010efe8f24bef73800063a153b0f7dbd7
            DNA Value : 0x0000000040020000013aca034d40a285
         Build String : Lcls2XilinxC1100Pgp4_6Gbps: Vivado v2022.2, rdsrv407 (Ubuntu 20.04.6 LTS), Built Fri 12 May 2023 01:45:53 AM PDT by ruckman

---------- DMA Firmware General ----------
          Int Req Count : 0
         Continue Count : 0
          Address Count : 4096
    Hw Write Buff Count : 256
     Hw Read Buff Count : 0
           Cache Config : 0x0
            Desc 128 En : 1
            Enable Ver  : 0x4010301
      Driver Load Count : 3
               IRQ Hold : 10000
              BG Enable : 0x0

-------- DMA Kernel Driver General --------
 DMA Driver's Git Version : 5.19.0-dirty
 DMA Driver's API Version : 0x6

---- Read Buffers (Firmware->Software) ----
         Buffer Count : 256
          Buffer Size : 2097152
          Buffer Mode : 1
      Buffers In User : 0
        Buffers In Hw : 256
  Buffers In Pre-Hw Q : 0
  Buffers In Rx Queue : 0

---- Write Buffers (Software->Firmware) ---
         Buffer Count : 16
          Buffer Size : 2097152
          Buffer Mode : 1
      Buffers In User : 0
        Buffers In Hw : 0
  Buffers In Pre-Hw Q : 0
  Buffers In Sw Queue : 16
```