### PR TITLE
bug fixes and updates to axistreamdma.c

### DIFF
--- a/petalinux/axistreamdma/files/axistreamdma.c
+++ b/petalinux/axistreamdma/files/axistreamdma.c
@@ -200,7 +200,7 @@ int Rce_Probe(struct platform_device *pdev) {
       writel(0x1,((uint8_t *)dev->reg)+0x8);
       if ( readl(((uint8_t *)dev->reg)+0x8) != 0x1 ) {
          release_mem_region(dev->baseAddr, dev->baseSize);
-         dev_info(dev->device,"Probe: Empty register space. Exiting\n");
+         pr_info("%s: Probe: Empty register space. Exiting.\n", dev->device);
          return(-1);
       }
       dev->hwFunc = &(AxisG1_functions);
@@ -211,7 +211,7 @@ int Rce_Probe(struct platform_device *pdev) {
 #if ! defined( __aarch64__)
    if( (dev->cfgMode & BUFF_ARM_ACP) || (dev->cfgMode & AXIS2_RING_ACP) ) {
        set_dma_ops(&pdev->dev,&arm_coherent_dma_ops);
-       dev_info(dev->device,"Probe: Set COHERENT DMA =%i\n",dev->cfgMode);
+       pr_info("%s: Probe: Set COHERENT DMA =%i\n",dev->device,dev->cfgMode);
    }
 #endif
 

--- a/petalinux/axistreamdma/files/axistreamdma.c
+++ b/petalinux/axistreamdma/files/axistreamdma.c
@@ -188,14 +188,14 @@ int Rce_Probe(struct platform_device *pdev) {
 
    // Set hardware functions
    // Version 2
-   if ( ((ioread32(dev->reg) >> 24) & 0xFF) >= 2 ) {
+   if ( ((readl(dev->reg) >> 24) & 0xFF) >= 2 ) {
       dev->hwFunc = &(AxisG2_functions);
    }
 
    // Version 1
    else {
-      iowrite32(0x1,((uint8_t *)dev->reg)+0x8);
-      if ( ioread32(((uint8_t *)dev->reg)+0x8) != 0x1 ) {
+      writel(0x1,((uint8_t *)dev->reg)+0x8);
+      if ( readl(((uint8_t *)dev->reg)+0x8) != 0x1 ) {
          release_mem_region(dev->baseAddr, dev->baseSize);
          dev_info(dev->device,"Probe: Empty register space. Exiting\n");
          return(-1);

--- a/petalinux/axistreamdma/files/axistreamdma.c
+++ b/petalinux/axistreamdma/files/axistreamdma.c
@@ -199,7 +199,6 @@ int Rce_Probe(struct platform_device *pdev) {
    else {
       writel(0x1,((uint8_t *)dev->reg)+0x8);
       if ( readl(((uint8_t *)dev->reg)+0x8) != 0x1 ) {
-         release_mem_region(dev->baseAddr, dev->baseSize);
          pr_info("%s: Probe: Empty register space. Exiting.\n", dev->device);
          return(-1);
       }

--- a/petalinux/axistreamdma/files/axistreamdma.c
+++ b/petalinux/axistreamdma/files/axistreamdma.c
@@ -1,14 +1,4 @@
 /**
- *-----------------------------------------------------------------------------
- * Title      : Top level module
- * ----------------------------------------------------------------------------
- * File       : rce_top.c
- * Author     : Ryan Herbst, rherbst@slac.stanford.edu
- * Created    : 2016-08-08
- * Last update: 2016-08-08
- * ----------------------------------------------------------------------------
- * Description:
- * Top level module types and functions.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to
  * the license terms in the LICENSE.txt file found in the top-level directory
@@ -67,7 +57,19 @@ MODULE_AUTHOR("Ryan Herbst");
 MODULE_DESCRIPTION("AXI Stream DMA driver. V3");
 MODULE_LICENSE("GPL");
 
-static int Rce_DmaNop(struct device *dev) {
+/**
+ * Rce_DmaNop - No-operation function for DMA device power management.
+ *
+ * This function is intended to be used as a placeholder for power management
+ * operations where no action is needed. It simply returns 0, indicating success,
+ * and is used for both runtime_suspend and runtime_resume operations in the
+ * device's power management operations structure.
+ *
+ * @dev: The device structure.
+ * @return: Always returns 0, indicating success.
+ */
+static int Rce_DmaNop(struct device *dev)
+{
    return 0;
 }
 
@@ -95,7 +97,19 @@ static struct platform_driver Rce_DmaPdrv = {
 
 module_platform_driver(Rce_DmaPdrv);
 
-// Create and init device
+/**
+ * Rce_Probe - Probe function for DMA device initialization.
+ *
+ * This function is called by the Linux kernel when a platform device
+ * matching the driver's device ID table is found. It performs device
+ * initialization, including resource allocation, device registration,
+ * and DMA configuration. It identifies the correct device instance
+ * based on the device name, initializes the device structure, maps
+ * device memory regions, and configures DMA settings.
+ *
+ * @pdev: Platform device structure representing the DMA device.
+ * @return: 0 on success, negative error code on failure.
+ */
 int Rce_Probe(struct platform_device *pdev) {
    struct DmaDevice *dev;
 
@@ -214,42 +228,53 @@ cleanup_force_exit:
    
 }
 
-
-// Cleanup device
-int Rce_Remove(struct platform_device *pdev) {
-   int32_t      x;
-   const char * tmpName;
-   int32_t      tmpIdx;
-
+/**
+ * Rce_Remove - Clean up resources upon removal of the DMA device.
+ *
+ * This function is called when the DMA device is removed from the system.
+ * It performs cleanup operations such as decrementing the global device
+ * count and calling the common DMA cleanup function. It also logs the
+ * removal operation for debugging purposes.
+ *
+ * @pdev: The platform device structure representing the DMA device.
+ * @return: Returns 0 on successful cleanup, -1 if no matching device is found.
+ */
+int Rce_Remove(struct platform_device *pdev)
+{
+   int32_t x;
+   const char *tmpName;
+   int32_t tmpIdx;
    struct DmaDevice *dev = NULL;
 
    pr_info("%s: Remove: Remove called.\n", MOD_NAME);
 
+   // Extract device name suffix
    tmpName = pdev->name + 9;
 
-   // Find matching entry
+   // Search for matching device entry
    tmpIdx = -1;
-   for ( x=0; x < MAX_DMA_DEVICES; x++ ) {
-      if (strcmp(tmpName,RceDevNames[x]) == 0) {
+   for (x = 0; x < MAX_DMA_DEVICES; x++) {
+      if (strcmp(tmpName, RceDevNames[x]) == 0) {
          tmpIdx = x;
          break;
       }
    }
 
-   // Matching device not found
-   if ( tmpIdx < 0 ) {
+   // If no matching device is found, log and exit
+   if (tmpIdx < 0) {
       pr_info("%s: Remove: Matching device not found.\n", MOD_NAME);
-      return(-1);
+      return -1;
    }
-   dev = &gDmaDevices[tmpIdx];
 
-   // Decrement count
+   // Get device structure and decrement global device count
+   dev = &gDmaDevices[tmpIdx];
    gDmaDevCount--;
 
-   // Call common dma init function
+   // Perform common DMA cleanup operations
    Dma_Clean(dev);
+
    pr_info("%s: Remove: Driver is unloaded.\n", MOD_NAME);
-   return(0);
+   return 0;
 }
 
 // Parameters
@@ -288,4 +313,3 @@ MODULE_PARM_DESC(cfgMode1, "RX buffer mode");
 
 module_param(cfgMode2,int,0);
 MODULE_PARM_DESC(cfgMode2, "RX buffer mode");
-

--- a/petalinux/axistreamdma/files/axistreamdma.c
+++ b/petalinux/axistreamdma/files/axistreamdma.c
@@ -132,7 +132,7 @@ int Rce_Probe(struct platform_device *pdev) {
    // Matching device not found
    if ( tmpIdx < 0 ) {
       pr_warn("%s: Probe: Matching device not found: %s.\n", MOD_NAME,tmpName);
-      return(-1);
+      return -1;
    }
    dev = &gDmaDevices[tmpIdx];
 
@@ -143,7 +143,10 @@ int Rce_Probe(struct platform_device *pdev) {
    dev->index = tmpIdx;
 
    // Create a device name
-   strcpy(dev->devName,tmpName);
+   if (strscpy(dev->devName, tmpName, sizeof(dev->devName)) < 0) {
+      pr_err("%s: Probe: Source string too long for destination: %s.\n", MOD_NAME,tmpName);
+      return -1;
+   }
 
    // Get Base Address of registers from pci structure.
    dev->baseAddr = pdev->resource[0].start;


### PR DESCRIPTION
### Description
- [use readl() and writel() instead of ioread32() and iowrite32()](https://github.com/slaclab/aes-stream-drivers/commit/8bf52f39e91bb5b6b0bc2ff20a98d18b122d2c0b)
  - These changes replace the direct I/O access functions with the recommended memory-mapped I/O functions, improving portability and security within the kernel module.
- [Replaced the strcpy call with strncpy and cleaned up code comments](https://github.com/slaclab/aes-stream-drivers/pull/117/commits/0d24dbbf5d8cf6df82c41b651a396dbb19dac83f)
  - strscpy ensures that the destination is null-terminated, even when truncation occurs, and provides a way to detect if the copy was successful or if truncation happened.
- [replacing dev_info with pr_info](https://github.com/slaclab/aes-stream-drivers/pull/117/commits/34eb142431c73237d75397d25f0946a1b7e47c4c)
  - because dev_info is generally discouraged for debugging in production code
- [removing release_mem_region because common/driver src code will be updated to devm_request_mem_region](https://github.com/slaclab/aes-stream-drivers/pull/117/commits/595c193eb8a0d69710391f96875ade2f5b1829bc)
  - When you use devm_request_mem_region to request a memory region, the memory is managed automatically by the device management (devm) API within the Linux kernel. This means that the memory region will be automatically released when the device is detached or the driver is unloaded. Therefore, you do not need to explicitly call a function to release the memory region when using devm_request_mem_region.
- [Update the driver to use the pm_runtime API for runtime_suspend and runtime_resume](https://github.com/slaclab/aes-stream-drivers/pull/117/commits/57078f43b19f1271cb6b2a1d9fadee08c7973920)
  - While they are still technically functional, it is recommended to update the driver to use the pm_runtime API for better power management and compatibility with newer kernels.

### JIRA
https://jira.slac.stanford.edu/browse/ESROGUE-665