### PR TITLE
bug fixes and updates to aximemorymap.c

### DIFF
--- a/petalinux/aximemorymap/files/aximemorymap.c
+++ b/petalinux/aximemorymap/files/aximemorymap.c
@@ -51,7 +51,7 @@ module_exit(Map_Exit);
 struct MapDevice dev;
 
 // Global variable for the device class
-struct class * gCl;
+struct class * gCl = NULL;
 
 // Define interface routines
 struct file_operations MapFunctions = {
@@ -85,15 +85,13 @@ int Map_Init(void) {
    }
 
    // Create class struct if it does not already exist
-   if (gCl == NULL) {
-      pr_info("%s: Init: Creating device class\n",MOD_NAME);
-      if ((gCl = class_create(THIS_MODULE, dev.devName)) == NULL) {
-         pr_err("%s: Init: Failed to create device class\n",MOD_NAME);
-         unregister_chrdev_region(dev.devNum, 1); // Unregister device numbers on failure
-         return(-1);
-      }
-      gCl->devnode = (void *)Map_DevNode;
+   pr_info("%s: Init: Creating device class\n",MOD_NAME);
+   if ((gCl = class_create(THIS_MODULE, dev.devName)) == NULL) {
+      pr_err("%s: Init: Failed to create device class\n",MOD_NAME);
+      unregister_chrdev_region(dev.devNum, 1); // Unregister device numbers on failure
+      return(-1);
    }
+   gCl->devnode = (void *)Map_DevNode;
 
    // Attempt to create the device
    if (device_create(gCl, NULL, dev.devNum, NULL, dev.devName) == NULL) {

--- a/petalinux/aximemorymap/files/aximemorymap.c
+++ b/petalinux/aximemorymap/files/aximemorymap.c
@@ -24,14 +24,6 @@
 #include <linux/slab.h>
 #include <linux/version.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 25)
-  /* 'ioremap_nocache' was deprecated in kernels >= 5.6, so instead we use 'ioremap' which
-  is no-cache by default since kernels 2.6.25. */
-#    define IOREMAP_NO_CACHE(address, size) ioremap(address, size)
-#else /* KERNEL_VERSION < 2.6.25 */
-#    define IOREMAP_NO_CACHE(address, size) ioremap_nocache(address, size)
-#endif
-
 // Module Name
 #define MOD_NAME "axi_memory_map"
 
@@ -151,7 +143,7 @@ int Map_Init(void) {
    dev.maps->next = NULL;
 
    // Map initial memory space
-   dev.maps->base = IOREMAP_NO_CACHE(dev.maps->addr, MAP_SIZE);
+   dev.maps->base = ioremap_wc(dev.maps->addr, MAP_SIZE);
    if (!dev.maps->base) {
       pr_err("%s: Init: Could not map memory addr 0x%llx with size 0x%x.\n", MOD_NAME, (uint64_t)dev.maps->addr, MAP_SIZE);
       kfree(dev.maps); // Clean up on failure
@@ -280,7 +272,7 @@ uint8_t *Map_Find(uint64_t addr) {
          }
 
          new->addr = (addr / MAP_SIZE) * MAP_SIZE; // Align to MAP_SIZE
-         new->base = IOREMAP_NO_CACHE(new->addr, MAP_SIZE); // Map physical address
+         new->base = ioremap_wc(new->addr, MAP_SIZE); // Map physical address
          if (!new->base) {
             pr_err("%s: Map_Find: Could not map memory addr 0x%llx (0x%llx) with size 0x%x.\n",
                    MOD_NAME, (uint64_t)new->addr, (uint64_t)addr, MAP_SIZE);

--- a/petalinux/aximemorymap/files/aximemorymap.c
+++ b/petalinux/aximemorymap/files/aximemorymap.c
@@ -339,7 +339,11 @@ ssize_t Map_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
                // Write data to the register
                writel(rData.data, base);
                ret = 0; // Success
+            } else {
+               pr_warn("%s: Dma_Write_Register: Map_Find failed.\n", MOD_NAME);
             }
+         } else {
+            pr_warn("%s: Dma_Write_Register: get_user failed.\n", MOD_NAME);
          }
          break;
 
@@ -353,19 +357,24 @@ ssize_t Map_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
                // Put the updated register data back to user space
                if (!put_user(rData.data, &((struct DmaRegisterData __user *)arg)->data)) {
                   ret = 0; // Success
+               } else {
+                  pr_warn("%s: Dma_Read_Register: put_user failed.\n", MOD_NAME);
                }
+            } else {
+               pr_warn("%s: Dma_Read_Register: Map_Find failed.\n", MOD_NAME);
             }
+         } else {
+            pr_warn("%s: Dma_Read_Register: get_user failed.\n", MOD_NAME);
          }
          break;
 
       default:
          // Unsupported IOCTL command
-         ret = -1; // Error
+         pr_warn("%s: Map_Ioctl: Unsupported IOCTL command.\n", MOD_NAME);
    }
 
    return ret; // Return the result
 }
