### PR TITLE
common/driver: Applying "Kernel-doc" style

### DIFF
--- a/common/driver/axi_version.c
+++ b/common/driver/axi_version.c
@@ -1,9 +1,13 @@
 /**
- *-----------------------------------------------------------------------------
- * Title      : AXI Version Access
  * ----------------------------------------------------------------------------
- * File       : axi_version.h
- * Created    : 2017-03-16
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ *    Implements the driver functionality for reading and managing
+ *    the AXI version register within a hardware device. It provides an interface for accessing
+ *    version information, facilitating compatibility checks and firmware updates. The code includes
+ *    routines to read the version register, interpret the version data, and report it back to the
+ *    user or application, ensuring smooth integration and operation within a larger system.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to 
  * the license terms in the LICENSE.txt file found in the top-level directory 
@@ -14,54 +18,105 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #include <axi_version.h>
 #include <AxiVersion.h>
 #include <dma_common.h>
 #include <linux/seq_file.h>
 
-// AXI Version Get
-int32_t AxiVersion_Get(struct DmaDevice *dev, void * base, uint64_t arg) {
+/**
+ * AxiVersion_Get - Retrieve the AXI version information.
+ * @dev: Pointer to the device structure.
+ * @base: Base address of the device.
+ * @arg: User-space pointer to store the AXI version information.
+ *
+ * This function reads the AXI version from the device and copies it to
+ * user space. It uses the AxiVersion_Read function to obtain the version
+ * information from the device registers and then copies this information
+ * to a user-space location specified by @arg.
+ *
+ * Return: 0 on success, -1 on failure to copy data to user space.
+ */
+int32_t AxiVersion_Get(struct DmaDevice *dev, void *base, uint64_t arg) {
    struct AxiVersion axiVersion;
    int32_t ret;
 
+   // Read the AXI version from the device
    AxiVersion_Read(dev, base, &axiVersion);
 
-   if ((ret=copy_to_user((void *)arg,&axiVersion,sizeof(struct AxiVersion)))) {
-      dev_warn(dev->device,"AxiVersion_Get: copy_to_user failed. ret=%i, user=%p kern=%p\n",
-          ret, (void *)arg, &axiVersion);
-      return(-1);
+   // Attempt to copy the AXI version information to user space
+   ret = copy_to_user((void *)arg, &axiVersion, sizeof(struct AxiVersion));
+   if (ret) {
+      // Log a warning if copy to user space fails
+      dev_warn(dev->device,
+               "AxiVersion_Get: copy_to_user failed. ret=%i, user=%p kern=%p\n",
+               ret, (void *)arg, &axiVersion);
+      return -1;
    }
-   return(0);
+   return 0;
 }
 
-// AXI Version Read
+/**
+ * AxiVersion_Read - Reads the AXI version information.
+ * @dev: Pointer to the DmaDevice structure.
+ * @base: Base address of the AXI version registers.
+ * @aVer: Pointer to the AxiVersion structure to populate.
+ *
+ * This function reads the AXI version information from the hardware registers
+ * and populates the provided AxiVersion structure with the firmware version,
+ * scratch pad, up time count, feature descriptor value, user-defined values,
+ * device ID, git hash, device DNA value, and build string.
+ */
 void AxiVersion_Read(struct DmaDevice *dev, void * base, struct AxiVersion *aVer) {
    struct AxiVersion_Reg *reg = (struct AxiVersion_Reg *)base;
    uint32_t x;
 
+   // Read firmware version, scratch pad, and uptime count
    aVer->firmwareVersion = ioread32(&(reg->firmwareVersion));
    aVer->scratchPad      = ioread32(&(reg->scratchPad));
    aVer->upTimeCount     = ioread32(&(reg->upTimeCount));
    
-   for (x=0; x < 2; x++) 
+   // Read feature descriptor values
+   for (x = 0; x < 2; x++) {
       ((uint32_t *)aVer->fdValue)[x] = ioread32(&(reg->fdValue[x]));   
+   }
 
-   for (x=0; x < 64; x++) 
+   // Read user-defined values
+   for (x = 0; x < 64; x++) {
       aVer->userValues[x] = ioread32(&(reg->userValues[x]));
+   }
 
+   // Read device ID
    aVer->deviceId = ioread32(&(reg->deviceId));
 
-   for (x=0; x < 40; x++)
+   // Read git hash
+   for (x = 0; x < 40; x++) {
       ((uint32_t *)aVer->gitHash)[x] = ioread32(&(reg->gitHash[x]));
+   }
 
-   for (x=0; x < 4; x++) 
+   // Read device DNA value
+   for (x = 0; x < 4; x++) {
       ((uint32_t *)aVer->dnaValue)[x] = ioread32(&(reg->dnaValue[x]));
+   }
 
-   for (x=0; x < 64; x++) 
+   // Read build string
+   for (x = 0; x < 64; x++) {
       ((uint32_t *)aVer->buildString)[x] = ioread32(&(reg->buildString[x]));
+   }
 }
 
-// AXI Version Show
+/**
+ * AxiVersion_Show - Display AXI version information.
+ * @s: sequence file pointer to which this function will write.
+ * @dev: pointer to the DmaDevice structure.
+ * @aVer: pointer to the AxiVersion structure containing version info.
+ *
+ * This function prints the firmware version information, including firmware
+ * version, scratch pad, up time count, Git hash, DNA value, and build string
+ * of the AXI to the provided sequence file. The function checks if the Git hash
+ * indicates uncommitted code (marked as 'dirty') and formats the output
+ * accordingly.
+ */
 void AxiVersion_Show(struct seq_file *s, struct DmaDevice *dev, struct AxiVersion *aVer) {
    int32_t x;
    bool gitDirty = true;
@@ -74,13 +129,11 @@ void AxiVersion_Show(struct seq_file *s, struct DmaDevice *dev, struct AxiVersio
    // seq_printf(s,"             Fd Value : 0x");
    // for (x=0; x < 8; x++) seq_printf(s,"%.02x",aVer->fdValue[8-x]);
    // seq_printf(s,"\n");   
-   
-
    // for (x=0; x < 64; x++)
    // seq_printf(s,"          User Values : 0x%x\n",aVer->userValues[x]);
-
    // seq_printf(s,"            Device ID : 0x%x\n",aVer->deviceId);
 
+   // Git hash processing to determine if code is 'dirty'
    seq_printf(s,"             Git Hash : ");
    for (x=0; x < 20; x++) {
       if ( aVer->gitHash[19-x] != 0 ) gitDirty = false;
@@ -92,21 +145,32 @@ void AxiVersion_Show(struct seq_file *s, struct DmaDevice *dev, struct AxiVersio
    }
    seq_printf(s,"\n");
 
+   // Displaying DNA value
    seq_printf(s,"            DNA Value : 0x");
    for (x=0; x < 16; x++) seq_printf(s,"%.02x",aVer->dnaValue[15-x]);
    seq_printf(s,"\n");
 
+   // Build string display
    seq_printf(s,"         Build String : %s\n",aVer->buildString);
 }
 
-// AXI Version Set User Reset
+/**
+ * AxiVersion_SetUserReset - Sets the user reset state in the AXI version register.
+ * @base: Pointer to the base address of the AXI Version register block.
+ * @state: Boolean value indicating the desired state of the user reset; true to set, false to clear.
+ *
+ * This function sets or clears the user reset bit in the AXI version register based on the
+ * provided state. It writes directly to the hardware register to effect this change.
+ */
 void AxiVersion_SetUserReset(void *base, bool state) {
    struct AxiVersion_Reg *reg = (struct AxiVersion_Reg *)base;
    uint32_t val;
 
-   if ( state ) val = 0x1;
-   else val = 0x0;
-   
-   iowrite32(val,&(reg->userReset));
-}
+   if (state) {
+      val = 0x1;  // Set user reset
+   } else {
+      val = 0x0;  // Clear user reset
+   }
 
+   iowrite32(val, &(reg->userReset));  // Write the value to the userReset register
+}

--- a/common/driver/axi_version.c
+++ b/common/driver/axi_version.c
@@ -9,12 +9,12 @@
  *    routines to read the version register, interpret the version data, and report it back to the
  *    user or application, ensuring smooth integration and operation within a larger system.
  * ----------------------------------------------------------------------------
- * This file is part of the aes_stream_drivers package. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the aes_stream_drivers package, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -75,10 +75,10 @@ void AxiVersion_Read(struct DmaDevice *dev, void * base, struct AxiVersion *aVer
    aVer->firmwareVersion = ioread32(&(reg->firmwareVersion));
    aVer->scratchPad      = ioread32(&(reg->scratchPad));
    aVer->upTimeCount     = ioread32(&(reg->upTimeCount));
-   
+
    // Read feature descriptor values
    for (x = 0; x < 2; x++) {
-      ((uint32_t *)aVer->fdValue)[x] = ioread32(&(reg->fdValue[x]));   
+      ((uint32_t *)aVer->fdValue)[x] = ioread32(&(reg->fdValue[x]));
    }
 
    // Read user-defined values
@@ -125,10 +125,10 @@ void AxiVersion_Show(struct seq_file *s, struct DmaDevice *dev, struct AxiVersio
    seq_printf(s,"     Firmware Version : 0x%x\n",aVer->firmwareVersion);
    seq_printf(s,"           ScratchPad : 0x%x\n",aVer->scratchPad);
    seq_printf(s,"        Up Time Count : %u\n",aVer->upTimeCount);
-   
+
    // seq_printf(s,"             Fd Value : 0x");
    // for (x=0; x < 8; x++) seq_printf(s,"%.02x",aVer->fdValue[8-x]);
-   // seq_printf(s,"\n");   
+   // seq_printf(s,"\n");
    // for (x=0; x < 64; x++)
    // seq_printf(s,"          User Values : 0x%x\n",aVer->userValues[x]);
    // seq_printf(s,"            Device ID : 0x%x\n",aVer->deviceId);

--- a/common/driver/axi_version.h
+++ b/common/driver/axi_version.h
@@ -1,9 +1,11 @@
 /**
- *-----------------------------------------------------------------------------
- * Title      : AXI Version Access
  * ----------------------------------------------------------------------------
- * File       : axi_version.h
- * Created    : 2017-03-16
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ *    Provides access and utility functions for the AXI version register space.
+ *    This header file defines the structure and prototypes for managing and
+ *    interacting with AXI version data.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to
  * the license terms in the LICENSE.txt file found in the top-level directory
@@ -14,13 +16,36 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #ifndef __AXI__VERSION_H__
 #define __AXI__VERSION_H__
+
 #include <linux/types.h>
 #include <dma_common.h>
 #include <AxiVersion.h>
 
-// AXI Version register space
+/**
+ * struct AxiVersion_Reg - AXI Version register space
+ * @firmwareVersion: Firmware version number
+ * @scratchPad: General purpose scratch pad register
+ * @upTimeCount: Counter for uptime in clock cycles
+ * @spareA: Reserved space
+ * @haltReload: Halt and reload signal control
+ * @fpgaReload: FPGA reload signal control
+ * @fpgaReloadAddr: FPGA reload address
+ * @userReset: User reset control
+ * @spareB: Reserved space
+ * @fdValue: Front door value for secure access
+ * @spareC: Reserved space
+ * @userValues: User definable register space
+ * @deviceId: Device identification register
+ * @spareD: Reserved space
+ * @gitHash: GIT hash value for the firmware build
+ * @spareE: Reserved space
+ * @dnaValue: Device DNA value
+ * @spareF: Reserved space
+ * @buildString: Firmware build string
+ */
 struct AxiVersion_Reg {
    uint32_t firmwareVersion;   // 0x0000
    uint32_t scratchPad;        // 0x0004
@@ -55,17 +80,10 @@ struct AxiVersion_Reg {
    uint32_t buildString[64];   // 0x0800 - 0x08FC
 };
 
-// AXI Version Get
-int32_t AxiVersion_Get(struct DmaDevice *dev, void * base, uint64_t arg);
-
-// AXI Version Read
-void AxiVersion_Read(struct DmaDevice *dev, void * base, struct AxiVersion *aVer);
-
-// AXI Version Show
+// Function prototypes
+int32_t AxiVersion_Get(struct DmaDevice *dev, void *base, uint64_t arg);
+void AxiVersion_Read(struct DmaDevice *dev, void *base, struct AxiVersion *aVer);
 void AxiVersion_Show(struct seq_file *s, struct DmaDevice *dev, struct AxiVersion *aVer);
-
-// AXI Version Set User Reset
 void AxiVersion_SetUserReset(void *base, bool state);
 
-#endif
-
+#endif // __AXI__VERSION_H__

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -1,12 +1,12 @@
 /**
- *-----------------------------------------------------------------------------
- * Title      : AXIS Gen2 Functions
  * ----------------------------------------------------------------------------
- * File       : axis_gen2.c
- * Created    : 2017-02-03
+ * Company    : SLAC National Accelerator Laboratory
  * ----------------------------------------------------------------------------
  * Description:
- * Access functions for Gen2 AXIS DMA
+ *    This module provides an interface and management functions for handling
+ *    DMA operations on Axis Generation 2 devices. It includes mechanisms for buffer
+ *    management, IRQ handling, and command execution, enabling efficient data
+ *    transfer and control operations between the host and the Axis Gen2 hardware.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to
  * the license terms in the LICENSE.txt file found in the top-level directory
@@ -17,34 +17,66 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #include <axis_gen2.h>
 #include <AxisDriver.h>
 #include <linux/seq_file.h>
 #include <linux/signal.h>
 #include <linux/slab.h>
 
-// Set functions for gen2 card
+/**
+ * struct hardware_functions - Hardware function pointers for AXIS Gen2 card.
+ *
+ * This structure provides a set of function pointers for handling various
+ * hardware operations specific to the AXIS Gen2 card. It is part of the device
+ * driver implementation, enabling abstraction and polymorphism for different
+ * hardware implementations.
+ *
+ * @irq: Pointer to the function handling interrupts.
+ * @init: Pointer to the initialization function.
+ * @enable: Pointer to the function that enables the device.
+ * @clear: Pointer to the function that clears device state or buffers.
+ * @retRxBuffer: Pointer to the function that returns a received buffer.
+ * @sendBuffer: Pointer to the function for sending a buffer.
+ * @command: Pointer to the function that handles device-specific commands.
+ * @seqShow: Pointer to the function that supports the seq_file interface for device status reporting.
+ */
 struct hardware_functions AxisG2_functions = {
-   .irq             = AxisG2_Irq,
-   .init            = AxisG2_Init,
-   .enable          = AxisG2_Enable,
-   .clear           = AxisG2_Clear,
-   .retRxBuffer     = AxisG2_RetRxBuffer,
-   .sendBuffer      = AxisG2_SendBuffer,
-   .command         = AxisG2_Command,
-   .seqShow         = AxisG2_SeqShow,
+   .irq          = AxisG2_Irq,
+   .init         = AxisG2_Init,
+   .enable       = AxisG2_Enable,
+   .clear        = AxisG2_Clear,
+   .retRxBuffer  = AxisG2_RetRxBuffer,
+   .sendBuffer   = AxisG2_SendBuffer,
+   .command      = AxisG2_Command,
+   .seqShow      = AxisG2_SeqShow,
 };
 
-
-// Map return descriptors to return record
+/**
+ * AxisG2_MapReturn - Map return descriptor
+ * @dev: Pointer to the device structure.
+ * @ret: Pointer to the return structure to be mapped.
+ * @desc128En: Descriptor size enable flag (1 for 128-bit, 0 for 64-bit).
+ * @index: Index of the descriptor to be mapped.
+ * @ring: Pointer to the ring buffer.
+ *
+ * This inline function maps a return descriptor for processing, handling the
+ * mapping of return descriptors from the DMA engine based on the descriptor
+ * size indicated by @desc128En. It updates the @ret structure with the
+ * descriptor's information.
+ *
+ * Return: Status of the mapping (0 for failure, 1 for success).
+ */
 inline uint8_t AxisG2_MapReturn ( struct DmaDevice * dev, struct AxisG2Return *ret, uint32_t desc128En, uint32_t index, uint32_t *ring) {
    uint32_t * ptr;
    uint32_t chan;
    uint32_t dest;
 
+   // Calculate pointer to the descriptor based on index and descriptor size
    ptr = (ring + (index*(desc128En?4:2)));
 
    if ( desc128En ) {
+      // For 128-bit descriptors
       if ( ptr[3] == 0 ) return 0;
 
       chan        = (ptr[3] >> 8) & 0xF;
@@ -59,6 +91,7 @@ inline uint8_t AxisG2_MapReturn ( struct DmaDevice * dev, struct AxisG2Return *r
       ret->result = ptr[0] & 0x7;
 
    } else {
+      // For 64-bit descriptors
       if ( ptr[1] == 0 ) return 0;
 
       ret->dest   = (ptr[1] >> 24) & 0xFF;
@@ -68,76 +101,127 @@ inline uint8_t AxisG2_MapReturn ( struct DmaDevice * dev, struct AxisG2Return *r
       ret->index  = (ptr[0] >>  4) & 0xFFF;
       ret->cont   = (ptr[0] >>  3) & 0x1;
       ret->result = ptr[0] & 0x7;
-      ret->id     = 0;
+      ret->id     = 0; // ID is set to 0 for 64-bit descriptors
    }
 
+   // Logging for debug purposes
    if ( dev->debug > 0 )
       dev_info(dev->device,"MapReturn: desc idx %i, raw 0x%x, 0x%x, 0x%x, 0x%x\n",index,ptr[0],ptr[1],ptr[2],ptr[3]);
 
+   // Clear the processed descriptor area
    memset(ptr,0,(desc128En?16:8));
    return 1;
 }
 
-// Add buffer to free list
+/**
+ * AxisG2_WriteFree - Add buffer to free list
+ * @buff: Buffer to be added to the free list.
+ * @reg: Pointer to the device register structure.
+ * @desc128En: Descriptor size enable flag.
+ *
+ * Adds a buffer to the free list, making it available for use again.
+ * This function manages the addition of buffers back to the device's pool
+ * of free buffers. It writes the buffer index and, if enabled, the buffer handle
+ * to the device's write FIFOs to mark the buffer as free.
+ */
 inline void AxisG2_WriteFree ( struct DmaBuffer *buff, struct AxisG2Reg *reg, uint32_t desc128En ) {
    uint32_t wrData[2];
 
+   // Mask the buffer index to fit within the 28-bit field
    wrData[0] = buff->index & 0x0FFFFFFF;
 
-   if ( desc128En ) {
-      wrData[0] |= (buff->buffHandle << 24) & 0xF0000000; // Addr bits 7:4
-      wrData[1]  = (buff->buffHandle >>  8) & 0xFFFFFFFF; // Addr bits 39:8
+   if (desc128En) {
+      // If using 128-bit descriptors, encode the buffer handle across two 32-bit writes
+      // First part: Addr bits 7:4 into the upper 4 bits of the first word
+      wrData[0] |= (buff->buffHandle << 24) & 0xF0000000;
+      // Second part: Addr bits 39:8 into the entirety of the second word
+      wrData[1]  = (buff->buffHandle >>  8) & 0xFFFFFFFF;
 
-      iowrite32(wrData[1],&(reg->writeFifoB));
+      // Write the second part to the device's write FIFO B
+      iowrite32(wrData[1], &(reg->writeFifoB));
    }
-   else iowrite32(buff->buffHandle,&(reg->dmaAddr[buff->index])); // Address table
+   // If not using 128-bit descriptors, write the buffer handle directly
+   // to the device's DMA address table based on the buffer index
+   else {
+      // For 64-bit descriptors
+      iowrite32(buff->buffHandle, &(reg->dmaAddr[buff->index]));
+   }
 
-   iowrite32(wrData[0],&(reg->writeFifoA));
+   // Write the first part (or the entire buffer index for 32-bit descriptors)
+   // to the device's write FIFO A
+   iowrite32(wrData[0], &(reg->writeFifoA));
 }
 
-// Add buffer to tx list
-inline void AxisG2_WriteTx ( struct DmaBuffer *buff, struct AxisG2Reg *reg, uint32_t desc128En ) {
+/**
+ * AxisG2_WriteTx - Add buffer to TX list
+ * @buff: Buffer to be transmitted.
+ * @reg: Pointer to the device register structure.
+ * @desc128En: Descriptor size enable flag.
+ *
+ * Adds a buffer to the transmission list, making it ready for sending
+ * out. This function configures the buffer's metadata and submits it to
+ * the appropriate FIFO for transmission based on the descriptor size
+ * enabled by the `desc128En` flag.
+ */
+inline void AxisG2_WriteTx(struct DmaBuffer *buff, struct AxisG2Reg *reg, uint32_t desc128En) {
    uint32_t rdData[4];
    uint32_t dest;
    uint32_t chan;
 
+   // Configure buffer flags for transmission
    rdData[0]  = (buff->flags >> 13) & 0x00000008; // bit[3] = continue = flags[16]
    rdData[0] |= (buff->flags <<  8) & 0x00FF0000; // Bits[23:16] = lastUser = flags[15:8]
    rdData[0] |= (buff->flags << 24) & 0xFF000000; // Bits[31:24] = firstUser = flags[7:0]
 
-   if ( desc128En ) {
+   if (desc128En) {
+      // For 128-bit descriptor enabled
       dest = buff->dest % 256;
       chan = buff->dest / 256;
 
-      rdData[0] |= (chan << 4) & 0x000000F0;
-      rdData[0] |= (dest << 8) & 0x0000FF00;
+      rdData[0] |= (chan << 4) & 0x000000F0; // Channel number
+      rdData[0] |= (dest << 8) & 0x0000FF00; // Destination ID
 
-      rdData[1] = buff->size;
+      rdData[1] = buff->size; // Buffer size
 
+      // Buffer index and handle for 128-bit descriptor
       rdData[2] = buff->index & 0x0FFFFFFF;
-      rdData[2] |= (buff->buffHandle << 24) & 0xF0000000; // Addr bits 7:4
-      rdData[3]  = (buff->buffHandle >>  8) & 0xFFFFFFFF; // Addr bits 39:8
+      rdData[2] |= (buff->buffHandle << 24) & 0xF0000000; // Addr bits[31:28]
+      rdData[3]  = (buff->buffHandle >>  8) & 0xFFFFFFFF; // Addr bits[39:8]
 
-      iowrite32(rdData[3],&(reg->readFifoD));
-      iowrite32(rdData[2],&(reg->readFifoC));
+      // Write to FIFO registers for 128-bit descriptor
+      iowrite32(rdData[3], &(reg->readFifoD));
+      iowrite32(rdData[2], &(reg->readFifoC));
+   } else {
+      // For 64-bit descriptors
+      rdData[0] |= (buff->index <<  4) & 0x0000FFF0; // Buffer ID
+
+      rdData[1]  = buff->size & 0x00FFFFFF; // Buffer size
+      rdData[1] |= (buff->dest << 24) & 0xFF000000; // Destination ID
+
+      // Write buffer handle to DMA address table
+      iowrite32(buff->buffHandle, &(reg->dmaAddr[buff->index]));
    }
-   else {
 
-      rdData[0] |= (buff->index <<  4) & 0x0000FFF0; // Bits[15:4] = buffId
-
-      rdData[1]  = buff->size & 0x00FFFFFF;   // bits[23:0]  = size
-      rdData[1] |= (buff->dest << 24) & 0xFF000000; // bits[31:24] = dest
-
-      iowrite32(buff->buffHandle,&(reg->dmaAddr[buff->index])); // Address table
-   }
-
-   iowrite32(rdData[1],&(reg->readFifoB));
-   iowrite32(rdData[0],&(reg->readFifoA));
+   // Write to FIFO registers
+   iowrite32(rdData[1], &(reg->readFifoB));
+   iowrite32(rdData[0], &(reg->readFifoA));
 }
 
+/**
+ * AxisG2_Process - Process receive and transmit data
+ * @dev: Pointer to the device structure
+ * @reg: Pointer to the device register structure
+ * @hwData: Hardware data to be processed
+ *
+ * This function processes both received and to be transmitted data, handling
+ * the data movement from and to the hardware, and managing both the receive
+ * and transmit queues.
+ *
+ * Returns: Number of processed items
+ */
 uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct AxisG2Data *hwData ) {
-   struct DmaDesc     * desc;
-   struct DmaBuffer   * buff;
+   struct DmaDesc *desc;
+   struct DmaBuffer *buff;
    struct AxisG2Return ret;
 
    uint32_t x;
@@ -160,10 +244,10 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct A
       if ((buff = dmaRetBufferIdxIrq (dev,ret.index)) != NULL) {
 
          // Add to receive/write software queue
-         if ( hwData->hwWrBuffCnt >= (hwData->addrCount-1) ) dmaQueuePushIrq(&(hwData->wrQueue),buff);
-
-         // Add to receive/write hardware queue
-         else {
+         if ( hwData->hwWrBuffCnt >= (hwData->addrCount-1) ) {
+            dmaQueuePushIrq(&(hwData->wrQueue),buff);
+         } else {
+            // Add directly to receive/write hardware queue
             ++(hwData->hwWrBuffCnt);
             AxisG2_WriteFree(buff,reg,hwData->desc128En);
          }
@@ -174,7 +258,6 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct A
    // Process transmit software queue
    if ( hwData->desc128En ) {
       while ( (hwData->hwRdBuffCnt < (hwData->addrCount-1)) && ((buff = dmaQueuePopIrq(&(hwData->rdQueue))) != NULL) ) {
-
          // Write to hardware
          AxisG2_WriteTx(buff,reg,hwData->desc128En);
          ++hwData->hwRdBuffCnt;
@@ -183,10 +266,10 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct A
 
    ////////////////// Receive Buffers /////////////////////////
 
-   // Lock mask
+   // Lock to protect shared resources
    spin_lock(&dev->maskLock);
 
-   // Check write descriptor
+   // Check write (receive) descriptors
    while ( AxisG2_MapReturn(dev,&ret,hwData->desc128En,hwData->writeIndex,hwData->writeAddr) ) {
       ++handleCount;
       --(hwData->hwWrBuffCnt);
@@ -194,6 +277,7 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct A
       if ( dev->debug > 0 ) dev_info(dev->device,"Process: Got RX Descriptor: Idx=%i, Pos=%i\n",ret.index,hwData->writeIndex);
 
       if ( (buff = dmaGetBufferList(&(dev->rxBuffers),ret.index)) != NULL ) {
+         // Set buffer properties based on descriptor info
          buff->count++;
 
          buff->size  = ret.size;
@@ -212,11 +296,14 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct A
                ret.size, ret.dest, ret.fuser, ret.luser, ret.cont, buff->error);
          }
 
-         // Find owner of lane/vc
-         if ( buff->dest < DMA_MAX_DEST ) desc = dev->desc[buff->dest];
-         else desc = NULL;
+         // Determine the owner of the buffer based on dest
+         if (buff->dest < DMA_MAX_DEST) {
+            desc = dev->desc[buff->dest];
+         } else {
+            desc = NULL;
+         }
 
-         // Return entry to FPGA if desc is not open
+         // Return entry to FPGA if descriptor is not open
          if ( desc == NULL ) {
             if ( dev->debug > 0 ) dev_info(dev->device,"Process: Port not open return to free list.\n");
 
@@ -226,24 +313,25 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct A
             }
             else dmaQueuePushIrq(&(hwData->wrQueue),buff);
 
+            // Background operation handling
             if ( (hwData->bgEnable >> buff->id) & 0x1 ) {
                iowrite32(0x1,&(reg->bgCount[buff->id]));
             }
          }
 
-         // lane/vc is open,  Add to RX Queue
+         // Lane/VC is open; add to RX queue
          else dmaRxBufferIrq(desc,buff);
       }
       else dev_warn(dev->device,"Process: Failed to locate RX buffer index %i.\n", ret.index);
 
-      // Update index
+      // Update write index
       hwData->writeIndex = ((hwData->writeIndex+1) % hwData->addrCount);
    }
 
-   // Unlock
+   // Release the lock
    spin_unlock(&dev->maskLock);
 
-   // Get (write / receive) return buffer list
+   // Get (write / receive) return buffer list and process
    if ( hwData->desc128En ) {
       do {
          rCnt = ((hwData->addrCount-1) - hwData->hwWrBuffCnt);
@@ -259,27 +347,53 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct A
    return handleCount;
 }
 
-// Interrupt handler, or service task
-irqreturn_t AxisG2_Irq(int irq, void *dev_id) {
-   struct DmaDevice   * dev;
-   struct AxisG2Reg   * reg;
-   struct AxisG2Data  * hwData;
+/**
+ * AxisG2_Irq - Interrupt handler for AXIS Gen2 DMA.
+ * @irq: Interrupt request number.
+ * @dev_id: Pointer to device-specific data.
+ *
+ * This function is invoked when the AXIS Gen2 DMA device triggers an interrupt.
+ * It disables further interrupts, logs the interrupt occurrence if debugging is enabled,
+ * and schedules work to handle the data if appropriate.
+ *
+ * Return:
+ * IRQ_HANDLED - Indicates that the interrupt was successfully handled.
+ */
+irqreturn_t AxisG2_Irq(int irq, void *dev_id)
+{
+   struct DmaDevice *dev;
+   struct AxisG2Reg *reg;
+   struct AxisG2Data *hwData;
 
-   dev    = (struct DmaDevice *)dev_id;
-   reg    = (struct AxisG2Reg *)dev->reg;
+   dev = (struct DmaDevice *)dev_id;
+   reg = (struct AxisG2Reg *)dev->reg;
    hwData = (struct AxisG2Data *)dev->hwData;
 
    // Disable interrupt
-   iowrite32(0x0,&(reg->intEnable));
+   iowrite32(0x0, &(reg->intEnable));
 
-   if ( dev->debug > 0 ) dev_info(dev->device,"Irq: Called.\n");
+   // Log interrupt occurrence if debugging is enabled
+   if (dev->debug > 0) {
+      dev_info(dev->device, "Irq: Called.\n");
+   }
 
-   // Handle data in work task
-   if ( (! dev->cfgIrqDis) && hwData->wqEnable ) queue_work(hwData->wq,&(hwData->irqWork));
-   return(IRQ_HANDLED);
+   // Schedule work to handle the data if not disabled and work queue is enabled
+   if ((!dev->cfgIrqDis) && hwData->wqEnable) {
+      queue_work(hwData->wq, &(hwData->irqWork));
+   }
+
+   return IRQ_HANDLED;
 }
 
-// Init card in top level Probe
+/**
+ * AxisG2_Init - Initialize Axis G2 DMA device
+ * @dev: Pointer to the DmaDevice structure representing the device.
+ *
+ * This function initializes the Axis G2 DMA device during the probe phase. It sets up
+ * necessary resources, configurations, and software structures for device operation.
+ * This includes setting up DMA buffers, configuring hardware registers, and initializing
+ * software queues for efficient DMA transfers.
+ */
 void AxisG2_Init(struct DmaDevice *dev) {
    uint32_t x;
    uint32_t size;
@@ -288,84 +402,87 @@ void AxisG2_Init(struct DmaDevice *dev) {
    struct AxisG2Data *hwData;
    struct AxisG2Reg  *reg;
 
+   // Map device registers for access
    reg = (struct AxisG2Reg *)dev->reg;
 
-   // Dest mask
+   // Initialize destination mask to all 1's
    memset(dev->destMask,0xFF,DMA_MASK_SIZE);
 
-   // Init hw data
+   // Allocate and initialize hardware data structure
    hwData = (struct AxisG2Data *)kmalloc(sizeof(struct AxisG2Data),GFP_KERNEL);
    dev->hwData = hwData;
    hwData->dev = dev;
 
-   // 64-bit or 128-bit mode
+   // Determine operation mode (64-bit or 128-bit) based on hardware version
    hwData->desc128En = ((ioread32(&(reg->enableVer)) & 0x10000) != 0);
 
-   // Keep track of the number of buffers in hardware
+   // Initialize buffer counters
    hwData->hwWrBuffCnt = 0;
    hwData->hwRdBuffCnt = 0;
 
-   // Init software buffer queues for 128bit mode
+   // Initialize software queues if in 128-bit descriptor mode
    if ( hwData->desc128En ) {
       dmaQueueInit(&hwData->wrQueue,dev->rxBuffers.count);
       dmaQueueInit(&hwData->rdQueue,dev->txBuffers.count + dev->rxBuffers.count);
       hwData->buffList = (struct DmaBuffer **)kmalloc(BUFF_LIST_SIZE * sizeof(struct DmaBuffer *),GFP_ATOMIC);
    }
 
-   // Set read and write ring buffers
+   // Calculate and set the addressable space based on register settings
    hwData->addrCount = (1 << ioread32(&(reg->addrWidth)));
-
-   // Set alloc size
    size = hwData->addrCount*(hwData->desc128En?16:8);
 
+   // Allocate DMA buffers based on configuration mode
    if(dev->cfgMode & AXIS2_RING_ACP) {
+      // Allocate read and write buffers in contiguous physical memory
       hwData->readAddr   = kmalloc(size, GFP_DMA | GFP_KERNEL);
       hwData->readHandle = virt_to_phys(hwData->readAddr);
-
       hwData->writeAddr   = kmalloc(size, GFP_DMA | GFP_KERNEL);
       hwData->writeHandle = virt_to_phys(hwData->writeAddr);
-   }
-   else {
+   } else {
+      // Allocate coherent DMA buffers for read and write operations
       hwData->readAddr = dma_alloc_coherent(dev->device, size, &(hwData->readHandle), GFP_DMA32 | GFP_KERNEL);
       hwData->writeAddr = dma_alloc_coherent(dev->device, size, &(hwData->writeHandle), GFP_DMA32 | GFP_KERNEL);
    }
 
+   // Log buffer addresses
    dev_info(dev->device,"Init: Read  ring at: sw 0x%llx -> hw 0x%llx.\n",(uint64_t)hwData->readAddr,(uint64_t)hwData->readHandle);
    dev_info(dev->device,"Init: Write ring at: sw 0x%llx -> hw 0x%llx.\n",(uint64_t)hwData->writeAddr,(uint64_t)hwData->writeHandle);
 
-   // Init and set ring address
+   // Initialize read ring buffer addresses and indices
    iowrite32(hwData->readHandle&0xFFFFFFFF,&(reg->rdBaseAddrLow));
    iowrite32((hwData->readHandle >> 32)&0xFFFFFFFF,&(reg->rdBaseAddrHigh));
    memset(hwData->readAddr,0,size);
    hwData->readIndex = 0;
 
-   // Init and set ring address
+   // Initialize write ring buffer addresses and indices
    iowrite32(hwData->writeHandle&0xFFFFFFFF,&(reg->wrBaseAddrLow));
    iowrite32((hwData->writeHandle>>32)&0xFFFFFFFF,&(reg->wrBaseAddrHigh));
    memset(hwData->writeAddr,0,size);
    hwData->writeIndex = 0;
 
+   // Initialize interrupt and continuity counters
    hwData->missedIrq = 0;
    hwData->contCount = 0;
 
-   // Set cache mode, bits3:0 = descWr, bits 11:8 = bufferWr, bits 15:12 = bufferRd
+   // Configure cache mode based on device configuration:
+   // bits3:0 = descWr, bits 11:8 = bufferWr, bits 15:12 = bufferRd
    x = 0;
-   if ( dev->cfgMode & BUFF_ARM_ACP   ) x |= 0xA600; // Buffer
-   if ( dev->cfgMode & AXIS2_RING_ACP ) x |= 0x00A6; // Desc
-   iowrite32(x,&(reg->cacheConfig));
+   if (dev->cfgMode & BUFF_ARM_ACP) x |= 0xA600; // Buffer write and read cache policy
+   if (dev->cfgMode & AXIS2_RING_ACP) x |= 0x00A6; // Descriptor write cache policy
+   iowrite32(x, &(reg->cacheConfig));
 
-   // Set MAX RX
+   // Set maximum transfer size
    iowrite32(dev->cfgSize,&(reg->maxSize));
 
-   // Clear FIFOs
+   // Reset FIFOs to clear any residual data
    iowrite32(0x1,&(reg->fifoReset));
    iowrite32(0x0,&(reg->fifoReset));
 
-   // Continue and drop
+   // Enable continuous mode and disable drop mode
    iowrite32(0x1,&(reg->contEnable));
    iowrite32(0x0,&(reg->dropEnable));
 
-   // IRQ Holdoff
+   // Set IRQ holdoff time if supported by hardware version
    if ( ((ioread32(&(reg->enableVer)) >> 24) & 0xFF) >= 3 ) iowrite32(dev->cfgIrqHold,&(reg->irqHoldOff));
 
    // Push RX buffers to hardware and map
@@ -386,7 +503,7 @@ void AxisG2_Init(struct DmaDevice *dev) {
       }
    }
 
-   // Setup buffer groups
+   // Initialize buffer group settings if supported by hardware version
    hwData->bgEnable = 0;
    if ( ((ioread32(&(reg->enableVer)) >> 24) & 0xFF) >= 4 ) {
       for (x =0; x < 8; x++) {
@@ -398,8 +515,16 @@ void AxisG2_Init(struct DmaDevice *dev) {
    dev_info(dev->device,"Init: Found Version 2 Device. Desc128En=%i\n",hwData->desc128En);
 }
 
-
-// Enable the card
+/**
+ * AxisG2_Enable - Enable the AXIS Gen2 device
+ * @dev: Pointer to the device structure.
+ *
+ * This function enables the AXIS Gen2 device, making it ready for operation.
+ * It is typically called after the device has been initialized to start its
+ * functionality. The function configures the device's hardware registers to
+ * enable the device and its interrupt handling. It also initializes and starts
+ * a workqueue if required, based on the device's configuration.
+ */
 void AxisG2_Enable(struct DmaDevice *dev) {
    struct AxisG2Reg  *reg;
    struct AxisG2Data *hwData;
@@ -407,92 +532,119 @@ void AxisG2_Enable(struct DmaDevice *dev) {
    reg = (struct AxisG2Reg *)dev->reg;
    hwData = (struct AxisG2Data *)dev->hwData;
 
-   // Enable
-   iowrite32(0x1,&(reg->enableVer));
+   // Enable the device by setting the enable version and online registers
+   iowrite32(0x1, &(reg->enableVer));
+   iowrite32(0x1, &(reg->online));
 
-   // Online
-   iowrite32(0x1,&(reg->online));
-
-   // Start workqueue
-   if ( hwData->desc128En ) {
+   // Check if descriptor 128-bit enable flag is set
+   if (hwData->desc128En) {
       hwData->wqEnable = 1;
 
-      // Background task to ensure regular interval of interrupts
-      if ( ! dev->cfgIrqDis ) {
-      	 hwData->wq = create_singlethread_workqueue("AXIS_G2_WORKQ");
+      // Configure workqueue and delayed work for interrupt handling or polling
+      if (!dev->cfgIrqDis) {
+         // Create a single-thread workqueue for interrupt handling
+         hwData->wq = create_singlethread_workqueue("AXIS_G2_WORKQ");
          INIT_DELAYED_WORK(&(hwData->dlyWork), AxisG2_WqTask_IrqForce);
-         queue_delayed_work(hwData->wq,&(hwData->dlyWork),10);
+         queue_delayed_work(hwData->wq, &(hwData->dlyWork), 10);
 
-         // Init processing work, called from IRQ
+         // Initialize work for processing, called from IRQ
          INIT_WORK(&(hwData->irqWork), AxisG2_WqTask_Service);
-      }
-
-      // Polling mode without interrupts
-      else {
+      } else {
+         // Allocate workqueue for polling mode, without interrupts
          hwData->wq = alloc_workqueue("%s", WQ_MEM_RECLAIM | WQ_SYSFS, 1, "AXIS_G2_WORKQ");
          INIT_WORK(&(hwData->irqWork), AxisG2_WqTask_Poll);
-         queue_work_on(dev->cfgIrqDis,hwData->wq,&(hwData->irqWork));
+         queue_work_on(dev->cfgIrqDis, hwData->wq, &(hwData->irqWork));
       }
-   }
-   else hwData->wqEnable = 0;
-
-   // Enable interrupt
-   if ( ! dev->cfgIrqDis ) {
-      iowrite32(0x1,&(reg->intEnable));
+   } else {
+      hwData->wqEnable = 0;
    }
 
-   // Enable
-   iowrite32(0x1,&(reg->enableVer));
+   // Enable interrupt handling if not disabled by configuration
+   if (!dev->cfgIrqDis) {
+      iowrite32(0x1, &(reg->intEnable));
+   }
 
-   // Online
-   iowrite32(0x1,&(reg->online));
+   // Re-enable the device and online status to ensure settings take effect
+   iowrite32(0x1, &(reg->enableVer));
+   iowrite32(0x1, &(reg->online));
 
-   // Enable interrupt
-   iowrite32(0x1,&(reg->intEnable));
+   // Re-enable interrupt handling as a final step
+   iowrite32(0x1, &(reg->intEnable));
 }
 
-// Clear card in top level Remove
+/**
+ * AxisG2_Clear - Clear device resources
+ * @dev: Pointer to the device structure.
+ *
+ * This function clears and releases the device resources during the removal
+ * phase. It ensures that the device's interrupts are disabled, the work queue
+ * is stopped and destroyed, RX and TX are disabled, FIFOs are cleared, and
+ * all allocated memory for buffers is freed, thus properly shutting down and
+ * cleaning up the device.
+ */
 void AxisG2_Clear(struct DmaDevice *dev) {
    struct AxisG2Reg *reg;
-   struct AxisG2Data * hwData;
+   struct AxisG2Data *hwData;
 
    reg = (struct AxisG2Reg *)dev->reg;
    hwData = (struct AxisG2Data *)dev->hwData;
 
-   // Disable interrupt, stop work queue
-   iowrite32(0x0,&(reg->intEnable));
+   // Disable interrupts to prevent further device activity.
+   iowrite32(0x0, &(reg->intEnable));
 
-   // Stop work queue
-   if ( hwData->wqEnable ) {
+   // Stop and destroy the work queue if enabled.
+   if (hwData->wqEnable) {
       hwData->wqEnable = 0;
-      if ( ! dev->cfgIrqDis ) cancel_delayed_work_sync(&(hwData->dlyWork));
+      // Cancel any pending delayed work if IRQs are not disabled.
+      if (!dev->cfgIrqDis) {
+         cancel_delayed_work_sync(&(hwData->dlyWork));
+      }
+      // Ensure all work for the device is completed before freeing resources.
       flush_workqueue(hwData->wq);
       destroy_workqueue(hwData->wq);
    }
 
-   // Disable rx and tx
-   iowrite32(0x0,&(reg->enableVer));
-   iowrite32(0x0,&(reg->online));
+   // Disable RX and TX to stop data transfers.
+   iowrite32(0x0, &(reg->enableVer));
+   iowrite32(0x0, &(reg->online));
 
-   // Clear FIFOs
-   iowrite32(0x1,&(reg->fifoReset));
+   // Clear FIFOs to reset the device's internal state.
+   iowrite32(0x1, &(reg->fifoReset));
 
-   // Free buffers
-   if(dev->cfgMode & AXIS2_RING_ACP) {
+   // Free allocated buffers depending on the device configuration.
+   if (dev->cfgMode & AXIS2_RING_ACP) {
+      // For AXIS2_RING_ACP mode, use kfree for buffer deallocation.
       kfree(hwData->readAddr);
       kfree(hwData->writeAddr);
-   }
-   else {
-      dma_free_coherent(dev->device, hwData->addrCount*8, hwData->writeAddr, hwData->writeHandle);
-      dma_free_coherent(dev->device, hwData->addrCount*8, hwData->readAddr, hwData->readHandle);
+   } else {
+      // For non-ACP modes, use dma_free_coherent to ensure proper DMA memory management.
+      dma_free_coherent(dev->device, hwData->addrCount * 8, hwData->writeAddr, hwData->writeHandle);
+      dma_free_coherent(dev->device, hwData->addrCount * 8, hwData->readAddr, hwData->readHandle);
    }
 
-   if ( hwData->desc128En ) kfree(hwData->buffList);
+   // Free the buffer list if descriptor 128-bit mode is enabled.
+   if (hwData->desc128En) {
+      kfree(hwData->buffList);
+   }
 
+   // Finally, free the hardware data structure itself.
    kfree(hwData);
 }
 
-// Return buffer list to card
+/**
+ * AxisG2_RetRxBuffer - Return receive buffers to card
+ * @dev:   Pointer to the device structure.
+ * @buff:  Buffers to be returned.
+ * @count: Number of buffers to be returned.
+ *
+ * This function returns received buffers back to the card for reuse,
+ * which is typically invoked after the application has processed the received data.
+ * It handles both 64-bit and 128-bit descriptor modes, ensuring buffers are
+ * correctly returned to the hardware for future use. Errors in buffer mapping are
+ * reported, and the function supports background operation mode for buffer group
+ * credits, triggering an interrupt after pushing buffers to the software queue
+ * in 128-bit descriptor mode.
+ */
 void AxisG2_RetRxBuffer(struct DmaDevice *dev, struct DmaBuffer **buff, uint32_t count) {
    struct AxisG2Reg *reg;
    struct AxisG2Data *hwData;
@@ -501,101 +653,141 @@ void AxisG2_RetRxBuffer(struct DmaDevice *dev, struct DmaBuffer **buff, uint32_t
    reg = (struct AxisG2Reg *)dev->reg;
    hwData = (struct AxisG2Data *)dev->hwData;
 
-   // Prep for hardware
-   for (x =0; x < count; x++) {
-      if ( dmaBufferToHw(buff[x]) < 0 ) {
-         dev_warn(dev->device,"RetRxBuffer: Failed to map dma buffer.\n");
+   // Prepare for hardware interaction
+   for (x = 0; x < count; x++) {
+      if (dmaBufferToHw(buff[x]) < 0) {
+         dev_warn(dev->device, "RetRxBuffer: Failed to map dma buffer.\n");
          return;
       }
 
-      // Write to hardware if 64-bit desc, no lock required
-      if ( ! hwData->desc128En ) AxisG2_WriteFree(buff[x],reg,hwData->desc128En);
+      // Directly write to hardware for 64-bit descriptors, no locking needed
+      if (!hwData->desc128En) {
+         AxisG2_WriteFree(buff[x], reg, hwData->desc128En);
+      }
    }
 
-   // Push to software queue for 128bit desc, force an interrupt
-   if ( hwData->desc128En ) {
-      dmaQueuePushList(&(hwData->wrQueue),buff,count);
+   // For 128-bit descriptors, push to software queue and force an interrupt
+   if (hwData->desc128En) {
+      dmaQueuePushList(&(hwData->wrQueue), buff, count);
 
-      // Process buffer group credits
-      if ( hwData->bgEnable != 0 ) {
-         for (x =0; x < count; x++) {
-            if ( (hwData->bgEnable >> buff[x]->id) & 0x1 ) {
-               iowrite32(0x1,&(reg->bgCount[buff[x]->id]));
+      // Handle buffer group credits if background operation is enabled
+      if (hwData->bgEnable != 0) {
+         for (x = 0; x < count; x++) {
+            if ((hwData->bgEnable >> buff[x]->id) & 0x1) {
+               iowrite32(0x1, &(reg->bgCount[buff[x]->id]));
             }
          }
       }
 
-      iowrite32(0x1,&(reg->forceInt));
+      // Force an interrupt to process the returned buffers
+      iowrite32(0x1, &(reg->forceInt));
    }
 }
 
-// Send a buffer
+/**
+ * AxisG2_SendBuffer - Send a buffer or a series of buffers.
+ * @dev:   Pointer to the device structure.
+ * @buff:  Buffer to be sent.
+ * @count: Number of buffers to be sent.
+ *
+ * This function sends out a buffer or a series of buffers, queuing them for transmission
+ * through the DMA engine. It supports both 64-bit and 128-bit descriptor modes. In 64-bit
+ * mode, buffers are written directly to the hardware, while in 128-bit mode, buffers are
+ * pushed to a software queue and an interrupt is forced to handle the transfer.
+ *
+ * Return: On success, the number of buffers queued for transmission. On error, -1 if
+ *         a buffer mapping to hardware fails.
+ */
 int32_t AxisG2_SendBuffer(struct DmaDevice *dev, struct DmaBuffer **buff, uint32_t count) {
-   struct AxisG2Data * hwData;
+   struct AxisG2Data *hwData;
    struct AxisG2Reg *reg;
    unsigned long iflags;
-
    uint32_t x;
 
    reg = (struct AxisG2Reg *)dev->reg;
    hwData = (struct AxisG2Data *)dev->hwData;
 
-   // Prep for hardware
-   for (x =0; x < count; x++) {
-      if ( dmaBufferToHw(buff[x]) < 0 ) {
-         dev_warn(dev->device,"SendBuffer: Failed to map dma buffer.\n");
-         return(-1);
+   // Prepare buffers for hardware transmission
+   for (x = 0; x < count; x++) {
+      if (dmaBufferToHw(buff[x]) < 0) {
+         dev_warn(dev->device, "SendBuffer: Failed to map dma buffer.\n");
+         return -1;
       }
 
-      // Write directly to hardware for 64-bit desc
-      if ( ! hwData->desc128En ) {
-         spin_lock_irqsave(&dev->writeHwLock,iflags);
-         AxisG2_WriteTx(buff[x],reg,hwData->desc128En);
-         spin_unlock_irqrestore(&dev->writeHwLock,iflags);
+      // Direct hardware write for 64-bit descriptors
+      if (!hwData->desc128En) {
+         spin_lock_irqsave(&dev->writeHwLock, iflags);
+         AxisG2_WriteTx(buff[x], reg, hwData->desc128En);
+         spin_unlock_irqrestore(&dev->writeHwLock, iflags);
       }
    }
 
-   // Push to software queue for 128bit desc, force an interrupt
-   if ( hwData-> desc128En ) {
-      dmaQueuePushList(&(hwData->rdQueue),buff,count);
-      iowrite32(0x1,&(reg->forceInt));
+   // For 128-bit descriptors, push to software queue and force an interrupt
+   if (hwData->desc128En) {
+      dmaQueuePushList(&(hwData->rdQueue), buff, count);
+      iowrite32(0x1, &(reg->forceInt));
    }
-   return(count);
+
+   return count;
 }
 
-// Execute command
-int32_t AxisG2_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
+/**
+ *---------------------------------------------------------------------------
+ * AxisG2_Command - Execute device command
+ * @dev: Pointer to the device structure.
+ * @cmd: Command to be executed.
+ * @arg: Argument for the command.
+ *
+ * Executes a specific command on the device, providing a mechanism for
+ * controlling device behavior or querying device status.
+ *
+ * Return: Status of the command execution.
+ *---------------------------------------------------------------------------
+ */
+int32_t AxisG2_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg)
+{
    struct AxisG2Reg *reg;
    reg = (struct AxisG2Reg *)dev->reg;
 
    switch (cmd) {
 
-      // Read ACK
       case AXIS_Read_Ack:
+         // Lock the device command execution context
          spin_lock(&dev->commandLock);
-         iowrite32(0x1,&(reg->acknowledge));
+         // Acknowledge the read request
+         iowrite32(0x1, &(reg->acknowledge));
+         // Unlock after command execution
          spin_unlock(&dev->commandLock);
-         return(0);
+         return 0;
          break;
 
-      // Write Req Missed
       case AXIS_Write_ReqMissed:
-         return(ioread32(&(reg->wrReqMissed)));
+         // Return the number of missed write requests
+         return ioread32(&(reg->wrReqMissed));
          break;
 
       default:
-         dev_warn(dev->device,"Command: Invalid command=%i\n",cmd);
-         return(-1);
+         // Log a warning for an invalid command and return an error
+         dev_warn(dev->device, "Command: Invalid command=%i\n", cmd);
+         return -1;
          break;
    }
 }
 
-
-// Add data to proc dump
+/**
+ * AxisG2_SeqShow - Add data to proc dump.
+ * @s: Sequence file pointer.
+ * @dev: Pointer to the device structure.
+ *
+ * This function adds device-specific data to the proc file system dump,
+ * enabling debugging and status queries via the /proc file system. It
+ * iterates through various DMA firmware and hardware state parameters,
+ * formatting and printing them to the sequence file for easy access
+ * and readability.
+ */
 void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
    struct AxisG2Reg *reg;
-   struct AxisG2Data * hwData;
-
+   struct AxisG2Data *hwData;
    uint32_t x;
 
    reg = (struct AxisG2Reg *)dev->reg;
@@ -629,66 +821,114 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
    }
 }
 
-
-// Work queue task to force periodic IRQ
-void AxisG2_WqTask_IrqForce ( struct work_struct *work ) {
+/**
+ *-------------------------------------------------------------------------------
+ * AxisG2_WqTask_IrqForce - Work queue task to force periodic IRQ
+ * @work: Pointer to the work_struct structure.
+ *
+ * This function forces a periodic interrupt request (IRQ) to ensure that the
+ * device remains responsive and to handle any conditions that require regular
+ * attention. It is designed to be used as part of a work queue mechanism.
+ *-------------------------------------------------------------------------------
+ */
+void AxisG2_WqTask_IrqForce(struct work_struct *work) {
    struct AxisG2Reg *reg;
-   struct AxisG2Data * hwData;
-   struct delayed_work * dlyWork;
+   struct AxisG2Data *hwData;
+   struct delayed_work *dlyWork;
 
-   dlyWork = container_of(work,    struct delayed_work, work);
-   hwData  = container_of(dlyWork, struct AxisG2Data,   dlyWork);
+   // Convert from work_struct to delayed_work
+   dlyWork = container_of(work, struct delayed_work, work);
+   // Get the container AxisG2Data
+   hwData = container_of(dlyWork, struct AxisG2Data, dlyWork);
 
+   // Access device registers
    reg = (struct AxisG2Reg *)hwData->dev->reg;
 
-   iowrite32(0x1,&(reg->forceInt));
+   // Force an interrupt
+   iowrite32(0x1, &(reg->forceInt));
 
-   if ( hwData->wqEnable ) queue_delayed_work(hwData->wq,&(hwData->dlyWork),10);
+   // If work queue is enabled, re-queue the work with a delay
+   if (hwData->wqEnable)
+      queue_delayed_work(hwData->wq, &(hwData->dlyWork), 10);
 }
 
-
-// Work queue task to run a poll loop
-void AxisG2_WqTask_Poll ( struct work_struct *work ) {
+/**
+ * AxisG2_WqTask_Poll - Work queue task for polling
+ * @work: Work structure.
+ *
+ * Implements a polling mechanism as a work queue task. This function allows
+ * for periodic checks of the device status or data without relying on interrupts.
+ * It processes data through the AxisG2_Process function and logs the number of
+ * handled items if debugging is enabled. If work queue processing is enabled,
+ * it re-queues itself for continuous operation.
+ */
+void AxisG2_WqTask_Poll(struct work_struct *work) {
    uint32_t handleCount;
    struct AxisG2Reg *reg;
    struct DmaDevice *dev;
    struct AxisG2Data *hwData;
 
+   // Extract hardware data from the work structure
    hwData = container_of(work, struct AxisG2Data, irqWork);
 
+   // Retrieve device and register structures
    reg = (struct AxisG2Reg *)hwData->dev->reg;
    dev = (struct DmaDevice *)hwData->dev;
 
-   // Process data
-   handleCount = AxisG2_Process (dev, reg, hwData);
+   // Process data and return the number of handled items
+   handleCount = AxisG2_Process(dev, reg, hwData);
 
-   if ( dev->debug > 0 && handleCount > 0 ) dev_info(dev->device,"Poll: Done. Handled = %i\n",handleCount);
+   // Log the number of handled items if debugging is enabled
+   if (dev->debug > 0 && handleCount > 0) {
+      dev_info(dev->device, "Poll: Done. Handled = %i\n", handleCount);
+   }
 
-   if ( hwData->wqEnable ) queue_work_on(dev->cfgIrqDis,hwData->wq,&(hwData->irqWork));
+   // Re-queue work if work queue processing is enabled
+   if (hwData->wqEnable) {
+      queue_work_on(dev->cfgIrqDis, hwData->wq, &(hwData->irqWork));
+   }
 }
 
-
-// Work queue task to handle IRQ processing
-void AxisG2_WqTask_Service ( struct work_struct *work ) {
+/**
+ * AxisG2_WqTask_Service - Work queue task for IRQ processing
+ * @work: Work structure.
+ *
+ * This function handles IRQ processing as a work queue task, allowing for
+ * deferred or asynchronous processing of interrupt-driven events. It is
+ * designed to process data, handle interrupt acknowledgment, and manage
+ * interrupt enablement through work queues.
+ */
+void AxisG2_WqTask_Service(struct work_struct *work) {
    uint32_t handleCount;
-
    struct AxisG2Reg *reg;
    struct DmaDevice *dev;
    struct AxisG2Data *hwData;
 
+   // Obtain the hardware data from the work structure
    hwData = container_of(work, struct AxisG2Data, irqWork);
 
+   // Cast device and register pointers from the hardware data
    reg = (struct AxisG2Reg *)hwData->dev->reg;
    dev = (struct DmaDevice *)hwData->dev;
 
-   if ( dev->debug > 0 ) dev_info(dev->device,"Service: Entered\n");
+   // Debug information: entering service routine
+   if (dev->debug > 0) {
+      dev_info(dev->device, "Service: Entered\n");
+   }
 
-   // Process data
-   handleCount = AxisG2_Process (dev, reg, hwData);
+   // Process incoming data and handle it accordingly
+   handleCount = AxisG2_Process(dev, reg, hwData);
 
-   // Enable interrupt and update ack count
-   if ( handleCount == 0 ) hwData->missedIrq++;
-   if ( dev->debug > 0 ) dev_info(dev->device,"Service: Done. Handled = %i\n",handleCount);
-   iowrite32(0x30000 + handleCount,&(reg->intAckAndEnable));
+   // Increment missed IRQ counter if no handle was processed
+   if (handleCount == 0) {
+      hwData->missedIrq++;
+   }
+
+   // Debug information: completion of service routine
+   if (dev->debug > 0) {
+      dev_info(dev->device, "Service: Done. Handled = %i\n", handleCount);
+   }
+
+   // Acknowledge interrupt and enable next interrupt
+   iowrite32(0x30000 + handleCount, &(reg->intAckAndEnable));
 }
-

--- a/common/driver/axis_gen2.h
+++ b/common/driver/axis_gen2.h
@@ -1,12 +1,14 @@
 /**
- *-----------------------------------------------------------------------------
- * Title      : AXIS Gen2 Functions
  * ----------------------------------------------------------------------------
- * File       : axis_gen2.h
- * Created    : 2017-02-03
+ * Company    : SLAC National Accelerator Laboratory
  * ----------------------------------------------------------------------------
  * Description:
- * Access functions for Gen2 AXIS DMA
+ *    This header file defines the interfaces and data structures for the Axis
+ *    Gen2 DMA driver. It includes function prototypes for device initialization,
+ *    data transmission, and reception management, along with definitions for
+ *    handling device-specific commands and interrupts. Designed for
+ *    high-performance data movement, this API facilitates efficient
+ *    communication between the host and Axis Gen2 hardware.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to
  * the license terms in the LICENSE.txt file found in the top-level directory
@@ -17,6 +19,7 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #ifndef __AXIS_GEN2_H__
 #define __AXIS_GEN2_H__
 
@@ -28,6 +31,49 @@
 #define AXIS2_RING_ACP 0x10
 #define BUFF_LIST_SIZE 1000
 
+/**
+ * struct AxisG2Reg - AXIS Gen2 Register Map.
+ * @enableVer: Version and enable register (0x0000).
+ * @intEnable: Interrupt enable register (0x0004).
+ * @contEnable: Continuous operation enable register (0x0008).
+ * @dropEnable: Drop packet enable register (0x000C).
+ * @wrBaseAddrLow: Write base address low register (0x0010).
+ * @wrBaseAddrHigh: Write base address high register (0x0014).
+ * @rdBaseAddrLow: Read base address low register (0x0018).
+ * @rdBaseAddrHigh: Read base address high register (0x001C).
+ * @fifoReset: FIFO reset register (0x0020).
+ * @spareA: Spare register A (0x0024).
+ * @maxSize: Maximum transfer size register (0x0028).
+ * @online: Online status register (0x002C).
+ * @acknowledge: Interrupt acknowledge register (0x0030).
+ * @channelCount: Number of channels register (0x0034).
+ * @addrWidth: Address width register (0x0038).
+ * @cacheConfig: Cache configuration register (0x003C).
+ * @readFifoA: Read FIFO A register (0x0040).
+ * @readFifoB: Read FIFO B register (0x0044).
+ * @writeFifoA: Write FIFO A register (0x0048).
+ * @intAckAndEnable: Interrupt acknowledge and enable register (0x004C).
+ * @intReqCount: Interrupt request count register (0x0050).
+ * @hwWrIndex: Hardware write index register (0x0054).
+ * @hwRdIndex: Hardware read index register (0x0058).
+ * @wrReqMissed: Write request missed register (0x005C).
+ * @readFifoC: Read FIFO C register (0x0060).
+ * @readFifoD: Read FIFO D register (0x0064).
+ * @spareB: Spare registers B (0x0068 - 0x006C).
+ * @writeFifoB: Write FIFO B register (0x0070).
+ * @spareC: Spare registers C (0x0074 - 0x007C).
+ * @forceInt: Force interrupt register (0x0080).
+ * @irqHoldOff: IRQ hold-off time register (0x0084).
+ * @spareD: Spare registers D (0x0088 - 0x008C).
+ * @bgThold: Background threshold registers (0x0090 - 0x00AC).
+ * @bgCount: Background count registers (0x00B0 - 0x00CC).
+ * @spareE: Spare registers E (0x00D0 - 0x3FFC).
+ * @dmaAddr: DMA address array (0x4000 - 0x7FFC).
+ *
+ * This structure maps the AXIS Gen2 registers. It includes control, status,
+ * configuration, and data buffer registers. The map is designed for efficient
+ * hardware access to perform DMA operations.
+ */
 struct AxisG2Reg {
    uint32_t enableVer;       // 0x0000
    uint32_t intEnable;       // 0x0004
@@ -60,27 +106,75 @@ struct AxisG2Reg {
    uint32_t spareC[3];       // 0x0074 - 0x007C
    uint32_t forceInt;        // 0x0080
    uint32_t irqHoldOff;      // 0x0084
-
    uint32_t spareD[2];       // 0x0088 - 0x008C
    uint32_t bgThold[8];      // 0x0090 - 0x00AC
    uint32_t bgCount[8];      // 0x00B0 - 0x00CC
-
    uint32_t spareE[4044];    // 0x00D0 - 0x3FFC
-
    uint32_t dmaAddr[4096];   // 0x4000 - 0x7FFC
 };
 
+/**
+ * struct AxisG2Return - Represents the return structure for AXIS Gen2.
+ *
+ * This structure is used to store the result of an AXIS Gen2 operation, providing
+ * various details about the transaction including its size, result, and user-defined
+ * flags. It's part of the data handling in DMA transactions, capturing the essence
+ * of a completed operation's outcome.
+ *
+ * @index:  The index of the operation, typically used for identifying the
+ *          transaction in a sequence of operations.
+ * @size:   The size of the data transferred in this operation, in bytes.
+ * @result: The result of the operation, where a specific value usually indicates
+ *          success or a certain type of failure.
+ * @fuser:  The first user-defined value, which can be used for tagging the
+ *          operation with custom information at the start.
+ * @luser:  The last user-defined value, which can be used for tagging the
+ *          operation with custom information at the end.
+ * @dest:   The destination identifier, useful for routing the result to the
+ *          correct handler or buffer.
+ * @cont:   A flag indicating whether the operation is continuous or a single shot.
+ *          This can be used to control the flow of data processing.
+ * @id:     An identifier for the operation, providing a unique tag for tracking
+ *          and referencing purposes.
+ */
 struct AxisG2Return {
-   uint32_t index;
-   uint32_t size;
-   uint8_t  result;
-   uint8_t  fuser;
-   uint8_t  luser;
-   uint16_t dest;
-   uint8_t  cont;
-   uint8_t  id;
+   uint32_t index;  // Index of the operation
+   uint32_t size;   // Size of the data transferred
+   uint8_t  result; // Result of the operation
+   uint8_t  fuser;  // First user-defined value
+   uint8_t  luser;  // Last user-defined value
+   uint16_t dest;   // Destination identifier
+   uint8_t  cont;   // Continuous operation flag
+   uint8_t  id;     // Operation identifier
 };
 
+/**
+ * struct AxisG2Data - Structure to manage AXIS Gen2 DMA data.
+ * @dev: Pointer to the associated DmaDevice structure.
+ * @desc128En: Indicates if 128-bit descriptors are enabled.
+ * @readAddr: Pointer to the base address for DMA read operations.
+ * @readHandle: DMA handle for the read operations.
+ * @readIndex: Current index in the read buffer.
+ * @writeAddr: Pointer to the base address for DMA write operations.
+ * @writeHandle: DMA handle for the write operations.
+ * @writeIndex: Current index in the write buffer.
+ * @addrCount: Number of addresses for DMA operations.
+ * @missedIrq: Counter for missed IRQs.
+ * @hwWrBuffCnt: Hardware write buffer count.
+ * @hwRdBuffCnt: Hardware read buffer count.
+ * @wrQueue: Write queue for managing DMA write requests.
+ * @rdQueue: Read queue for managing DMA read requests.
+ * @contCount: Counter for continuous operations.
+ * @bgEnable: Flag to enable background operations.
+ * @wqEnable: Flag to enable workqueue operations.
+ * @wq: Pointer to the workqueue structure.
+ * @dlyWork: Delayed work structure for scheduling tasks.
+ * @irqWork: Work structure for IRQ handling.
+ * @buffList: Pointer to a list of DmaBuffer pointers.
+ *
+ * This structure is used by the AXIS Gen2 DMA driver to manage data related
+ * to DMA operations, including addressing, buffers, and hardware counters.
+ */
 struct AxisG2Data {
    struct DmaDevice *dev;
 
@@ -115,53 +209,22 @@ struct AxisG2Data {
    struct DmaBuffer  ** buffList;
 };
 
-// Map return
+// Function prototypes
 inline uint8_t AxisG2_MapReturn ( struct DmaDevice *dev, struct AxisG2Return *ret, uint32_t desc128En, uint32_t index, uint32_t *ring);
-
-// Add buffer to free list
 inline void AxisG2_WriteFree ( struct DmaBuffer *buff, struct AxisG2Reg *reg, uint32_t desc128En );
-
-// Add buffer to tx list
 inline void AxisG2_WriteTx ( struct DmaBuffer *buff, struct AxisG2Reg *reg, uint32_t desc128En );
-
-// Process receive and transmit data
 uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct AxisG2Data *hwData );
-
-// Interrupt handler
 irqreturn_t AxisG2_Irq(int irq, void *dev_id);
-
-// Init card in top level Probe
 void AxisG2_Init(struct DmaDevice *dev);
-
-// enable device
 void AxisG2_Enable(struct DmaDevice *dev);
-
-// Clear card in top level Remove
 void AxisG2_Clear(struct DmaDevice *dev);
-
-// Return receive buffers to card
 void AxisG2_RetRxBuffer(struct DmaDevice *dev, struct DmaBuffer **buff, uint32_t count);
-
-// Send a buffer
 int32_t AxisG2_SendBuffer(struct DmaDevice *dev, struct DmaBuffer **buff, uint32_t count);
-
-// Execute command
 int32_t AxisG2_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg);
-
-// Add data to proc dump
 void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev);
-
-// Set functions for gen2 card
 extern struct hardware_functions AxisG2_functions;
-
-// Work queue task to force periodic IRQ
 void AxisG2_WqTask_IrqForce ( struct work_struct *work );
-
-// Work queue task to run a poll loop
 void AxisG2_WqTask_Poll ( struct work_struct *work );
-
-// Work queue task to handle IRQ processing
 void AxisG2_WqTask_Service ( struct work_struct *work );
 
-#endif
-
+#endif // __AXIS_GEN2_H__

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -1,14 +1,13 @@
 /**
- *-----------------------------------------------------------------------------
- * Title      : General purpose DMA buffers.
  * ----------------------------------------------------------------------------
- * File       : dma_buffer.c
- * Author     : Ryan Herbst, rherbst@slac.stanford.edu
- * Created    : 2016-08-08
- * Last update: 2016-08-08
+ * Company    : SLAC National Accelerator Laboratory
  * ----------------------------------------------------------------------------
  * Description:
- * General purpose DMA buffers for drivers.
+ *    This file implements the management and operations of general-purpose Direct
+ *    Memory Access (DMA) buffers used within the driver framework. These buffers
+ *    facilitate efficient data transfers between the CPU and hardware peripherals
+ *    without CPU intervention, optimizing performance for high-speed data
+ *    processing and transfer tasks.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to 
  * the license terms in the LICENSE.txt file found in the top-level directory 
@@ -19,6 +18,7 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #include <dma_buffer.h>
 #include <asm/io.h>
 #include <linux/dma-mapping.h>
@@ -27,8 +27,22 @@
 #include <linux/slab.h>
 #include <dma_common.h>
 
-// Create a list of buffer
-// Return number of buffers created
+/**
+ * dmaAllocBuffers - Allocate DMA buffers and organize them into a list
+ * @dev: pointer to the DMA device structure
+ * @list: pointer to the DMA buffer list structure to populate
+ * @count: number of buffers to allocate
+ * @baseIdx: base index for buffer enumeration
+ * @direction: the DMA data transfer direction
+ *
+ * This function allocates a specified number of DMA buffers and organizes them
+ * into a list for management. It handles different buffer types based on the
+ * device configuration, including coherent, streaming, and ACP (ARM Coherent Port).
+ * It returns the number of successfully allocated buffers, which can be less than
+ * requested in case of allocation failures.
+ *
+ * Return: the count of successfully allocated buffers, or 0 on failure.
+ */
 size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
                          uint32_t count, uint32_t baseIdx, enum dma_data_direction direction) {
    uint32_t x;
@@ -148,138 +162,232 @@ cleanup_forced_exit:
    return 0;
 }
 
-// Free a list of buffers
+/**
+ * dmaFreeBuffersList - Free a list of DMA buffers.
+ * @list: pointer to the structure DmaBufferList representing the list of buffers.
+ *
+ * This function iterates through a list of DMA buffers and frees each buffer
+ * according to its type (coherent, streaming, or ARM ACP). It supports different
+ * freeing mechanisms based on the buffer type, including dma_free_coherent for
+ * coherent buffers and dma_unmap_single for streaming buffers. The function also
+ * resets the buffer count to 0 after all buffers have been freed.
+ */
 void dmaFreeBuffersList(struct DmaBufferList *list) {
    uint32_t sl;
    uint32_t sli;
    uint32_t x;
    
-   for (x=0; x < list->count; x++) {
+   for (x = 0; x < list->count; x++) {
       sl  = x / BUFFERS_PER_LIST;
       sli = x % BUFFERS_PER_LIST;
 
-      if ( list->indexed[sl][sli]->buffAddr != NULL ) {
+      if (list->indexed[sl][sli]->buffAddr != NULL) {
 
-         // Coherent buffer
-         if ( list->dev->cfgMode & BUFF_COHERENT ) {
-            dma_free_coherent(list->dev->device, list->dev->cfgSize,list->indexed[sl][sli]->buffAddr,list->indexed[sl][sli]->buffHandle);
+         // Free coherent buffer
+         if (list->dev->cfgMode & BUFF_COHERENT) {
+            dma_free_coherent(list->dev->device, list->dev->cfgSize,
+                              list->indexed[sl][sli]->buffAddr,
+                              list->indexed[sl][sli]->buffHandle);
          }
 
-         // Streaming type
-         if ( list->dev->cfgMode & BUFF_STREAM ) {
-            dma_unmap_single(list->dev->device,list->indexed[sl][sli]->buffHandle,list->dev->cfgSize,list->direction);
+         // Unmap streaming buffer
+         if (list->dev->cfgMode & BUFF_STREAM) {
+            dma_unmap_single(list->dev->device,
+                             list->indexed[sl][sli]->buffHandle,
+                             list->dev->cfgSize, list->direction);
          }
 
-         // Streaming buffer type or ARM ACP
-         if ( (list->dev->cfgMode & BUFF_STREAM) || (list->dev->cfgMode & BUFF_ARM_ACP) ) {
+         // Free buffer for streaming type or ARM ACP
+         if ((list->dev->cfgMode & BUFF_STREAM) || (list->dev->cfgMode & BUFF_ARM_ACP)) {
             kfree(list->indexed[sl][sli]->buffAddr);
          }
       }
+      // Free the buffer structure
       kfree(list->indexed[sl][sli]);
    }
+   // Reset buffer count
    list->count = 0;
 }
 
-// Free a list of buffers including heads
-void dmaFreeBuffers ( struct DmaBufferList *list ) {
+/**
+ * dmaFreeBuffers - Free a list of DMA buffers including head buffers
+ * @list: pointer to the DmaBufferList structure to be freed
+ *
+ * This function frees all buffers associated with a DMA buffer list,
+ * including the head of the list and any indexed or sorted buffers.
+ * It also calls dmaFreeBuffersList to handle list-specific deallocations.
+ */
+void dmaFreeBuffers(struct DmaBufferList *list) {
    uint32_t x;
+
+   // Free the list itself
    dmaFreeBuffersList(list);
 
-   for (x=0; x < list->subCount; x++) kfree(list->indexed[x]);
-   if ( list->indexed != NULL ) kfree(list->indexed);
-   if ( list->sorted  != NULL ) kfree(list->sorted);
+   // Free each buffer in the indexed array
+   for (x = 0; x < list->subCount; x++)
+      kfree(list->indexed[x]);
+
+   // Free the indexed and sorted arrays if they are not NULL
+   if (list->indexed != NULL)
+      kfree(list->indexed);
+   if (list->sorted != NULL)
+      kfree(list->sorted);
 }
 
-
-// Generic Binary search
+/**
+ * bsearch - Perform a binary search on a sorted array.
+ * @key: pointer to the item being searched for
+ * @base: pointer to the first element in the array
+ * @num: number of elements in the array
+ * @size: size of each element in the array
+ * @cmp: comparator function which returns negative if the first argument is less
+ *       than the second, zero if they're equal, and positive if the first
+ *       argument is greater than the second
+ *
+ * This function performs a binary search on a sorted array. It assumes that
+ * the array is sorted in ascending order according to the comparator function.
+ * The function returns a pointer to the matching element if found, or NULL if
+ * not found.
+ *
+ * Return: On success, returns a pointer to the matching element. If no match
+ *         is found, returns NULL.
+ */
 void *bsearch(const void *key, const void *base, size_t num, size_t size,
-         int (*cmp)(const void *key, const void *elt)) {
-
+              int (*cmp)(const void *key, const void *elt)) {
    int start = 0, end = num - 1, mid, result;
+
    if (num == 0) return NULL;
 
    while (start <= end) {
       mid = (start + end) / 2;
-      result = cmp(key, base + mid * size);
+      result = cmp(key, (const char *)base + mid * size);
       if (result < 0)
          end = mid - 1;
       else if (result > 0)
          start = mid + 1;
       else
-         return (void *)base + mid * size;
+         return (void *)((const char *)base + mid * size);
    }
    return NULL;
 }
 
+/**
+ * dmaSortComp - Compare two DMA buffers for sorting.
+ * @p1: pointer to the first DMA buffer.
+ * @p2: pointer to the second DMA buffer.
+ *
+ * This function compares two DMA buffers based on their buffer handles
+ * to determine their order. It's used primarily for sorting purposes.
+ *
+ * Return: 1 if the first buffer is greater, -1 if less, and 0 if equal.
+ */
+int32_t dmaSortComp(const void *p1, const void *p2) {
+   struct DmaBuffer **b1 = (struct DmaBuffer **)p1;
+   struct DmaBuffer **b2 = (struct DmaBuffer **)p2;
 
-// Buffer comparison for sort
-// Return comparison result, 1 if greater, -1 if less, 0 if equal
-int32_t dmaSortComp (const void *p1, const void *p2) {
-   struct DmaBuffer ** b1 = (struct DmaBuffer **)p1;
-   struct DmaBuffer ** b2 = (struct DmaBuffer **)p2;
-
-   if ( (*b1)->buffHandle > (*b2)->buffHandle ) return 1;
-   if ( (*b1)->buffHandle < (*b2)->buffHandle ) return -1;
-   return(0);
+   if ((*b1)->buffHandle > (*b2)->buffHandle) return 1;
+   if ((*b1)->buffHandle < (*b2)->buffHandle) return -1;
+   return 0;
 }
 
-
-// Buffer comparison for search
-// Return comparison result, 1 if greater, -1 if less, 0 if equal
-int32_t dmaSearchComp (const void *key, const void *element) {
-   struct DmaBuffer ** buff = (struct DmaBuffer **)element;
-
+/**
+ * dmaSearchComp - Compare a DMA buffer against a search key for searching.
+ * @key: the search key, typically a DMA buffer handle.
+ * @element: pointer to the DMA buffer to compare against the key.
+ *
+ * This function compares a given DMA buffer's handle against a search key
+ * to facilitate efficient search operations, such as binary search, within
+ * an array of DMA buffers.
+ *
+ * Return: 1 if the buffer handle is less than the search key, -1 if greater,
+ * and 0 if equal.
+ */
+int32_t dmaSearchComp(const void *key, const void *element) {
+   struct DmaBuffer **buff = (struct DmaBuffer **)element;
    dma_addr_t value = *((dma_addr_t *)key);
 
-   if ( (*buff)->buffHandle < value ) return 1;
-   if ( (*buff)->buffHandle > value ) return -1;
-   return(0);
+   if ((*buff)->buffHandle < value) return 1;
+   if ((*buff)->buffHandle > value) return -1;
+   return 0;
 }
 
-// Find a buffer, return index, or -1 on error
-struct DmaBuffer * dmaFindBufferList ( struct DmaBufferList *list, dma_addr_t handle ) {
+/**
+ * dmaFindBufferList - Find a DMA buffer in a list by its handle.
+ * @list: pointer to the DMA buffer list where the search is performed.
+ * @handle: the DMA address (handle) of the buffer to find.
+ *
+ * This function searches for a DMA buffer within a given list by its handle.
+ * The search is performed differently based on the organization of the list:
+ * if the list is not sorted, it performs a linear search through all entries;
+ * if the list is sorted, it uses a binary search for efficiency.
+ *
+ * Return: Pointer to the found DmaBuffer if successful, NULL if not found.
+ */
+struct DmaBuffer *dmaFindBufferList(struct DmaBufferList *list, dma_addr_t handle) {
    uint32_t x;
    uint32_t sl;
    uint32_t sli;
 
-   // Stream buffers have to be found with a loop because entries are dynamic and unsorted
-   // We can only search if there is a single sub list
-   if ( list->sorted == NULL ) {
-      for ( x=0; x < list->count; x++ ) {
-         sl  = x / BUFFERS_PER_LIST;
+   // Handle unsorted list case: linear search required due to dynamic and unsorted entries
+   if (list->sorted == NULL) {
+      for (x = 0; x < list->count; x++) {
+         sl = x / BUFFERS_PER_LIST;
          sli = x % BUFFERS_PER_LIST;
-         if ( list->indexed[sl][sli]->buffHandle == handle ) return(list->indexed[sl][sli]);
+         if (list->indexed[sl][sli]->buffHandle == handle) {
+            return(list->indexed[sl][sli]);
+         }
       }
-
-      // Not found
+      // Buffer not found in unsorted list
       return(NULL);
    }
-
-   // Sorted list search is more efficiant
+   // Handle sorted list case: binary search for efficiency
    else {
-      struct DmaBuffer ** result = (struct DmaBuffer **) 
+      struct DmaBuffer **result = (struct DmaBuffer **)
          bsearch(&handle, list->sorted, list->count, sizeof(struct DmaBuffer *), dmaSearchComp);
 
-      if ( result == NULL ) return(NULL);
-      else return((*result));
+      if (result == NULL) {
+         // Buffer not found in sorted list
+         return(NULL);
+      } else {
+         return((*result));
+      }
    }
 }
 
-// Find a buffer from either list
-struct DmaBuffer * dmaFindBuffer ( struct DmaDevice *dev, dma_addr_t handle ) {
+/**
+ * dmaFindBuffer - Find a buffer from either the TX or RX list
+ * @dev: pointer to the DmaDevice structure
+ * @handle: DMA address to find
+ *
+ * This function searches for a DMA buffer that matches the given DMA address
+ * in either the transmission (TX) or reception (RX) buffer lists of the device.
+ *
+ * Return: pointer to the DmaBuffer if found, NULL otherwise.
+ */
+struct DmaBuffer *dmaFindBuffer(struct DmaDevice *dev, dma_addr_t handle) {
    struct DmaBuffer *buff;
 
-   if ( (buff = dmaFindBufferList (&(dev->txBuffers),handle)) != NULL) return(buff);
-   if ( (buff = dmaFindBufferList (&(dev->rxBuffers),handle)) != NULL) return(buff);
+   if ((buff = dmaFindBufferList(&(dev->txBuffers), handle)) != NULL) return(buff);
+   if ((buff = dmaFindBufferList(&(dev->rxBuffers), handle)) != NULL) return(buff);
    return(NULL);
 }
 
-// Get a buffer using index, in passed list
-struct DmaBuffer * dmaGetBufferList ( struct DmaBufferList *list, uint32_t index ) {
+/**
+ * dmaGetBufferList - Get a buffer using index in the passed list
+ * @list: pointer to the DmaBufferList structure
+ * @index: index of the buffer within the list
+ *
+ * Retrieves a DMA buffer from a specified list based on the buffer's index.
+ * The function calculates the segment list and segment list index to locate
+ * the buffer within the list's multi-dimensional array structure.
+ *
+ * Return: pointer to the DmaBuffer if within range, NULL otherwise.
+ */
+struct DmaBuffer *dmaGetBufferList(struct DmaBufferList *list, uint32_t index) {
    uint32_t sl;
    uint32_t sli;
 
-   if ( index < list->baseIdx || index >= (list->baseIdx + list->count) ) return(NULL);
+   if (index < list->baseIdx || index >= (list->baseIdx + list->count)) return(NULL);
    else {
       sl  = (index - list->baseIdx) / BUFFERS_PER_LIST;
       sli = (index - list->baseIdx) % BUFFERS_PER_LIST;
@@ -287,113 +395,185 @@ struct DmaBuffer * dmaGetBufferList ( struct DmaBufferList *list, uint32_t index
    }
 }
 
-// Get a buffer using index, in either list
-struct DmaBuffer * dmaGetBuffer ( struct DmaDevice *dev, uint32_t index ) {
+/**
+ * dmaGetBuffer - Get a buffer using index, in either the TX or RX list
+ * @dev: pointer to the DmaDevice structure
+ * @index: index of the buffer
+ *
+ * Retrieves a DMA buffer by its index from either the transmission (TX) or
+ * reception (RX) buffer lists of the device.
+ *
+ * Return: pointer to the DmaBuffer if found, NULL otherwise.
+ */
+struct DmaBuffer *dmaGetBuffer(struct DmaDevice *dev, uint32_t index) {
    struct DmaBuffer *buff;
-   if ( ( buff = dmaGetBufferList(&(dev->txBuffers),index)) != NULL ) return(buff);
-   if ( ( buff = dmaGetBufferList(&(dev->rxBuffers),index)) != NULL ) return(buff);
+   if ((buff = dmaGetBufferList(&(dev->txBuffers), index)) != NULL) return(buff);
+   if ((buff = dmaGetBufferList(&(dev->rxBuffers), index)) != NULL) return(buff);
    return(NULL);
 }
 
-// Conditionally return buffer to transmit buffer. If buffer is not found in 
-// transmit list return a pointer to the buffer. Passed value is the dma handle.
-struct DmaBuffer * dmaRetBufferIrq ( struct DmaDevice *dev, dma_addr_t handle ) {
+/**
+ * dmaRetBufferIrq - Conditionally return buffer to the transmit queue.
+ * @dev: Pointer to the device structure.
+ * @handle: DMA handle for the buffer to be returned.
+ *
+ * This function attempts to return a buffer to the device's transmit queue
+ * based on the given DMA handle. If the buffer is found in the transmit list,
+ * it is prepared for hardware interaction and re-queued. If not found in the
+ * transmit list but found in the receive list, it is returned directly.
+ * If the buffer cannot be found in either list, a warning is issued.
+ *
+ * Return: NULL if the buffer is re-queued or not found, or a pointer to the
+ * buffer if it is found in the receive list.
+ */
+struct DmaBuffer *dmaRetBufferIrq(struct DmaDevice *dev, dma_addr_t handle) {
    struct DmaBuffer *buff;
 
-   // Return buffer to transmit queue if it is found
-   if ( (buff = dmaFindBufferList (&(dev->txBuffers),handle)) != NULL) {
-      dmaBufferFromHw(buff);
-      dmaQueuePushIrq(&(dev->tq),buff);
-      return(NULL);
+   // Attempt to return buffer to transmit queue if found
+   if ((buff = dmaFindBufferList(&(dev->txBuffers), handle)) != NULL) {
+      dmaBufferFromHw(buff);   // Prepare buffer for hardware interaction
+      dmaQueuePushIrq(&(dev->tq), buff); // Re-queue the buffer
+      return (NULL);
    }
-
-   // Return rx buffer
-   else if ( (buff = dmaFindBufferList (&(dev->rxBuffers),handle)) != NULL) {
-      return(buff);
+   // Attempt to return rx buffer if found in receive list
+   else if ((buff = dmaFindBufferList(&(dev->rxBuffers), handle)) != NULL) {
+      return (buff);
    }
-
-   // Buffer is not found
+   // Log warning if buffer is not found in either list
    else {
-      dev_warn(dev->device,"dmaRetBufferIrq: Failed to locate descriptor %.8x.\n",(uint32_t)handle);
-      return(NULL);
+      dev_warn(dev->device, "dmaRetBufferIrq: Failed to locate descriptor %.8x.\n", (uint32_t)handle);
+      return (NULL);
    }
 }
 
-// Conditionally return buffer to transmit buffer. If buffer is not found in 
-// transmit list return a pointer to the buffer. Passed value is the dma handle.
-struct DmaBuffer * dmaRetBufferIdx ( struct DmaDevice *dev, uint32_t index ) {
+/**
+ * dmaRetBufferIdx - Conditionally return buffer to transmit buffer
+ * @dev: pointer to the DMA device structure
+ * @index: index of the DMA buffer to retrieve
+ *
+ * This function attempts to return a buffer to the transmit queue based on
+ * its index. If the buffer is found in the transmit list, it is returned to
+ * the queue. If not found in the transmit list but found in the receive list,
+ * a pointer to the buffer is returned. If the buffer is not found in either
+ * list, a warning is issued, and NULL is returned. The intention is to manage
+ * buffer allocation dynamically during DMA operations.
+ *
+ * Return: NULL if the buffer is returned to the transmit queue or if it cannot
+ *         be found. Otherwise, returns a pointer to the found buffer.
+ */
+struct DmaBuffer *dmaRetBufferIdx(struct DmaDevice *dev, uint32_t index) {
    struct DmaBuffer *buff;
 
-   // Return buffer to transmit queue if it is found
-   if ( (buff = dmaGetBufferList (&(dev->txBuffers),index)) != NULL) {
+   // Attempt to return buffer to the transmit queue
+   if ((buff = dmaGetBufferList(&(dev->txBuffers), index)) != NULL) {
       dmaBufferFromHw(buff);
-      dmaQueuePush(&(dev->tq),buff);
-      return(NULL);
+      dmaQueuePush(&(dev->tq), buff);
+      return (NULL);
    }
-
-   // Return rx buffer
-   else if ( (buff = dmaGetBufferList (&(dev->rxBuffers),index)) != NULL) {
-      return(buff);
+   // Attempt to retrieve and return the buffer from the receive queue
+   else if ((buff = dmaGetBufferList(&(dev->rxBuffers), index)) != NULL) {
+      return (buff);
    }
-
-   // Buffer is not found
+   // Log warning if the buffer cannot be found in either queue
    else {
-      dev_warn(dev->device,"dmaRetBufferIdxIrq: Failed to locate descriptor %i.\n",index);
-      return(NULL);
+      dev_warn(dev->device, "dmaRetBufferIdx: Failed to locate descriptor %i.\n", index);
+      return (NULL);
    }
 }
 
-// Conditionally return buffer to transmit buffer. If buffer is not found in 
-// transmit list return a pointer to the buffer. Passed value is the dma handle.
-struct DmaBuffer * dmaRetBufferIdxIrq ( struct DmaDevice *dev, uint32_t index ) {
+/**
+ * dmaRetBufferIdxIrq - Conditionally return buffer to transmit buffer.
+ * @dev: pointer to the DmaDevice structure
+ * @index: index of the DMA buffer in the buffer list
+ *
+ * This function attempts to return a buffer to the transmit queue if it is
+ * found in the transmit list based on the provided index. If the buffer is
+ * not found in the transmit list, it tries to find it in the receive list.
+ * If the buffer is still not found, it logs a warning message. This function
+ * is typically called within an IRQ context to manage buffer handling.
+ *
+ * Return: NULL if the buffer is successfully returned to the transmit queue
+ *         or if it is not found. Otherwise, a pointer to the DmaBuffer if
+ *         it is found in the receive list.
+ */
+struct DmaBuffer *dmaRetBufferIdxIrq(struct DmaDevice *dev, uint32_t index) {
    struct DmaBuffer *buff;
 
-   // Return buffer to transmit queue if it is found
-   if ( (buff = dmaGetBufferList (&(dev->txBuffers),index)) != NULL) {
+   // Attempt to return buffer to transmit queue if found
+   if ((buff = dmaGetBufferList(&(dev->txBuffers), index)) != NULL) {
       dmaBufferFromHw(buff);
-      dmaQueuePushIrq(&(dev->tq),buff);
-      return(NULL);
+      dmaQueuePushIrq(&(dev->tq), buff);
+      return (NULL);
    }
-
-   // Return rx buffer
-   else if ( (buff = dmaGetBufferList (&(dev->rxBuffers),index)) != NULL) {
-      return(buff);
+   // Attempt to return buffer from receive queue if found
+   else if ((buff = dmaGetBufferList(&(dev->rxBuffers), index)) != NULL) {
+      return (buff);
    }
-
-   // Buffer is not found
+   // Log warning if buffer is not found in either list
    else {
-      dev_warn(dev->device,"dmaRetBufferIdxIrq: Failed to locate descriptor %i.\n",index);
-      return(NULL);
+      dev_warn(dev->device, "dmaRetBufferIdxIrq: Failed to locate descriptor %i.\n", index);
+      return (NULL);
    }
 }
 
-// Push buffer to descriptor receive queue
-void dmaRxBuffer ( struct DmaDesc *desc, struct DmaBuffer *buff ) {
+/**
+ * dmaRxBuffer - Push buffer to descriptor's receive queue.
+ * @desc: pointer to the DmaDesc structure
+ * @buff: pointer to the DmaBuffer to be pushed
+ *
+ * This function pushes a buffer to the descriptor's receive queue. It is
+ * intended to be called outside of IRQ context. Before pushing, it ensures
+ * the buffer is ready for software processing.
+ */
+void dmaRxBuffer(struct DmaDesc *desc, struct DmaBuffer *buff) {
    dmaBufferFromHw(buff);
-   dmaQueuePush(&(desc->q),buff);
-   if (desc->async_queue) kill_fasync(&desc->async_queue, SIGIO, POLL_IN);
+   dmaQueuePush(&(desc->q), buff);
+   if (desc->async_queue)
+      kill_fasync(&desc->async_queue, SIGIO, POLL_IN);
 }
 
-// Push buffer to descriptor receive queue
-// Called inside IRQ routine
-void dmaRxBufferIrq ( struct DmaDesc *desc, struct DmaBuffer *buff ) {
+/**
+ * dmaRxBufferIrq - Push buffer to descriptor's receive queue from IRQ context.
+ * @desc: pointer to the DmaDesc structure
+ * @buff: pointer to the DmaBuffer to be pushed
+ *
+ * Similar to dmaRxBuffer, but specifically designed to be called from an IRQ
+ * handler. This ensures that the operation is safe to perform from interrupt
+ * context, making use of IRQ-safe queue operations.
+ */
+void dmaRxBufferIrq(struct DmaDesc *desc, struct DmaBuffer *buff) {
    dmaBufferFromHw(buff);
-   dmaQueuePushIrq(&(desc->q),buff);
-   if (desc->async_queue) kill_fasync(&desc->async_queue, SIGIO, POLL_IN);
+   dmaQueuePushIrq(&(desc->q), buff);
+   if (desc->async_queue)
+      kill_fasync(&desc->async_queue, SIGIO, POLL_IN);
 }
 
-// Sort a buffer list
-void dmaSortBuffers ( struct DmaBufferList *list ) {
-   if ( list->count > 0 ) 
-      sort(list->sorted,list->count,sizeof(struct DmaBuffer *),dmaSortComp,NULL);
+/**
+ * dmaSortBuffers - Sort a list of DMA buffers
+ * @list: pointer to the DMA buffer list to be sorted
+ *
+ * This function sorts a list of DMA buffers based on a comparison function.
+ * The sorting is necessary to ensure buffers are processed in the correct order.
+ */
+void dmaSortBuffers(struct DmaBufferList *list) {
+   if (list->count > 0)
+      sort(list->sorted, list->count, sizeof(struct DmaBuffer *), dmaSortComp, NULL);
 }
 
-// Buffer being passed to hardware
-// Return -1 on error
-int32_t dmaBufferToHw ( struct DmaBuffer *buff) {
-
-   // Buffer is stream mode, sync
-   if ( buff->buffList->dev->cfgMode & BUFF_STREAM ) {
+/**
+ * dmaBufferToHw - Prepare and pass a DMA buffer to hardware
+ * @buff: pointer to the DMA buffer to be passed to hardware
+ *
+ * Prepares a DMA buffer for hardware access by synchronizing it for device use.
+ * This function is called when a buffer is about to be passed to the hardware,
+ * typically for DMA operations. It handles stream mode buffers by performing
+ * necessary DMA sync operations.
+ *
+ * Returns 0 on success, or -1 on error.
+ */
+int32_t dmaBufferToHw(struct DmaBuffer *buff) {
+   // Check if buffer is in stream mode and sync
+   if (buff->buffList->dev->cfgMode & BUFF_STREAM) {
       dma_sync_single_for_device(buff->buffList->dev->device, 
                                  buff->buffHandle, 
                                  buff->buffList->dev->cfgSize,
@@ -401,15 +581,23 @@ int32_t dmaBufferToHw ( struct DmaBuffer *buff) {
    }
 
    buff->inHw = 1;
-   return(0);
+   return 0;
 }
 
-// Buffer being returned from hardware
-void dmaBufferFromHw ( struct DmaBuffer *buff ) {
+/**
+ * dmaBufferFromHw - Retrieve a DMA buffer from hardware
+ * @buff: pointer to the DMA buffer being returned from hardware
+ *
+ * Marks a DMA buffer as no longer being in hardware use and performs necessary
+ * synchronization for CPU access. This function is called when a buffer is
+ * returned from the hardware, typically after DMA operations are completed.
+ * It handles stream mode buffers by performing necessary DMA sync operations.
+ */
+void dmaBufferFromHw(struct DmaBuffer *buff) {
    buff->inHw = 0;
 
-   // Buffer is stream mode, sync
-   if ( buff->buffList->dev->cfgMode & BUFF_STREAM ) {
+   // Check if buffer is in stream mode and sync
+   if (buff->buffList->dev->cfgMode & BUFF_STREAM) {
       dma_sync_single_for_cpu(buff->buffList->dev->device, 
                               buff->buffHandle, 
                               buff->buffList->dev->cfgSize,
@@ -417,49 +605,73 @@ void dmaBufferFromHw ( struct DmaBuffer *buff ) {
    }
 }
 
-// Init queue
-// Return number initialized
-size_t dmaQueueInit ( struct DmaQueue *queue, uint32_t count ) {
+/**
+ * dmaQueueInit - Initialize a DMA queue.
+ * @queue: pointer to the DMA queue to initialize.
+ * @count: number of elements in the DMA queue.
+ *
+ * This function initializes a DMA queue structure, allocating memory for
+ * the queue and its sub-queues based on the specified count. It also
+ * initializes synchronization primitives used in queue operations.
+ *
+ * Return: The number of elements initialized in the queue on success,
+ *         0 on allocation failure.
+ */
+size_t dmaQueueInit(struct DmaQueue *queue, uint32_t count) {
    uint32_t x;
 
-   queue->count    = count+1;
+   // Set queue parameters
+   queue->count = count + 1;
    queue->subCount = (queue->count / BUFFERS_PER_LIST) + 1;
-   queue->read     = 0;
-   queue->write    = 0;
+   queue->read = 0;
+   queue->write = 0;
 
-   queue->queue = (struct DmaBuffer ***)kmalloc(queue->subCount * sizeof(struct DmaBuffer **),GFP_KERNEL);
+   // Allocate memory for the queue pointers
+   queue->queue = (struct DmaBuffer ***)kmalloc(queue->subCount * sizeof(struct DmaBuffer **), GFP_KERNEL);
    if (queue->queue == NULL) {
       goto cleanup_force_exit;
    }
 
-   for(x=0; x < queue->subCount; x++) {
-      queue->queue[x] = (struct DmaBuffer **)kmalloc(BUFFERS_PER_LIST * sizeof(struct DmaBuffer *),GFP_KERNEL);
+   // Allocate memory for each sub-queue
+   for (x = 0; x < queue->subCount; x++) {
+      queue->queue[x] = (struct DmaBuffer **)kmalloc(BUFFERS_PER_LIST * sizeof(struct DmaBuffer *), GFP_KERNEL);
       if (queue->queue[x] == NULL) {
          goto cleanup_sub_queue;
       }
    }
-   
+
+   // Initialize synchronization primitives
    spin_lock_init(&(queue->lock));
    init_waitqueue_head(&(queue->wait));
-   return(count);
 
-   /* cleanup */
+   // Return the original count as the number of initialized elements
+   return count;
+
 cleanup_sub_queue:
-   for (x=0; x < queue->subCount; x++) 
+   // Cleanup in case of allocation failure for sub-queues
+   for (x = 0; x < queue->subCount; x++)
       if (queue->queue[x] != NULL)
          kfree(queue->queue[x]);
 
 cleanup_force_exit:
+   // Return 0 to indicate failure to initialize the queue
    return 0;
-
 }
 
-// Free queue
-void dmaQueueFree ( struct DmaQueue *queue ) {
+/**
+ * dmaQueueFree - Frees all allocated memory within the DMA queue.
+ * @queue: pointer to the DmaQueue structure to be freed.
+ *
+ * This function releases all memory resources associated with the DMA queue,
+ * including the queue elements and the queue array itself. It resets the queue
+ * count and sub-count to zero.
+ */
+void dmaQueueFree(struct DmaQueue *queue)
+{
    uint32_t x;
 
    queue->count = 0;
-   for (x=0; x < queue->subCount; x++) 
+   for (x = 0; x < queue->subCount; x++)
       if (queue->queue[x] != NULL)
          kfree(queue->queue[x]);
 
@@ -467,234 +679,384 @@ void dmaQueueFree ( struct DmaQueue *queue ) {
    kfree(queue->queue);
 }
 
-// Dma queue is not empty
-// Return 0 if empty, 1 if not empty
-uint32_t dmaQueueNotEmpty ( struct DmaQueue *queue ) {
-   if ( queue->read == queue->write ) return(0);
-   else return(1);
+/**
+ * dmaQueueNotEmpty - Checks if the DMA queue is not empty.
+ * @queue: pointer to the DmaQueue structure to be checked.
+ *
+ * Return: 0 if the queue is empty, 1 if it is not empty.
+ *
+ * This function determines whether the DMA queue has any pending elements by
+ * comparing the read and write pointers. It is useful for deciding whether
+ * data processing or retrieval operations are necessary.
+ */
+uint32_t dmaQueueNotEmpty(struct DmaQueue *queue)
+{
+   if (queue->read == queue->write)
+      return 0;
+   else
+      return 1;
 }
 
-// Push a queue entry
-// Use this routine outside of interrupt handler
-// Return 1 if fail, 0 if success
-uint32_t dmaQueuePush  ( struct DmaQueue *queue, struct DmaBuffer *entry ) {
+/**
+ * dmaQueuePush - Push a queue entry.
+ * @queue: pointer to the DMA queue structure.
+ * @entry: pointer to the DMA buffer entry to be added to the queue.
+ *
+ * This function adds a new entry to the DMA queue. It should be used
+ * outside of interrupt handlers to ensure proper synchronization.
+ * The function employs a circular queue mechanism to manage DMA buffer
+ * entries efficiently. It takes care of locking and ensures thread safety.
+ *
+ * Return: 0 on success, indicating the entry was successfully added to the queue.
+ *         1 on failure, indicating a buffer overflow or other issue preventing
+ *         the entry from being added to the queue.
+ */
+uint32_t dmaQueuePush(struct DmaQueue *queue, struct DmaBuffer *entry)
+{
    unsigned long iflags;
    uint32_t      next;
    uint32_t      ret;
 
-   spin_lock_irqsave(&(queue->lock),iflags);
+   // Protect the queue update with spinlock to ensure thread safety
+   spin_lock_irqsave(&(queue->lock), iflags);
 
-   next = (queue->write+1) % (queue->count);
+   // Calculate the next write position in a circular buffer fashion
+   next = (queue->write + 1) % (queue->count);
    ret = 0;
 
-   // Buffer overflow, should not occur
-   if ( next == queue->read ) ret = 1;
-   else {
+   // Check for buffer overflow - this condition should ideally never occur
+   if (next == queue->read) {
+      ret = 1; // Indicate failure due to no space left in the queue
+   } else {
+      // Add the entry to the queue and update the write index
       queue->queue[queue->write / BUFFERS_PER_LIST][queue->write % BUFFERS_PER_LIST] = entry;
       queue->write = next;
-      entry->inQ = 1;
+      entry->inQ = 1; // Mark the buffer as queued
    }
-   spin_unlock_irqrestore(&(queue->lock),iflags);
+
+   // Release the spinlock and restore interrupts
+   spin_unlock_irqrestore(&(queue->lock), iflags);
+
+   // Wake up any process waiting for queue space to become available
    wake_up_interruptible(&(queue->wait));
 
-   return(ret);
+   return ret;
 }
 
-
-// Push a queue entry
-// Use this routine inside of interrupt handler
-// Return 1 if fail, 0 if success
-uint32_t dmaQueuePushIrq ( struct DmaQueue *queue, struct DmaBuffer *entry ) {
-   uint32_t      next;
-   uint32_t      ret;
+/**
+ * dmaQueuePushIrq - Push a queue entry from an interrupt handler.
+ * @queue: pointer to the DMA queue structure where the entry will be added.
+ * @entry: pointer to the DMA buffer entry to be pushed into the queue.
+ *
+ * This function is designed to be called from within an interrupt handler
+ * to add a DMA buffer entry to a specified queue. It handles synchronization
+ * through spin locks and updates the queue's write pointer after adding the
+ * entry. In the case of a buffer overflow, which should not occur with proper
+ * queue management, the function returns an error.
+ *
+ * Return: 0 on success, indicating the entry was successfully added to the queue.
+ *         1 on failure, indicating a buffer overflow occurred.
+ */
+uint32_t dmaQueuePushIrq(struct DmaQueue *queue, struct DmaBuffer *entry) {
+   uint32_t next;
+   uint32_t ret;
 
    spin_lock(&(queue->lock));
 
-   next = (queue->write+1) % (queue->count);
+   next = (queue->write + 1) % (queue->count);
    ret = 0;
 
-   // Buffer overflow, should not occur
-   if ( next == queue->read ) ret = 1;
-   else {
+   // Check for buffer overflow, which indicates a queue management issue.
+   if (next == queue->read) {
+      ret = 1;
+   } else {
+      // Safely add the entry to the queue and mark it as in the queue.
       queue->queue[queue->write / BUFFERS_PER_LIST][queue->write % BUFFERS_PER_LIST] = entry;
       queue->write = next;
       entry->inQ = 1;
    }
+
    spin_unlock(&(queue->lock));
+
+   // Wake up any process waiting on the queue.
    wake_up_interruptible(&(queue->wait));
 
-   return(ret);
+   return ret;
 }
 
-
-// Return a block of buffers from queue
-// Return 1 if fail, 0 if success
-uint32_t dmaQueuePushList  ( struct DmaQueue *queue, struct DmaBuffer **buff, size_t cnt) {
+/**
+ * dmaQueuePushList - Enqueue a list of buffers to the DMA queue.
+ *
+ * @queue: Pointer to the DMA queue structure.
+ * @buff: Array of pointers to DmaBuffer structures to be enqueued.
+ * @cnt: Number of buffers in the @buff array.
+ *
+ * This function enqueues a list of buffers into the specified DMA queue.
+ * It ensures atomic access to the queue using spin locks and checks for
+ * buffer overflow conditions. The function updates the buffer queueing
+ * status and wakes up any processes waiting for buffers to be enqueued.
+ *
+ * Return: Returns 0 on success, indicating that all buffers have been
+ * successfully enqueued. Returns 1 if a buffer overflow condition is
+ * detected, indicating failure to enqueue all buffers.
+ */
+uint32_t dmaQueuePushList(struct DmaQueue *queue, struct DmaBuffer **buff, size_t cnt) {
    unsigned long iflags;
    uint32_t      next;
    uint32_t      ret;
    size_t        x;
 
-   spin_lock_irqsave(&(queue->lock),iflags);
+   // Acquire the queue spin lock and save the interrupt flags
+   spin_lock_irqsave(&(queue->lock), iflags);
    ret = 0;
 
-   for (x=0; x < cnt; x++) {
+   for (x = 0; x < cnt; x++) {
+      // Calculate the next write position in a circular buffer manner
+      next = (queue->write + 1) % (queue->count);
 
-      next = (queue->write+1) % (queue->count);
-
-      // Buffer overflow, should not occur
-      if ( next == queue->read ) {
+      // Check for buffer overflow condition
+      if (next == queue->read) {
+         // Overflow detected, unable to enqueue more buffers
          ret = 1;
          break;
-      }
-      else {
+      } else {
+         // Enqueue the buffer into the queue and mark it as in the queue
          queue->queue[queue->write / BUFFERS_PER_LIST][queue->write % BUFFERS_PER_LIST] = buff[x];
          queue->write = next;
          buff[x]->inQ = 1;
       }
    }
 
-   spin_unlock_irqrestore(&(queue->lock),iflags);
+   // Release the spin lock and restore the interrupt flags
+   spin_unlock_irqrestore(&(queue->lock), iflags);
+
+   // Wake up any processes waiting for buffers to be enqueued
    wake_up_interruptible(&(queue->wait));
 
-   return(ret);
+   return ret;
 }
 
-
-// Return a block of buffers from queue
-// Return 1 if fail, 0 if success
-// Use IRQ method inside of IRQ handler
-uint32_t dmaQueuePushListIrq ( struct DmaQueue *queue, struct DmaBuffer **buff, size_t cnt ) {
-   uint32_t      next;
-   uint32_t      ret;
-   size_t        x;
+/**
+ * dmaQueuePushListIrq - Enqueue a block of buffers into the DMA queue.
+ * @queue: Pointer to the DMA queue where buffers will be enqueued.
+ * @buff: Array of pointers to DmaBuffer structures to be enqueued.
+ * @cnt: Number of buffers in the @buff array.
+ *
+ * This function enqueues a list of DMA buffers into the specified queue
+ * using an IRQ-safe method, suitable for calling within IRQ handlers.
+ * It ensures atomic access to the queue and updates buffer states accordingly.
+ *
+ * The function uses spin_lock to protect the queue operations, ensuring that
+ * the enqueue operation is safe to call in an interrupt context or when
+ * concurrency issues might arise.
+ *
+ * Return: 0 on success, indicating that all buffers were successfully enqueued.
+ *         1 on failure, indicating a buffer overflow or inability to enqueue
+ *         all buffers.
+ */
+uint32_t dmaQueuePushListIrq(struct DmaQueue *queue, struct DmaBuffer **buff, size_t cnt) {
+   uint32_t next;
+   uint32_t ret;
+   size_t x;
 
    spin_lock(&(queue->lock));
    ret = 0;
 
-   for (x=0; x < cnt; x++) {
+   for (x = 0; x < cnt; x++) {
+      next = (queue->write + 1) % (queue->count);
 
-      next = (queue->write+1) % (queue->count);
-
-      // Buffer overflow, should not occur
-      if ( next == queue->read ) {
-         ret = 1;
+      // Check for buffer overflow - this condition should not normally occur.
+      if (next == queue->read) {
+         ret = 1; // Indicate failure due to overflow.
          break;
-      }
-      else {
+      } else {
+         // Properly place buffer in queue and mark it as in queue.
          queue->queue[queue->write / BUFFERS_PER_LIST][queue->write % BUFFERS_PER_LIST] = buff[x];
          queue->write = next;
-         buff[x]->inQ = 1;
+         buff[x]->inQ = 1; // Mark buffer as enqueued.
       }
    }
    spin_unlock(&(queue->lock));
+
+   // Wake up any processes waiting for buffers to become available.
    wake_up_interruptible(&(queue->wait));
 
-   return(ret);
+   return ret;
 }
 
-
-// Pop a queue entry
-// Use this routine outside of interrupt handler
-// Return a queue entry, NULL if nothing available
+/**
+ * dmaQueuePop - Pop a queue entry.
+ * @queue: pointer to the DmaQueue from which to pop the entry.
+ *
+ * This function pops an entry from the specified DMA queue. It should be used
+ * outside of interrupt handlers. The function ensures mutual exclusion via
+ * spinlocks and updates the queue's read pointer accordingly.
+ *
+ * Context: Can sleep if called outside of interrupt context.
+ *
+ * Return: A pointer to a DmaBuffer if available; NULL if the queue is empty.
+ */
 struct DmaBuffer * dmaQueuePop  ( struct DmaQueue *queue ) {
    unsigned long      iflags;
    struct DmaBuffer * ret;
 
    spin_lock_irqsave(&(queue->lock),iflags);
 
-   if ( queue->read == queue->write ) ret = NULL;
-   else {
+   if ( queue->read == queue->write ) {
+      ret = NULL;
+   } else {
 
       ret = queue->queue[queue->read / BUFFERS_PER_LIST][queue->read % BUFFERS_PER_LIST];
 
-      // Increment read pointer
+      // Increment read pointer safely within queue bounds
       queue->read = (queue->read + 1) % (queue->count);
 
+      // Mark the buffer as not in queue
       ret->inQ = 0;
    }
    spin_unlock_irqrestore(&(queue->lock),iflags);
    return(ret);
 }
 
-
-// Pop a queue entry
-// Use this routine inside of interrupt handler
-// Return a queue entry, NULL if nothing available
-struct DmaBuffer * dmaQueuePopIrq ( struct DmaQueue *queue ) {
-   struct DmaBuffer * ret;
+/**
+ * dmaQueuePopIrq - Pop a queue entry for DMA operations
+ * @queue: Pointer to the DmaQueue from which to pop the entry
+ *
+ * This function is intended for use within an interrupt handler to pop
+ * a queue entry from a DMA buffer queue. It safely removes and returns
+ * the next available DmaBuffer from the queue, if any, ensuring
+ * synchronization via spinlocks. If the queue is empty, NULL is returned.
+ *
+ * Context: Can be called in interrupt context.
+ *
+ * Return: Pointer to the popped DmaBuffer, or NULL if the queue is empty.
+ */
+struct DmaBuffer *dmaQueuePopIrq(struct DmaQueue *queue) {
+   struct DmaBuffer *ret;
 
    spin_lock(&(queue->lock));
 
-   if ( queue->read == queue->write ) ret = NULL;
-   else {
-
+   if (queue->read == queue->write) {
+      ret = NULL;
+   } else {
+      // Calculate the next buffer to pop based on the current read index
       ret = queue->queue[queue->read / BUFFERS_PER_LIST][queue->read % BUFFERS_PER_LIST];
 
-      // Increment read pointer
+      // Increment read pointer in a circular queue fashion
       queue->read = (queue->read + 1) % (queue->count);
 
+      // Mark the buffer as not in queue
       ret->inQ = 0;
    }
+
    spin_unlock(&(queue->lock));
-   return(ret);
+   return ret;
 }
 
-
-// Get a block of buffers from queue
-ssize_t dmaQueuePopList ( struct DmaQueue *queue, struct DmaBuffer**buff, size_t cnt ) {
+/**
+ * dmaQueuePopList - Dequeue a list of DMA buffers from a queue.
+ * @queue: Pointer to the DmaQueue from which to dequeue buffers.
+ * @buff: Pointer to an array of pointers to DmaBuffer where dequeued buffers will be stored.
+ * @cnt: The maximum number of buffers to dequeue.
+ *
+ * This function attempts to dequeue up to @cnt buffers from the specified @queue,
+ * storing the pointers to the dequeued buffers in the @buff array. It operates
+ * with interrupt disabling to ensure thread safety in an interrupt context.
+ *
+ * Context: Can sleep if called in a non-interrupt context.
+ * Return: The number of buffers actually dequeued. May be less than @cnt if the queue
+ *         doesn't have enough buffers. Returns 0 if the queue is empty or on error.
+ */
+ssize_t dmaQueuePopList(struct DmaQueue *queue, struct DmaBuffer **buff, size_t cnt) {
    unsigned long iflags;
    ssize_t ret;
 
    ret = 0;
-   spin_lock_irqsave(&(queue->lock),iflags);
+   // Protect the queue manipulation with a spinlock to ensure atomic access
+   spin_lock_irqsave(&(queue->lock), iflags);
 
+   // Loop to dequeue buffers until the count is met or the queue is empty
    while ( (ret < cnt) && (queue->read != queue->write) ) {
+      // Calculate the current buffer's position and retrieve it
       buff[ret] = queue->queue[queue->read / BUFFERS_PER_LIST][queue->read % BUFFERS_PER_LIST];
 
-      // Increment read pointer
+      // Increment the read pointer in a circular manner
       queue->read = (queue->read + 1) % (queue->count);
 
+      // Mark the buffer as no longer in the queue
       buff[ret]->inQ = 0;
       ret++;
    }
 
-   spin_unlock_irqrestore(&(queue->lock),iflags);
-   return(ret);
+   // Release the spinlock and restore the saved interrupt flags
+   spin_unlock_irqrestore(&(queue->lock), iflags);
+
+   return ret;
 }
 
-
-// Get a block of buffers from queue
-// Use IRQ method inside of IRQ handler
-ssize_t dmaQueuePopListIrq ( struct DmaQueue *queue, struct DmaBuffer**buff, size_t cnt ) {
+/**
+ * dmaQueuePopListIrq - Retrieve a block of buffers from a queue within an IRQ handler context.
+ *
+ * @queue: Pointer to the DmaQueue from which buffers are to be popped.
+ * @buff: Double pointer to DmaBuffer to store the addresses of the buffers retrieved.
+ * @cnt: The count of buffers to retrieve from the queue.
+ *
+ * This function attempts to retrieve a specified number of DMA buffers from a queue,
+ * ensuring thread safety by using spin locks. It is specifically designed to be called
+ * within an IRQ handler, using the IRQ-safe spin_lock and spin_unlock methods to protect
+ * the queue's integrity during concurrent access. The function updates the 'inQ' status
+ * of each buffer to indicate it is no longer in the queue.
+ *
+ * Return: The number of buffers successfully popped from the queue. This can be less than
+ * 'cnt' if there are not enough buffers in the queue at the time of the call.
+ */
+ssize_t dmaQueuePopListIrq(struct DmaQueue *queue, struct DmaBuffer **buff, size_t cnt) {
    ssize_t ret;
 
    ret = 0;
+   // Lock the queue to ensure exclusive access
    spin_lock(&(queue->lock));
 
-   while ( (ret < cnt) && (queue->read != queue->write) ) {
+   // Attempt to pop 'cnt' buffers from the queue
+   while ((ret < cnt) && (queue->read != queue->write)) {
+      // Retrieve the next buffer from the queue
       buff[ret] = queue->queue[queue->read / BUFFERS_PER_LIST][queue->read % BUFFERS_PER_LIST];
 
-      // Increment read pointer
+      // Increment the read pointer in a circular manner
       queue->read = (queue->read + 1) % (queue->count);
 
+      // Mark the buffer as no longer in the queue
       buff[ret]->inQ = 0;
       ret++;
    }
 
+   // Unlock the queue after operation
    spin_unlock(&(queue->lock));
    return(ret);
 }
 
-
-// Poll queue
-void dmaQueuePoll ( struct DmaQueue *queue, struct file *filp, poll_table *wait ) {
-   poll_wait(filp,&(queue->wait),wait);
+/**
+ * dmaQueuePoll - Poll a DMA queue for readiness
+ * @queue: pointer to the DmaQueue structure
+ * @filp: file pointer associated with the queue
+ * @wait: poll table to wait on
+ *
+ * This function adds the file pointer and wait queue to the poll table,
+ * allowing the process to wait for events on the DMA queue.
+ */
+void dmaQueuePoll(struct DmaQueue *queue, struct file *filp, poll_table *wait) {
+   poll_wait(filp, &(queue->wait), wait);
 }
 
-
-// Wait on queue
-void dmaQueueWait ( struct DmaQueue *queue ){
-   wait_event_interruptible(queue->wait,(queue->read != queue->write));
+/**
+ * dmaQueueWait - Wait for data in the DMA queue
+ * @queue: pointer to the DmaQueue structure
+ *
+ * Waits for data to become available in the DMA queue. The wait is interruptible,
+ * allowing signal handling to interrupt the wait if necessary. This function
+ * ensures that a process sleeps until there is data to read in the queue, comparing
+ * the read and write pointers of the queue to determine availability.
+ */
+void dmaQueueWait(struct DmaQueue *queue) {
+   wait_event_interruptible(queue->wait, (queue->read != queue->write));
 }
-

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -9,12 +9,12 @@
  *    without CPU intervention, optimizing performance for high-speed data
  *    processing and transfer tasks.
  * ----------------------------------------------------------------------------
- * This file is part of the aes_stream_drivers package. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the aes_stream_drivers package, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -100,7 +100,7 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
 
       // Coherent buffer, map dma coherent buffers
       if ( list->dev->cfgMode & BUFF_COHERENT ) {
-         buff->buffAddr = 
+         buff->buffAddr =
             dma_alloc_coherent(list->dev->device, list->dev->cfgSize, &(buff->buffHandle), GFP_DMA32 | GFP_KERNEL);
       }
 
@@ -111,7 +111,7 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
          if (buff->buffAddr != NULL) {
             buff->buffHandle = dma_map_single(list->dev->device,buff->buffAddr,
                                              list->dev->cfgSize,direction);
-    
+
             // Map error
             if ( dma_mapping_error(list->dev->device,buff->buffHandle) ) {
                buff->buffHandle = 0;
@@ -152,8 +152,8 @@ cleanup_buffers:
    if ( list->sorted  != NULL ) kfree(list->sorted);
 
 cleanup_list_heads:
-   for (x=0; x < list->subCount; x++) 
-      if ( list->indexed[x] != NULL ) 
+   for (x=0; x < list->subCount; x++)
+      if ( list->indexed[x] != NULL )
          kfree(list->indexed[x]);
    if ( list->indexed != NULL ) kfree(list->indexed);
 
@@ -176,7 +176,7 @@ void dmaFreeBuffersList(struct DmaBufferList *list) {
    uint32_t sl;
    uint32_t sli;
    uint32_t x;
-   
+
    for (x = 0; x < list->count; x++) {
       sl  = x / BUFFERS_PER_LIST;
       sli = x % BUFFERS_PER_LIST;
@@ -574,8 +574,8 @@ void dmaSortBuffers(struct DmaBufferList *list) {
 int32_t dmaBufferToHw(struct DmaBuffer *buff) {
    // Check if buffer is in stream mode and sync
    if (buff->buffList->dev->cfgMode & BUFF_STREAM) {
-      dma_sync_single_for_device(buff->buffList->dev->device, 
-                                 buff->buffHandle, 
+      dma_sync_single_for_device(buff->buffList->dev->device,
+                                 buff->buffHandle,
                                  buff->buffList->dev->cfgSize,
                                  buff->buffList->direction);
    }
@@ -598,8 +598,8 @@ void dmaBufferFromHw(struct DmaBuffer *buff) {
 
    // Check if buffer is in stream mode and sync
    if (buff->buffList->dev->cfgMode & BUFF_STREAM) {
-      dma_sync_single_for_cpu(buff->buffList->dev->device, 
-                              buff->buffHandle, 
+      dma_sync_single_for_cpu(buff->buffList->dev->device,
+                              buff->buffHandle,
                               buff->buffList->dev->cfgSize,
                               buff->buffList->direction);
    }

--- a/common/driver/fpga_prom.c
+++ b/common/driver/fpga_prom.c
@@ -5,12 +5,12 @@
  * File       : fpga_prom.c
  * Created    : 2017-03-16
  * ----------------------------------------------------------------------------
- * This file is part of the aes_stream_drivers package. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the aes_stream_drivers package, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -19,7 +19,7 @@
 #include <FpgaProm.h>
 #include <dma_common.h>
 
-// Prom Read 
+// Prom Read
 int32_t FpgaProm_Write(struct DmaDevice *dev, void * base, uint64_t arg) {
    int32_t  ret;
    uint32_t tempVal;
@@ -32,13 +32,13 @@ int32_t FpgaProm_Write(struct DmaDevice *dev, void * base, uint64_t arg) {
       return(-1);
    }
 
-   if ( dev->debug > 0 ) 
+   if ( dev->debug > 0 )
       dev_info(dev->device,"PromWrite: Addr=0x%x, Cmd=0x%x, Data=0x%x.\n", prom.address, prom.cmd, prom.data);
 
    // Set the data bus
    tempVal = ( (prom.cmd << 16) | prom.data );
    iowrite32(tempVal,&(reg->promData));
-   
+
    asm("nop");
 
    // Set the address bus and initiate the transfer
@@ -48,7 +48,7 @@ int32_t FpgaProm_Write(struct DmaDevice *dev, void * base, uint64_t arg) {
    return(0);
 }
 
-// Prom write 
+// Prom write
 int32_t FpgaProm_Read(struct DmaDevice *dev, void * base, uint64_t arg) {
    int32_t  ret;
    uint32_t tempVal;
@@ -74,7 +74,7 @@ int32_t FpgaProm_Read(struct DmaDevice *dev, void * base, uint64_t arg) {
    // Read the data register
    prom.data = ioread32(&(reg->promRead));
 
-   if ( dev->debug > 0 ) 
+   if ( dev->debug > 0 )
       dev_info(dev->device,"PromRead: Addr=0x%x, Cmd=0x%x, Data=0x%x.\n", prom.address, prom.cmd, prom.data);
 
    // Return the data structure

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -1,11 +1,12 @@
 /**
- *-----------------------------------------------------------------------------
- * Title      : GPU Async Functions
  * ----------------------------------------------------------------------------
- * File       : gpu_async.c
+ * Company    : SLAC National Accelerator Laboratory
  * ----------------------------------------------------------------------------
  * Description:
- * Helper functions for GPU Async interface
+ *    This module provides an interface for managing GPU tasks asynchronously,
+ *    facilitating non-blocking operations and efficient GPU utilization. It
+ *    includes functions for initializing the GPU for async operations, queueing
+ *    tasks, handling completion callbacks, and cleanup procedures.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to 
  * the license terms in the LICENSE.txt file found in the top-level directory 
@@ -16,6 +17,7 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #include <gpu_async.h>
 #include <GpuAsync.h>
 #include <linux/seq_file.h>
@@ -23,41 +25,76 @@
 #include <linux/slab.h>
 #include <nv-p2p.h>
 
-// Execute command
-void Gpu_Init(struct DmaDevice *dev, uint32_t offset) {
-   struct GpuData * gpuData;
+/**
+ * Gpu_Init - Initialize GPU with given offset
+ * @dev: pointer to the DmaDevice structure
+ * @offset: memory offset for GPU initialization
+ *
+ * This function allocates memory for GpuData structure, initializes
+ * it, and associates it with the given DmaDevice. It sets up
+ * the base address for GPU operations and initializes buffer counts.
+ */
+void Gpu_Init(struct DmaDevice *dev, uint32_t offset)
+{
+   struct GpuData *gpuData;
 
-   // Setup GPU Utility
-   gpuData = (struct GpuData *)kmalloc(sizeof(struct GpuData),GFP_KERNEL);
+   /* Allocate memory for GPU utility data */
+   gpuData = (struct GpuData *)kmalloc(sizeof(struct GpuData), GFP_KERNEL);
+   if (!gpuData)
+      return; // Handle memory allocation failure if necessary
+
+   /* Associate GPU utility data with the device */
    dev->utilData = gpuData;
 
+   /* Initialize GPU base address and buffer counts */
    gpuData->base = dev->base + offset;
    gpuData->writeBuffers.count = 0;
    gpuData->readBuffers.count = 0;
 }
 
-// Execute command
-int32_t Gpu_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
+/**
+ * Gpu_Command - Execute command on GPU.
+ * @dev: Pointer to the DmaDevice structure.
+ * @cmd: Command to execute.
+ * @arg: Argument for the command.
+ *
+ * This function executes a specified command on the GPU.
+ * It supports adding and removing NVIDIA Memory. If the command
+ * is not recognized, it logs a warning and returns an error.
+ *
+ * Return: 0 on success, -1 on error.
+ */
+int32_t Gpu_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg)
+{
    switch (cmd) {
-
       // Add NVIDIA Memory
       case GPU_Add_Nvidia_Memory:
-         return(Gpu_AddNvidia(dev,arg));
+         return Gpu_AddNvidia(dev, arg);
          break;
 
-      // Rem NVIDIA Memory
+      // Remove NVIDIA Memory
       case GPU_Rem_Nvidia_Memory:
-         return(Gpu_RemNvidia(dev,arg));
+         return Gpu_RemNvidia(dev, arg);
          break;
 
       default:
-         dev_warn(dev->device,"Command: Invalid command=%i\n",cmd); 
-         return(-1);
+         dev_warn(dev->device, "Command: Invalid command=%u\n", cmd);
+         return -1;
          break;
    }
 }
 
-// Add NVIDIA Memory
+/**
+ * Gpu_AddNvidia - Add NVIDIA GPU memory to the device
+ * @dev: pointer to the DMA device structure
+ * @arg: user space argument pointing to GpuNvidiaData structure
+ *
+ * This function adds NVIDIA GPU memory for DMA operations. It involves
+ * copying data from user space, validating it, and setting up DMA mappings
+ * through NVIDIA's Peer-to-Peer (P2P) API.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
 int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
    int32_t ret;
    uint32_t x;
@@ -71,37 +108,43 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
 
    data = (struct GpuData *)dev->utilData;
 
-   if ((ret = copy_from_user(&dat,(void *)arg,sizeof(struct GpuNvidiaData)))) {
-      dev_warn(dev->device,"Gpu_AddNvidia: copy_from_user failed. ret=%i, user=%p kern=%p\n", ret, (void *)arg, &dat);
-      return(-1);
+   // Copy data from user space
+   if ((ret = copy_from_user(&dat, (void *)arg, sizeof(struct GpuNvidiaData)))) {
+      dev_warn(dev->device, "Gpu_AddNvidia: copy_from_user failed. ret=%i, user=%p kern=%p\n", ret, (void *)arg, &dat);
+      return (-1);
    }
 
    if (!dat.size) return -EINVAL;
 
-   // Set pointers
-   if (dat.write) buffer = &(data->writeBuffers.list[data->writeBuffers.count]);
-   else buffer = &(data->readBuffers.list[data->readBuffers.count]);
+   // Set buffer pointers based on the operation mode (write/read)
+   if (dat.write)
+      buffer = &(data->writeBuffers.list[data->writeBuffers.count]);
+   else
+      buffer = &(data->readBuffers.list[data->readBuffers.count]);
 
-   buffer->write   = dat.write;
+   // Initialize buffer properties
+   buffer->write = dat.write;
    buffer->address = dat.address;
-   buffer->size    = dat.size;
-   buffer->pageTable  = 0;
+   buffer->size = dat.size;
+   buffer->pageTable = 0;
    buffer->dmaMapping = 0;
 
-   // do proper alignment, as required by NVIDIA kernel driver
+   // Align virtual start address as required by NVIDIA kernel driver
    virt_start = buffer->address & GPU_BOUND_MASK;
    pin_size = buffer->address + buffer->size - virt_start;
 
-   dev_warn(dev->device,"Gpu_AddNvidia: attemping to map. address=0x%llx, size=%i, virt_start=0x%llx, pin_size=%li, write=%i\n",
-         buffer->address,buffer->size,virt_start,pin_size,buffer->write);
+   dev_warn(dev->device, "Gpu_AddNvidia: attempting to map. address=0x%llx, size=%i, virt_start=0x%llx, pin_size=%li, write=%i\n",
+         buffer->address, buffer->size, virt_start, pin_size, buffer->write);
 
+   // Map GPU memory through NVIDIA P2P API
    ret = nvidia_p2p_get_pages(0, 0, virt_start, pin_size, &(buffer->pageTable), Gpu_FreeNvidia, dev);
 
    if (ret == 0) {
-      dev_warn(dev->device,"Gpu_AddNvidia: mapped memory with address=0x%llx, size=%i, page count=%i, write=%i\n",buffer->address,buffer->size,buffer->pageTable->entries,buffer->write);
+      dev_warn(dev->device, "Gpu_AddNvidia: mapped memory with address=0x%llx, size=%i, page count=%i, write=%i\n", buffer->address, buffer->size, buffer->pageTable->entries, buffer->write);
 
+      // DMA map the pages
       ret = nvidia_p2p_dma_map_pages(dev->pcidev, buffer->pageTable, &(buffer->dmaMapping));
-      dev_warn(dev->device,"Gpu_AddNvidia: dma map done. ret = %i\n",ret);
+      dev_warn(dev->device, "Gpu_AddNvidia: dma map done. ret = %i\n", ret);
 
       if (ret != 0) {
          dev_warn(dev->device,"Gpu_AddNvidia: error mapping page tables ret=%i\n",ret);
@@ -116,9 +159,10 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
             else break;
          }
 
-         dev_warn(dev->device,"Gpu_AddNvidia: dma address 0 = 0x%llx, total = %li, pages = %i\n", 
-               buffer->dmaMapping->dma_addresses[0],mapSize,x);
+         dev_warn(dev->device, "Gpu_AddNvidia: dma address 0 = 0x%llx, total = %li, pages = %i\n",
+               buffer->dmaMapping->dma_addresses[0], mapSize, x);
 
+         // Update buffer count and write DMA addresses to device
          if (buffer->write){
             iowrite32(buffer->dmaMapping->dma_addresses[0], data->base+0x100+data->writeBuffers.count*16);
             iowrite32(mapSize,data->base+0x108+data->writeBuffers.count*16);
@@ -149,48 +193,70 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
    return(0);
 }
 
-// REm NVIDIA Memory
-int32_t Gpu_RemNvidia(struct DmaDevice *dev, uint64_t arg) {
+/**
+ * Gpu_RemNvidia - Remove NVIDIA GPU memory mappings
+ * @dev: pointer to the DMA device structure
+ * @arg: argument specifying additional command or data (unused in this function)
+ *
+ * This function unmaps the write and read buffer memory previously mapped for NVIDIA GPU,
+ * using the NVIDIA Peer-to-Peer (P2P) DMA API. It iterates over the write and read buffers,
+ * unmaps each using nvidia_p2p_dma_unmap_pages, and releases the pages with nvidia_p2p_put_pages.
+ * Finally, it resets the buffers' count and disables a specific hardware functionality
+ * by writing to a register.
+ *
+ * Return: Always returns 0 indicating success.
+ */
+int32_t Gpu_RemNvidia(struct DmaDevice *dev, uint64_t arg)
+{
    uint32_t x;
-   u64      virt_start;
+   u64 virt_start;
 
-   struct GpuData * data;
-   struct GpuBuffer * buffer;
+   struct GpuData *data;
+   struct GpuBuffer *buffer;
 
+   // Retrieve the GPU specific data from the DMA device
    data = (struct GpuData *)dev->utilData;
 
-   for (x=0; x < data->writeBuffers.count; x++) {
+   // Unmap and release pages for all write buffers
+   for (x = 0; x < data->writeBuffers.count; x++) {
       buffer = &(data->writeBuffers.list[x]);
-
       virt_start = buffer->address & GPU_BOUND_MASK;
 
       nvidia_p2p_dma_unmap_pages(dev->pcidev, buffer->pageTable, buffer->dmaMapping);
       nvidia_p2p_put_pages(0, 0, virt_start, buffer->pageTable);
 
-      dev_warn(dev->device,"Gpu_AddNvidia: unmapped write memory with address=0x%llx\n", buffer->address);
+      dev_warn(dev->device, "Gpu_RemNvidia: unmapped write memory with address=0x%llx\n", buffer->address);
    }
 
-   for (x=0; x < data->readBuffers.count; x++) {
+   // Unmap and release pages for all read buffers
+   for (x = 0; x < data->readBuffers.count; x++) {
       buffer = &(data->readBuffers.list[x]);
-
       virt_start = buffer->address & GPU_BOUND_MASK;
 
       nvidia_p2p_dma_unmap_pages(dev->pcidev, buffer->pageTable, buffer->dmaMapping);
       nvidia_p2p_put_pages(0, 0, virt_start, buffer->pageTable);
 
-      dev_warn(dev->device,"Gpu_AddNvidia: unmapped read memory with address=0x%llx\n", buffer->address);
+      dev_warn(dev->device, "Gpu_RemNvidia: unmapped read memory with address=0x%llx\n", buffer->address);
    }
 
+   // Reset the buffer counts and disable specific functionality by writing to a register
    data->writeBuffers.count = 0;
-   data->readBuffers.count  = 0;
-   iowrite32(0,data->base+0x008);
-   return(0);
+   data->readBuffers.count = 0;
+   iowrite32(0, data->base + 0x008);
+
+   return 0;
 }
 
-// NVIDIA Callback
+/**
+ * Gpu_FreeNvidia - Release NVIDIA GPU resources
+ * @data: Pointer to the device-specific data
+ *
+ * This function is a callback for freeing NVIDIA GPU resources associated
+ * with a DMA device. It logs a warning message and removes NVIDIA GPU
+ * resources.
+ */
 void Gpu_FreeNvidia(void *data) {
-   struct DmaDevice * dev = (struct DmaDevice *)data;
-   dev_warn(dev->device,"Axis_FreeNvidia: Called\n");
-   Gpu_RemNvidia(dev,0);
+   struct DmaDevice *dev = (struct DmaDevice *)data;
+   dev_warn(dev->device, "Gpu_FreeNvidia: Called\n");
+   Gpu_RemNvidia(dev, 0);
 }
-

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -8,12 +8,12 @@
  *    includes functions for initializing the GPU for async operations, queueing
  *    tasks, handling completion callbacks, and cleanup procedures.
  * ----------------------------------------------------------------------------
- * This file is part of the aes_stream_drivers package. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the aes_stream_drivers package, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -1,11 +1,11 @@
 /**
- *-----------------------------------------------------------------------------
- * Title      : GPU Async Functions
  * ----------------------------------------------------------------------------
- * File       : gpu_async.h
+ * Company    : SLAC National Accelerator Laboratory
  * ----------------------------------------------------------------------------
  * Description:
- * Helper functions for GPU Async interface
+ *    This header file provides declarations for helper functions used to facilitate
+ *    asynchronous GPU operations within the kernel space. It includes interfaces for
+ *    initializing GPU tasks, managing data buffers, and handling asynchronous callbacks.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to
  * the license terms in the LICENSE.txt file found in the top-level directory
@@ -16,6 +16,7 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #ifndef __GPU_ASYNC_2_H__
 #define __GPU_ASYNC_2_H__
 
@@ -23,14 +24,42 @@
 #include <dma_buffer.h>
 #include <linux/interrupt.h>
 #include <nv-p2p.h>
-
-// NVIDIA Stuff
+/**
+ * GPU_BOUND_SHIFT - Shift for GPU address boundary
+ */
 #define GPU_BOUND_SHIFT   16
+
+/**
+ * GPU_BOUND_SIZE - Size of GPU address boundary
+ */
 #define GPU_BOUND_SIZE    ((u64)1 << GPU_BOUND_SHIFT)
-#define GPU_BOUND_OFFSET  (GPU_BOUND_SIZE-1)
+
+/**
+ * GPU_BOUND_OFFSET - Offset for GPU address boundary calculation
+ */
+#define GPU_BOUND_OFFSET  (GPU_BOUND_SIZE - 1)
+
+/**
+ * GPU_BOUND_MASK - Mask for aligning addresses to GPU boundary
+ */
 #define GPU_BOUND_MASK    (~GPU_BOUND_OFFSET)
+
+/**
+ * MAX_GPU_BUFFERS - Maximum number of GPU buffers allowed
+ */
 #define MAX_GPU_BUFFERS   16
 
+/**
+ * struct GpuBuffer - Represents a single GPU buffer
+ * @write: Write flag indicating the buffer's usage
+ * @address: Physical address of the buffer in memory
+ * @size: Size of the buffer in bytes
+ * @pageTable: Pointer to the NVIDIA-specific page table
+ * @dmaMapping: Pointer to the DMA mapping structure for this buffer
+ *
+ * This structure defines a single buffer's properties, including its
+ * memory address, size, and associated NVIDIA page table and DMA mapping.
+ */
 struct GpuBuffer {
    uint32_t write;
    uint64_t address;
@@ -39,32 +68,39 @@ struct GpuBuffer {
    struct nvidia_p2p_dma_mapping *dmaMapping;
 };
 
+/**
+ * struct GpuBuffers - Container for multiple GPU buffers
+ * @list: Array of GpuBuffer structures
+ * @count: Number of buffers currently in use
+ *
+ * This structure acts as a container for managing multiple GpuBuffer
+ * instances. It tracks the buffers in use and their count.
+ */
 struct GpuBuffers {
    struct GpuBuffer list[MAX_GPU_BUFFERS];
    uint32_t count;
 };
 
+/**
+ * struct GpuData - High-level structure representing GPU-related data
+ * @base: Base pointer to the GPU data in memory
+ * @writeBuffers: GpuBuffers structure for write operations
+ * @readBuffers: GpuBuffers structure for read operations
+ *
+ * This structure is designed to encapsulate all relevant data for
+ * GPU operations, including pointers to read and write buffers.
+ */
 struct GpuData {
    uint8_t * base;
-
    struct GpuBuffers writeBuffers;
    struct GpuBuffers readBuffers;
 };
 
-// Execute command
+// Function prototypes
 void Gpu_Init(struct DmaDevice *dev, uint32_t offset);
-
-// Execute command
 int32_t Gpu_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg);
-
-// Add NVIDIA Memory
 int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg);
-
-// Rem NVIDIA Memory
 int32_t Gpu_RemNvidia(struct DmaDevice *dev, uint64_t arg);
-
-// NVIDIA Callback
 void Gpu_FreeNvidia(void * data);
 
-#endif
-
+#endif // __GPU_ASYNC_2_H__


### PR DESCRIPTION
### Description
- [applying 'Kernel-doc' style to axis_gen2.c/axis_gen2.h](https://github.com/slaclab/aes-stream-drivers/commit/20446843af5f09f8b6153831afdc1261bbc8dc17)
- [applying 'Kernel-doc' style to axi_version.c/axi_version.h](https://github.com/slaclab/aes-stream-drivers/pull/119/commits/670c60d3c9f2ef584fb1bc7f528d867a9b883e22)
- [applying 'Kernel-doc' style to dma_buffer.c/dma_buffer.h](https://github.com/slaclab/aes-stream-drivers/pull/119/commits/c9419ea1d22508d92021db46fa0eea621cdb0ca4)
- [applying 'Kernel-doc' style to dma_common.c/dma_common.h](https://github.com/slaclab/aes-stream-drivers/pull/119/commits/f6ee8e380ec405e6e689a49c71e815045b272e01)
- [applying 'Kernel-doc' style to gpu_async.c/gpu_async.h](https://github.com/slaclab/aes-stream-drivers/pull/119/commits/6526cbb844ed9b3269a5be47b99c7e12d9d581e5)
- Not applying 'Kernel-doc' style to fpga_prom.c/fpga_prom.h because high probability of depreciation/removal in the future
  -  fpga_prom written for only Micron P30 PROM, which is obsolete and no drop in replacement both with respect to HW and SW 