### PR TITLE
Fix bad mapping call for new kernels

### DIFF
--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -906,17 +906,7 @@ int Dma_Mmap(struct file *filp, struct vm_area_struct *vma) {
 
       // Coherent buffer
       if ( dev->cfgMode & BUFF_COHERENT ) {
-
-         // Avoid mapping warnings for x86
-#if defined(dma_mmap_coherent) && (! defined(CONFIG_X86))
          ret = dma_mmap_coherent(dev->device,vma,buff->buffAddr,buff->buffHandle,dev->cfgSize);
-#else
-         ret = remap_pfn_range(vma, vma->vm_start,
-                               virt_to_phys((void *)buff->buffAddr) >> PAGE_SHIFT,
-                               vsize,
-                               vma->vm_page_prot);
-#endif
-
       }
 
       // Streaming buffer type or ARM ACP


### PR DESCRIPTION
Fix bad mapping call for new kernels.

This line was in error meaning it was calling the deprecated mapping function instead dma_mmap_coherent.