-
 
 /**
  * Map_Read - Read operation for AXI memory map device

--- a/petalinux/aximemorymap/files/aximemorymap.c
+++ b/petalinux/aximemorymap/files/aximemorymap.c
@@ -253,7 +253,7 @@ ssize_t Map_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
 
          if ( (base = Map_Find(rData.address)) == NULL ) return(-1);
 
-         iowrite32(rData.data,base);
+         writel(rData.data, base);
          return(0);
          break;
 
@@ -266,7 +266,7 @@ ssize_t Map_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
          }
 
          if ( (base = Map_Find(rData.address)) == NULL ) return(-1);
-         rData.data = ioread32(base);
+         rData.data = readl(base);
 
          // Return the data structure
          if ((ret=copy_to_user((void *)arg,&rData,sizeof(struct DmaRegisterData)))) {

--- a/petalinux/aximemorymap/files/aximemorymap.c
+++ b/petalinux/aximemorymap/files/aximemorymap.c
@@ -138,7 +138,7 @@ int Map_Init(void) {
    }
 
    // Allocate initial memory map
-   dev.maps = (struct MemMap *)kmalloc(sizeof(struct MemMap), GFP_KERNEL);
+   dev.maps = (struct MemMap *)kzalloc(sizeof(struct MemMap), GFP_KERNEL);
    if (dev.maps == NULL) {
       pr_err("%s: Init: Could not allocate map memory\n", MOD_NAME);
       cdev_del(&dev.charDev); // Clean up on failure
@@ -274,7 +274,7 @@ uint8_t *Map_Find(uint64_t addr) {
       // If address is beyond current map, and no next map or next map is further, insert new
       if ((cur->next == NULL) || (addr < ((struct MemMap *)cur->next)->addr)) {
          // Allocate and initialize new map structure
-         if ((new = (struct MemMap *)kmalloc(sizeof(struct MemMap), GFP_KERNEL)) == NULL) {
+         if ((new = (struct MemMap *)kzalloc(sizeof(struct MemMap), GFP_KERNEL)) == NULL) {
             pr_err("%s: Map_Find: Could not allocate map memory\n", MOD_NAME);
             return NULL;
          }


### PR DESCRIPTION
### Description
- [bug fixes for aximemorymap.Map_Init()](https://github.com/slaclab/aes-stream-drivers/commit/755a49ced19f7981b9894a7b0d49027f4a805763)
  - These changes ensure proper cleanup in case of failures during initialization by unregistering the character device region, destroying the device class, and releasing any allocated memory.
- [bug fixes for aximemorymap.Map_Exit()](https://github.com/slaclab/aes-stream-drivers/pull/116/commits/a0b23160c7ff07d321db2c2aab27e41938ff585f)
  - These additional cleanup steps ensure that the driver releases all allocated resources properly during module unloading, thereby preventing resource leaks and maintaining system stability.
- [changing printk to pr_info/pr_warn/pr_err](https://github.com/slaclab/aes-stream-drivers/pull/116/commits/7ef7090a2f7dcfe0c4493a6c8d4085d62ede4742)
  - because printk is generally discouraged for debugging in production code
- [use readl() and writel() instead of ioread32() and iowrite32()](https://github.com/slaclab/aes-stream-drivers/pull/116/commits/df014a6855ef040f794e008cec4558a33d4e2d14)
  - These changes replace the direct I/O access functions with the recommended memory-mapped I/O functions, improving portability and security within the kernel module.
- [Switching to kzalloc to automatically zero out the allocated memory can be beneficial for several reasons:](https://github.com/slaclab/aes-stream-drivers/pull/116/commits/06fb3e4b025da68864cbf204440565355b16733c)
  - Security: Automatically zeroing memory can help prevent the unintentional leak of sensitive information from previously used memory blocks.
  - Stability: Initializing memory to zero can prevent bugs related to uninitialized memory usage.
  - Simplicity: Using kzalloc simplifies the code by combining allocation and initialization into a single operation, reducing the risk of forgetting to explicitly zero the memory.
- [replaced copy_from_user/copy_to_user with get_user/put_user](https://github.com/slaclab/aes-stream-drivers/pull/116/commits/9e27bd003f8e745a41e809a247bcda98541a1869)
  - These functions are used for copying single simple variables from/to user space, providing a safer alternative to copy_from_user and copy_to_user when dealing with simple data structures.
- [replacing IOREMAP_NO_CACHE with ioremap_wc](https://github.com/slaclab/aes-stream-drivers/pull/116/commits/fe1d4b643b33677ad7efe49e42a121ad406cf3d4)
  - This change adapts the code to be compliant with the new kernel requirements by using ioremap_wc for write-combining mappings, which is recommended for device memory mappings that do not require caching. This adjustment ensures that the driver remains functional and efficient under the updated kernel API.
  - The ioremap_wc() function was first introduced in the Linux kernel version 2.6.15, released on January 21, 2006.
- [Replaced the strcpy call with strncpy and cleaned up code comments](https://github.com/slaclab/aes-stream-drivers/pull/116/commits/f3f0f799fbe82e34613a2a95f09e0fa72fc26353)
  - strscpy ensures that the destination is null-terminated, even when truncation occurs, and provides a way to detect if the copy was successful or if truncation happened.

### JIRA
https://jira.slac.stanford.edu/browse/ESROGUE-664