### PR TITLE
Release Candidate 5.19.2

### DIFF
--- a/petalinux/aximemorymap/aximemorymap.bb
+++ b/petalinux/aximemorymap/aximemorymap.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Recipe for  build an external aximemorymap Linux kernel module"
 SECTION = "PETALINUX/modules"
-LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 inherit module
 

--- a/petalinux/axistreamdma/axistreamdma.bb
+++ b/petalinux/axistreamdma/axistreamdma.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Recipe for  build an external axistreamdma Linux kernel module"
 SECTION = "PETALINUX/modules"
-LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 inherit module
 


### PR DESCRIPTION
### Description
- [update to .bb files for latest petalinux](https://github.com/slaclab/aes-stream-drivers/commit/fd2fe16dd60e5dd9b5f92766f3fed0c7927f9700)
  - LICENSE includes obsolete licenses GPLv2 [obsolete-license], switching to LICENSE=MIT