### PR TITLE
axi_version.c & dma_common.c bug fixes

### DIFF
--- a/common/driver/axi_version.c
+++ b/common/driver/axi_version.c
@@ -51,7 +51,7 @@ void AxiVersion_Read(struct DmaDevice *dev, void * base, struct AxiVersion *aVer
 
    aVer->deviceId = ioread32(&(reg->deviceId));
 
-   for (x=0; x < 64; x++) 
+   for (x=0; x < 40; x++)
       ((uint32_t *)aVer->gitHash)[x] = ioread32(&(reg->gitHash[x]));
 
    for (x=0; x < 4; x++) 

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -1003,7 +1003,9 @@ void * Dma_SeqStart(struct seq_file *s, loff_t *pos) {
 
 // Sequence next, always return NULL
 void * Dma_SeqNext(struct seq_file *s, void *v, loff_t *pos) {
-   return NULL;
+   loff_t *position = pos;
+   (*position)++;
+   return NULL; // or return pointer to next item
 }
 
 


### PR DESCRIPTION
### Description
- [gitHash is 40 element array, not 64 elements](https://github.com/slaclab/aes-stream-drivers/commit/5fc652c632330a6208184abf9f22cc7276e377d0)
- [bug fix for 'seq_file: buggy .next function Dma_SeqNext [datadev] did not update position index' error msg](https://github.com/slaclab/aes-stream-drivers/pull/112/commits/9e6d170baf33cc271f6b73d7325382201eaccc26)