### PR TITLE
bug fixes and updates to data_dev_top.c

### DIFF
--- a/data_dev/driver/src/data_dev_top.c
+++ b/data_dev/driver/src/data_dev_top.c
@@ -247,13 +247,20 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    AxiVersion_SetUserReset(dev->base + AVER_OFF,false);
 
    // 128bit desc, = 64-bit address map
-   if ( (readl(dev->reg) & 0x10000) != 0) {
+   if ((readl(dev->reg) & 0x10000) != 0) {
       // Get the AXI Address width (in units of bits)
-      axiWidth = (readl(dev->reg+0x34) >> 8) & 0xFF;
-      if ( !dma_set_mask_and_coherent(dev->device, DMA_BIT_MASK(axiWidth)) ) {
-         dev_info(dev->device,"Init: Using %d-bit DMA mask.\n",axiWidth);
+      axiWidth = (readl(dev->reg + 0x34) >> 8) & 0xFF;
+
+      if (!dma_set_mask(dev->device, DMA_BIT_MASK(axiWidth))) {
+         dev_info(dev->device, "Init: Using %d-bit DMA mask.\n", axiWidth);
+
+         if (!dma_set_coherent_mask(dev->device, DMA_BIT_MASK(axiWidth))) {
+            dev_info(dev->device, "Init: Using %d-bit coherent DMA mask.\n", axiWidth);
+         } else {
+            dev_warn(dev->device, "Init: Failed to set coherent DMA mask.\n");
+         }
       } else {
-         dev_warn(dev->device,"Init: Failed to set DMA mask.\n");
+         dev_warn(dev->device, "Init: Failed to set DMA mask.\n");
       }
    }
 

--- a/data_dev/driver/src/data_dev_top.c
+++ b/data_dev/driver/src/data_dev_top.c
@@ -241,9 +241,9 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    AxiVersion_SetUserReset(dev->base + AVER_OFF,false);
 
    // 128bit desc, = 64-bit address map
-   if ( (ioread32(dev->reg) & 0x10000) != 0) {
+   if ( (readl(dev->reg) & 0x10000) != 0) {
       // Get the AXI Address width (in units of bits)
-      axiWidth = (ioread32(dev->reg+0x34) >> 8) & 0xFF;
+      axiWidth = (readl(dev->reg+0x34) >> 8) & 0xFF;
       if ( !dma_set_mask_and_coherent(dev->device, DMA_BIT_MASK(axiWidth)) ) {
          dev_info(dev->device,"Init: Using %d-bit DMA mask.\n",axiWidth);
       } else {
@@ -265,7 +265,7 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
 
    dev_info(dev->device,"Init: Reg  space mapped to 0x%llx.\n",(uint64_t)dev->reg);
    dev_info(dev->device,"Init: User space mapped to 0x%llx with size 0x%x.\n",(uint64_t)dev->rwBase,dev->rwSize);
-   dev_info(dev->device,"Init: Top Register = 0x%x\n",ioread32(dev->reg));
+   dev_info(dev->device,"Init: Top Register = 0x%x\n",readl(dev->reg));
 
    // Increment count only after probe is setup successfully
    gDmaDevCount++;

--- a/data_dev/driver/src/data_dev_top.c
+++ b/data_dev/driver/src/data_dev_top.c
@@ -94,8 +94,7 @@ static struct pci_driver DataDevDriver = {
  *
  * Return: 0 on success, negative error code on failure.
  */
-int32_t DataDev_Init(void)
-{
+int32_t DataDev_Init(void) {
    int ret;
 
    /* Clear memory for all DMA devices */
@@ -111,7 +110,7 @@ int32_t DataDev_Init(void)
    ret = pci_register_driver(&DataDevDriver);
    if (probeReturn != 0)
    {
-      pr_err("%s: Probe failure detected in init. Unregistering driver.\n", MOD_NAME);
+      pr_err("%s: Init: failure detected in init. Unregistering driver.\n", MOD_NAME);
       pci_unregister_driver(&DataDevDriver);
       return probeReturn;
    }
@@ -286,8 +285,7 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
  * DMA device count, calls the common DMA clean function to free allocated resources,
  * and disables the PCI device.
  */
-void DataDev_Remove(struct pci_dev *pcidev)
-{
+void DataDev_Remove(struct pci_dev *pcidev) {
    uint32_t x;
    struct DmaDevice *dev = NULL;
 
@@ -334,8 +332,7 @@ void DataDev_Remove(struct pci_dev *pcidev)
  * Return: the result of the command execution. Returns -1 if the command
  * is not recognized.
  */
-int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg)
-{
+int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
    switch (cmd) {
       case AVER_Get:
          // AXI Version Read
@@ -361,8 +358,7 @@ int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg)
  * presenting a standardized view of device details for debugging or
  * system monitoring.
  */
-void DataDev_SeqShow(struct seq_file *s, struct DmaDevice *dev)
-{
+void DataDev_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
    struct AxiVersion aVer;
 
    // Read AXI version from device

--- a/data_dev/driver/src/data_dev_top.c
+++ b/data_dev/driver/src/data_dev_top.c
@@ -108,8 +108,7 @@ int32_t DataDev_Init(void) {
 
    /* Register PCI driver */
    ret = pci_register_driver(&DataDevDriver);
-   if (probeReturn != 0)
-   {
+   if (probeReturn != 0) {
       pr_err("%s: Init: failure detected in init. Unregistering driver.\n", MOD_NAME);
       pci_unregister_driver(&DataDevDriver);
       return probeReturn;
@@ -156,7 +155,7 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    struct AxisG2Data *hwData;
 
    if ( cfgMode != BUFF_COHERENT && cfgMode != BUFF_STREAM ) {
-      pr_warn("%s: Probe: Invalid buffer mode = %i.\n",MOD_NAME,cfgMode);
+      pr_err("%s: Probe: Invalid buffer mode = %i.\n", MOD_NAME, cfgMode);
       return -EINVAL; // Return directly with an error code
    }
 
@@ -178,7 +177,7 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
 
    // Overflow
    if (id->driver_data < 0) {
-      pr_warn("%s: Probe: Too Many Devices.\n",MOD_NAME);
+      pr_err("%s: Probe: Too Many Devices.\n", MOD_NAME);
       return -ENOMEM; // Return directly with an error code
    }
    dev = &gDmaDevices[id->driver_data];
@@ -190,8 +189,8 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    // Enable the device
    ret = pci_enable_device(pcidev);
    if (ret) {
-      pr_warn("%s: Probe: pci_enable_device() = %i.\n",MOD_NAME,ret);
-       return ret; // Return with error code
+      pr_err("%s: Probe: pci_enable_device() = %i.\n", MOD_NAME, ret);
+      return ret; // Return with error code
    }
    pci_set_master(pcidev);
 

--- a/data_dev/driver/src/data_dev_top.c
+++ b/data_dev/driver/src/data_dev_top.c
@@ -151,8 +151,8 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    struct hardware_functions *hfunc;
 
    int32_t x;
-   int32_t dummy;
    int32_t axiWidth;
+   int ret;
 
    struct AxisG2Data *hwData;
 
@@ -189,7 +189,11 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    sprintf(dev->devName,"%s_%i",MOD_NAME,dev->index);
 
    // Enable the device
-   dummy = pci_enable_device(pcidev);
+   ret = pci_enable_device(pcidev);
+   if (ret) {
+      pr_warn("%s: Probe: pci_enable_device() = %i.\n",MOD_NAME,ret);
+       return ret; // Return with error code
+   }
    pci_set_master(pcidev);
 
    // Get Base Address of registers from pci structure.

--- a/data_dev/driver/src/data_dev_top.c
+++ b/data_dev/driver/src/data_dev_top.c
@@ -184,7 +184,11 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    dev->index = id->driver_data;
 
    // Create a device name
-   sprintf(dev->devName,"%s_%i",MOD_NAME,dev->index);
+   ret = snprintf(dev->devName, sizeof(dev->devName), "%s_%i", MOD_NAME, dev->index);
+   if (ret < 0 || ret >= sizeof(dev->devName)) {
+      pr_err("%s: Probe: Error in snprintf() while formatting device name\n", MOD_NAME);
+      return -EINVAL; // Return directly with an error code
+   }
 
    // Enable the device
    ret = pci_enable_device(pcidev);

--- a/data_dev/driver/src/data_dev_top.c
+++ b/data_dev/driver/src/data_dev_top.c
@@ -1,5 +1,7 @@
 /**
- * ----------------------------------------------------------------------------
+ *-----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ *-----------------------------------------------------------------------------
  * Description:
  * This file is part of the aes_stream_drivers package, responsible for defining
  * top-level module types and functions for AES stream device drivers. It
@@ -15,6 +17,7 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #include <data_dev_top.h>
 #include <AxiVersion.h>
 #include <axi_version.h>

--- a/data_dev/driver/src/data_dev_top.h
+++ b/data_dev/driver/src/data_dev_top.h
@@ -1,12 +1,10 @@
 /**
  *-----------------------------------------------------------------------------
- * Title      : Top level module
- * ----------------------------------------------------------------------------
- * File       : data_dev_top.h
- * Created    : 2017-03-17
- * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ *-----------------------------------------------------------------------------
  * Description:
- * Top level module types and functions.
+ *    Defines the top-level module types and functions for the Data Device driver.
+ *    This driver is part of the aes_stream_drivers package.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to
  * the license terms in the LICENSE.txt file found in the top-level directory
@@ -17,6 +15,7 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #ifndef __DATA_DEV_TOP_H__
 #define __DATA_DEV_TOP_H__
 
@@ -25,44 +24,32 @@
 #include <linux/pci.h>
 #include <dma_common.h>
 
+/** Maximum number of DMA devices supported. */
 #define MAX_DMA_DEVICES 4
 
-// PCI ID
+/** PCI vendor and device identifiers. */
 #define PCI_VENDOR_ID_SLAC 0x1a4a
 #define PCI_DEVICE_ID_DDEV 0x2030
 
-// Address map
-#define AGEN2_OFF   0x00000000
-#define AGEN2_SIZE  0x00010000
-#define PHY_OFF     0x00010000
-#define PHY_SIZE    0x00010000
-#define AVER_OFF    0x00020000
-#define AVER_SIZE   0x00010000
-#define PROM_OFF    0x00030000
-#define PROM_SIZE   0x00050000
-#define USER_OFF    0x00800000
-#define USER_SIZE   0x00800000
+/** Address map for device registers. */
+#define AGEN2_OFF   0x00000000 /**< DMAv2 Engine Offset */
+#define AGEN2_SIZE  0x00010000 /**< DMAv2 Engine Size */
+#define PHY_OFF     0x00010000 /**< PCIe PHY Offset */
+#define PHY_SIZE    0x00010000 /**< PCIe PHY Size */
+#define AVER_OFF    0x00020000 /**< AxiVersion Offset */
+#define AVER_SIZE   0x00010000 /**< AxiVersion Size */
+#define PROM_OFF    0x00030000 /**< PROM Offset */
+#define PROM_SIZE   0x00050000 /**< PROM Size */
+#define USER_OFF    0x00800000 /**< User Space Offset */
+#define USER_SIZE   0x00800000 /**< User Space Size */
 
-// Init Kernel Module
+// Function prototypes
 int32_t DataDev_Init(void);
-
-// Exit Kernel Module
 void DataDev_Exit(void);
-
-// Create and init device
 int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id);
-
-// Cleanup device
 void  DataDev_Remove(struct pci_dev *pcidev);
-
-// Execute command
 int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg);
-
-// Add data to proc dump
 void DataDev_SeqShow(struct seq_file *s, struct DmaDevice *dev);
-
-// Set functions for gen2 card
 extern struct hardware_functions DataDev_functions;
 
-#endif
-
+#endif // __DATA_DEV_TOP_H__


### PR DESCRIPTION
### Description
- [code clean up using 'Kernel-doc' style](https://github.com/slaclab/aes-stream-drivers/commit/0eb9342a4bcfde5726dbaa38a11f10fe455a313f)
- [use readl() instead of ioread32()](https://github.com/slaclab/aes-stream-drivers/pull/118/commits/256bc402f514328b3c60a4d43cbe297b2e3d0415)
  - These changes replace the direct I/O access functions with the recommended memory-mapped I/O functions, improving portability and security within the kernel module.
- [Error Handling for pci_enable_device()](https://github.com/slaclab/aes-stream-drivers/pull/118/commits/16fb81121ae2a2009614841285cc95293b76bfb6)
  - Before accessing the device's resources, you must call pci_enable_device. This function can fail, so check its return value
- [use snprintf() w/ error checking instead of sprintf()](https://github.com/slaclab/aes-stream-drivers/pull/118/commits/208080cb9b6cbdce12b1990db2fff3676b6098bc)
  - snprintf() call ensures that the output is properly truncated if it exceeds the size of the destination buffer, thus preventing buffer overflow vulnerabilities
- [dma_set_mask_and_coherent is deprecated in favor of separate calls to dma_set_mask and dma_set_coherent_mask separately](https://github.com/slaclab/aes-stream-drivers/pull/118/commits/f193f36adbd4b8b4602271a31de2f57ebed04160)
  - using separate calls provides greater clarity, flexibility, and compatibility with future kernel versions, while potentially offering performance benefits and easing debugging efforts
- [polishing DataDev_Probe() code comments](https://github.com/slaclab/aes-stream-drivers/pull/118/commits/51d4b2373c561e78a4f72fa52435e95cc86db0c1)
- [adding cfgDevName feature to use the PCI device bus number for unique device naming](https://github.com/slaclab/aes-stream-drivers/pull/118/commits/3b2aabcf9a4b357c9a59e3b3324a253cf97d6867)
  - Helpful when multiple PCIe cards are installed in the same server