### PR TITLE
applying 'Kernel-doc' style to include header files

### DIFF
--- a/include/AxiVersion.h
+++ b/include/AxiVersion.h
@@ -1,35 +1,49 @@
 /**
  *-----------------------------------------------------------------------------
- * Title      : AXI Version
- * ----------------------------------------------------------------------------
- * File       : AxiVersion.h
- * Created    : 2017-03-17
- * ----------------------------------------------------------------------------
+ * Company: SLAC National Accelerator Laboratory
+ *-----------------------------------------------------------------------------
  * Description:
- * AXI Version Record
- * ----------------------------------------------------------------------------
- * This file is part of the aes_stream_drivers package. It is subject to
- * the license terms in the LICENSE.txt file found in the top-level directory
- * of this distribution and at:
+ *    Defines an interface for accessing AXI version information in kernel space.
+ *-----------------------------------------------------------------------------
+ * This file is part of the aes_stream_drivers package. It is subject to the
+ * license terms in the LICENSE.txt file found in the top-level directory of
+ * this distribution and at:
  *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
  * No part of the aes_stream_drivers package, including this file, may be
  * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
- * ----------------------------------------------------------------------------
-**/
+ *-----------------------------------------------------------------------------
+ **/
+
 #ifndef __AXI_VERSION_H__
 #define __AXI_VERSION_H__
 
 #ifdef DMA_IN_KERNEL
-#include <linux/types.h>
+   #include <linux/types.h>
 #else
-#include <stdint.h>
+   #include <stdint.h>
 #endif
 
-// Commands
+/**
+ * Commands for AXI version operations.
+ */
 #define AVER_Get 0x1200
 
-// AXI Version Data
+/**
+ * struct AxiVersion - Represents AXI version data.
+ * @firmwareVersion: Firmware version number.
+ * @scratchPad: General purpose scratch pad register.
+ * @upTimeCount: Counter for the uptime in ticks.
+ * @fdValue: Factory default values.
+ * @userValues: User-defined values for customization.
+ * @deviceId: Unique identifier for the device.
+ * @gitHash: Hash of the git commit for software tracking.
+ * @dnaValue: Device DNA value for identification.
+ * @buildString: String containing build information.
+ *
+ * This structure is used to hold version information and metadata related to
+ * the AXI interface, including both software and hardware identifiers.
+ */
 struct AxiVersion {
    uint32_t firmwareVersion;
    uint32_t scratchPad;
@@ -42,22 +56,31 @@ struct AxiVersion {
    uint8_t  buildString[256];
 };
 
-// Everything below is hidden during kernel module compile
 #ifndef DMA_IN_KERNEL
-#include <stdlib.h>
-#include <string.h>
-#include <sys/mman.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <sys/ioctl.h>
-#include <sys/signal.h>
-#include <sys/fcntl.h>
+   // Everything below is hidden during kernel module compile
+   #include <stdlib.h>
+   #include <string.h>
+   #include <sys/mman.h>
+   #include <stdio.h>
+   #include <unistd.h>
+   #include <sys/ioctl.h>
+   #include <sys/signal.h>
+   #include <sys/fcntl.h>
 
-// Read AXI Version
-static inline ssize_t axiVersionGet(int32_t fd, struct AxiVersion * aVer ) {
-   return(ioctl(fd,AVER_Get,aVer));
-}
+   /**
+    * axiVersionGet - Reads the AXI version information.
+    * @fd: File descriptor for the device.
+    * @aVer: Pointer to AxiVersion structure to fill with data.
+    *
+    * This function invokes an IOCTL call to read the AXI version information
+    * from the hardware and fills the provided AxiVersion structure with the
+    * data read.
+    *
+    * Return: The number of bytes read on success or an error code on failure.
+    */
+   static inline ssize_t axiVersionGet(int32_t fd, struct AxiVersion *aVer) {
+      return(ioctl(fd, AVER_Get, aVer));
+   }
 
-#endif
-#endif
-
+#endif // !DMA_IN_KERNEL
+#endif // __AXI_VERSION_H__

--- a/include/AxisDriver.h
+++ b/include/AxisDriver.h
@@ -1,14 +1,14 @@
 /**
  *-----------------------------------------------------------------------------
- * Title      : AXIS DMA Driver, Shared Header
- * ----------------------------------------------------------------------------
- * File       : AxisDriver.h
- * Author     : Ryan Herbst, rherbst@slac.stanford.edu
- * Created    : 2016-08-08
- * Last update: 2016-08-08
+ * Company    : SLAC National Accelerator Laboratory
  * ----------------------------------------------------------------------------
  * Description:
- * Defintions and inline functions for interacting with AXIS driver.
+ *    This file contains definitions and inline functions for interacting
+ *    with the AXIS driver as part of the aes_stream_drivers package.
+ *
+ *    It includes functionalities for setting flags within the AXIS protocol
+ *    and performing specific actions such as acknowledging reads and indicating
+ *    missed write requests.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to
  * the license terms in the LICENSE.txt file found in the top-level directory
@@ -18,54 +18,89 @@
  * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
-**/
+ **/
+
 #ifndef __ASIS_DRIVER_H__
 #define __ASIS_DRIVER_H__
 #include "DmaDriver.h"
 
-// Commands
-#define AXIS_Read_Ack 0x2001
-#define AXIS_Write_ReqMissed 0x2002
+// Command definitions
+#define AXIS_Read_Ack 0x2001          // Command to acknowledge read
+#define AXIS_Write_ReqMissed 0x2002   // Command to indicate a missed write request
 
-// Everything below is hidden during kernel module compile
+// Only define the following if not compiling for kernel space
 #ifndef DMA_IN_KERNEL
 
-// Set flags
-//static constexpr inline uint32_t axisSetFlags(uint32_t fuser, uint32_t luser, uint32_t cont) {
-//   return ( ((cont & 0x1) << 16)  | ((luser & 0xFF) << 8) | ((fuser & 0xFF) << 0) );
-//}
-
+/**
+ * Set flags for AXIS transactions.
+ *
+ * @param fuser First user-defined flag.
+ * @param luser Last user-defined flag.
+ * @param cont  Continuation flag.
+ *
+ * @return The combined flags value.
+ */
 static inline uint32_t axisSetFlags(uint32_t fuser, uint32_t luser, uint32_t cont) {
    uint32_t flags;
 
-   flags  = fuser & 0xFF;
-   flags += (luser << 8) & 0xFF00;
-   flags += (cont  << 16) & 0x10000;
-   return(flags);
+   // Set flags based on input parameters, ensuring each is in its correct position
+   flags  = fuser & 0xFF;            // First user-defined flag
+   flags |= (luser << 8) & 0xFF00;   // Last user-defined flag
+   flags |= (cont  << 16) & 0x10000; // Continuation flag
+
+   return flags;
 }
 
+/**
+ * Extract the first user-defined flag from the combined flags.
+ *
+ * @param flags The combined flags value.
+ *
+ * @return The first user-defined flag.
+ */
 static inline uint32_t axisGetFuser(uint32_t flags) {
-   return(flags & 0xFF);
+   return flags & 0xFF;
 }
 
+/**
+ * Extract the last user-defined flag from the combined flags.
+ *
+ * @param flags The combined flags value.
+ *
+ * @return The last user-defined flag.
+ */
 static inline uint32_t axisGetLuser(uint32_t flags) {
-   return((flags >> 8) & 0xFF);
+   return (flags >> 8) & 0xFF;
 }
 
+/**
+ * Extract the continuation flag from the combined flags.
+ *
+ * @param flags The combined flags value.
+ *
+ * @return The continuation flag.
+ */
 static inline uint32_t axisGetCont(uint32_t flags) {
-   return((flags >> 16) & 0x1);
+   return (flags >> 16) & 0x1;
 }
 
-// Read ACK
-static inline void axisReadAck (int32_t fd) {
-   ioctl(fd,AXIS_Read_Ack,0);
+/**
+ * Acknowledge a read operation.
+ *
+ * @param fd File descriptor for the AXIS device.
+ */
+static inline void axisReadAck(int32_t fd) {
+   ioctl(fd, AXIS_Read_Ack, 0);
 }
 
-// Write Req Missed
-static inline void axisWriteReqMissed (int32_t fd) {
-   ioctl(fd,AXIS_Write_ReqMissed,0);
+/**
+ * Indicate a missed write request.
+ *
+ * @param fd File descriptor for the AXIS device.
+ */
+static inline void axisWriteReqMissed(int32_t fd) {
+   ioctl(fd, AXIS_Write_ReqMissed, 0);
 }
 
-#endif
-#endif
-
+#endif // !DMA_IN_KERNEL
+#endif // __ASIS_DRIVER_H__

--- a/include/DataDriver.h
+++ b/include/DataDriver.h
@@ -1,28 +1,27 @@
 /**
  *-----------------------------------------------------------------------------
- * Title      : Data Development Card Driver, Shared Header
- * ----------------------------------------------------------------------------
- * File       : DataDriver.h
- * Created    : 2017-03-21
- * ----------------------------------------------------------------------------
+ * Company: SLAC National Accelerator Laboratory
+ *-----------------------------------------------------------------------------
  * Description:
- * Defintions and inline functions for interacting with Data Development driver.
- * ----------------------------------------------------------------------------
- * This file is part of the aes_stream_drivers package. It is subject to
- * the license terms in the LICENSE.txt file found in the top-level directory
- * of this distribution and at:
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
- * No part of the aes_stream_drivers package, including this file, may be
- * copied, modified, propagated, or distributed except according to the terms
- * contained in the LICENSE.txt file.
- * ----------------------------------------------------------------------------
-**/
+ *    Definitions and inline functions for interacting with the Data Development driver
+ *-----------------------------------------------------------------------------
+ * License:
+ *    This file is subject to the license terms in the LICENSE.txt file found
+ *    in the top-level directory of this distribution and at:
+ *       https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ *
+ *    No part of the aes_stream_drivers package, including this file, may be
+ *    copied, modified, propagated, or distributed except according to the terms
+ *    contained in the LICENSE.txt file.
+ *-----------------------------------------------------------------------------
+ */
+
 #ifndef __DATA_DRIVER_H__
 #define __DATA_DRIVER_H__
-#include <AxisDriver.h>
-#include <DmaDriver.h>
-#include <FpgaProm.h>
-#include <AxiVersion.h>
 
-#endif
+// Include dependencies for Data Development driver functionality
+#include <AxisDriver.h>  // Axis Communication Driver
+#include <DmaDriver.h>   // Direct Memory Access (DMA) Driver
+#include <AxiVersion.h>  // Kernel AXI Version Interface
 
+#endif // __DATA_DRIVER_H__

--- a/include/DmaDriver.h
+++ b/include/DmaDriver.h
@@ -498,7 +498,7 @@ static inline void **dmaMapDma(int32_t fd, uint32_t *count, uint32_t *size) {
    if (count != NULL) *count = bCount;
    if (size != NULL) *size = bSize;
 
-   if ((ret = (void **)malloc(sizeof(void *) * bCount)) == NULL) return(NULL);
+   if ( (ret = (void **)malloc(sizeof(void *) * bCount)) == 0 ) return(NULL);
 
    // Attempt to map
    gCount = 0;

--- a/include/DmaDriver.h
+++ b/include/DmaDriver.h
@@ -1,12 +1,13 @@
 /**
  *-----------------------------------------------------------------------------
- * Title      : DMA Driver, Common Header
- * ----------------------------------------------------------------------------
- * File       : DmaDriver.h
- * Created    : 2016-08-08
- * ----------------------------------------------------------------------------
+ * Company: SLAC National Accelerator Laboratory
+ *-----------------------------------------------------------------------------
  * Description:
- * Defintions and inline functions for interacting drivers.
+ *    This header file defines the interfaces and data structures used by
+ *    DMA (Direct Memory Access) drivers in the aes_stream_drivers package.
+ *    These drivers facilitate efficient data transfer between memory and
+ *    devices without requiring CPU intervention, improving throughput and
+ *    reducing latency for I/O operations.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to
  * the license terms in the LICENSE.txt file found in the top-level directory
@@ -17,49 +18,62 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #ifndef __DMA_DRIVER_H__
 #define __DMA_DRIVER_H__
 
 #ifdef DMA_IN_KERNEL
-#include <linux/types.h>
+   #include <linux/types.h>
 #else
-#include <stdint.h>
+   #include <stdint.h>
 #endif
 
-// API Version
+/* API Version */
 #define DMA_VERSION  0x06
 
-// Error values
+/* Error values */
 #define DMA_ERR_FIFO 0x01
 #define DMA_ERR_LEN  0x02
 #define DMA_ERR_MAX  0x04
 #define DMA_ERR_BUS  0x08
 
-// Commands
-#define DMA_Get_Buff_Count   0x1001
-#define DMA_Get_Buff_Size    0x1002
-#define DMA_Set_Debug        0x1003
-#define DMA_Set_Mask         0x1004
-#define DMA_Ret_Index        0x1005
-#define DMA_Get_Index        0x1006
-#define DMA_Read_Ready       0x1007
-#define DMA_Set_MaskBytes    0x1008
-#define DMA_Get_Version      0x1009
-#define DMA_Write_Register   0x100A
-#define DMA_Read_Register    0x100B
-#define DMA_Get_RxBuff_Count 0x100C
-#define DMA_Get_TxBuff_Count 0x100D
-#define DMA_Get_TxBuffinUser_Count 0x100F
-#define DMA_Get_TxBuffinHW_Count 0x1010
+/* Commands */
+#define DMA_Get_Buff_Count          0x1001
+#define DMA_Get_Buff_Size           0x1002
+#define DMA_Set_Debug               0x1003
+#define DMA_Set_Mask                0x1004
+#define DMA_Ret_Index               0x1005
+#define DMA_Get_Index               0x1006
+#define DMA_Read_Ready              0x1007
+#define DMA_Set_MaskBytes           0x1008
+#define DMA_Get_Version             0x1009
+#define DMA_Write_Register          0x100A
+#define DMA_Read_Register           0x100B
+#define DMA_Get_RxBuff_Count        0x100C
+#define DMA_Get_TxBuff_Count        0x100D
+#define DMA_Get_TxBuffinUser_Count  0x100F
+#define DMA_Get_TxBuffinHW_Count    0x1010
 #define DMA_Get_TxBuffinPreHWQ_Count 0x1011
-#define DMA_Get_TxBuffinSWQ_Count 0x1012
-#define DMA_Get_TxBuffMiss_Count 0x1013
+#define DMA_Get_TxBuffinSWQ_Count   0x1012
+#define DMA_Get_TxBuffMiss_Count    0x1013
 
-// Mask size
+/* Mask size */
 #define DMA_MASK_SIZE 512
 
-// TX Structure
-// Size = 0 for return index
+/**
+ * struct DmaWriteData - Structure representing a DMA write operation.
+ * @data: Physical address of the data to be written.
+ * @dest: Destination address within the device.
+ * @flags: Flags to control the write operation.
+ * @index: Index of the buffer to be used for the write operation.
+ * @size: Size of the data to be written.
+ * @is32: Flag indicating whether the system uses 32-bit addressing.
+ * @pad: Padding to align the structure to 64 bits.
+ *
+ * This structure is used to initiate a DMA write operation. It contains
+ * information about the data to be written, the destination, and various
+ * control flags.
+ */
 struct DmaWriteData {
    uint64_t  data;
    uint32_t  dest;
@@ -70,8 +84,21 @@ struct DmaWriteData {
    uint32_t  pad;
 };
 
-// RX Structure
-// Data = 0 for read index
+/**
+ * struct DmaReadData - Structure representing a DMA read operation.
+ * @data: Physical address where the read data will be stored.
+ * @dest: Source address within the device.
+ * @flags: Flags to control the read operation.
+ * @index: Index of the buffer to be used for the read operation.
+ * @error: Error code returned by the read operation.
+ * @size: Size of the data to be read.
+ * @is32: Flag indicating whether the system uses 32-bit addressing.
+ * @ret: The return value of the read operation, typically the size of the data read.
+ *
+ * This structure is used to initiate a DMA read operation. It contains
+ * information about where to store the read data, the source of the data,
+ * and various control flags.
+ */
 struct DmaReadData {
    uint64_t   data;
    uint32_t   dest;
@@ -83,13 +110,20 @@ struct DmaReadData {
    int32_t    ret;
 };
 
-// Register data
+/**
+ * struct DmaRegisterData - Register data structure.
+ * @address: Memory address.
+ * @data: Data to be written.
+ *
+ * This structure holds the data necessary to perform a register write operation
+ * within a DMA context.
+ */
 struct DmaRegisterData {
-   uint64_t   address;
-   uint32_t   data;
+   uint64_t address;
+   uint32_t data;
 };
 
-// Everything below is hidden during kernel module compile
+// Conditional inclusion for non-kernel environments
 #ifndef DMA_IN_KERNEL
 #include <stdlib.h>
 #include <string.h>
@@ -102,35 +136,79 @@ struct DmaRegisterData {
 #include <sys/fcntl.h>
 #include <sys/socket.h>
 
-// Write Frame
-static inline ssize_t dmaWrite(int32_t fd, const void * buf, size_t size, uint32_t flags, uint32_t dest) {
+/**
+ * dmaWrite - Writes data to a DMA channel.
+ * @fd: File descriptor for the DMA device.
+ * @buf: Pointer to the data buffer.
+ * @size: Size of the data to write.
+ * @flags: Flags for the write operation.
+ * @dest: Destination address for the write.
+ *
+ * This function writes a single frame of data to a DMA channel, specified by the
+ * file descriptor @fd. The data to be written is pointed to by @buf, with a specified
+ * size of @size. Additional parameters include flags (@flags) and a destination address
+ * (@dest).
+ *
+ * Return: Number of bytes written, or a negative error code on failure.
+ */
+static inline ssize_t dmaWrite(int32_t fd, const void *buf, size_t size, uint32_t flags, uint32_t dest) {
    struct DmaWriteData w;
 
-   memset(&w,0,sizeof(struct DmaWriteData));
-   w.dest    = dest;
-   w.flags   = flags;
-   w.size    = size;
-   w.is32    = (sizeof(void *)==4);
-   w.data    = (uint64_t)buf;
+   memset(&w, 0, sizeof(struct DmaWriteData));
+   w.dest = dest;
+   w.flags = flags;
+   w.size = size;
+   w.is32 = (sizeof(void *) == 4);
+   w.data = (uint64_t)buf;
 
-   return(write(fd,&w,sizeof(struct DmaWriteData)));
+   return(write(fd, &w, sizeof(struct DmaWriteData)));
 }
 
-// Write Frame, memory mapped
+/**
+ * dmaWriteIndex - Writes data to a DMA channel using an index.
+ * @fd: File descriptor for the DMA device.
+ * @index: Index of the data buffer.
+ * @size: Size of the data to write.
+ * @flags: Flags for the write operation.
+ * @dest: Destination address for the write.
+ *
+ * Similar to dmaWrite, but uses an index (@index) to specify the data buffer
+ * instead of a direct pointer. This is useful for memory-mapped I/O operations
+ * where data buffers are identified by indexes.
+ *
+ * Return: Number of bytes written, or a negative error code on failure.
+ */
 static inline ssize_t dmaWriteIndex(int32_t fd, uint32_t index, size_t size, uint32_t flags, uint32_t dest) {
    struct DmaWriteData w;
 
-   memset(&w,0,sizeof(struct DmaWriteData));
-   w.dest    = dest;
-   w.flags   = flags;
-   w.size    = size;
-   w.is32    = (sizeof(void *)==4);
-   w.index   = index;
+   memset(&w, 0, sizeof(struct DmaWriteData));
+   w.dest = dest;
+   w.flags = flags;
+   w.size = size;
+   w.is32 = (sizeof(void *) == 4);
+   w.index = index;
 
-   return(write(fd,&w,sizeof(struct DmaWriteData)));
+   return(write(fd, &w, sizeof(struct DmaWriteData)));
 }
 
-// Write frame from iovector
+/**
+ * dmaWriteVector - Writes an array of data frames to a DMA channel.
+ * @fd: File descriptor for the DMA device.
+ * @iov: Pointer to the array of iovec structures.
+ * @iovlen: Number of elements in the iov array.
+ * @begFlags: Flags for the beginning of the data stream.
+ * @midFlags: Flags for the middle of the data stream.
+ * @endFlags: Flags for the end of the data stream.
+ * @dest: Destination address for the write.
+ *
+ * This function writes multiple data frames to a DMA channel, where each frame is
+ * specified by an iovec structure in the array pointed to by @iov. The number of
+ * frames to write is specified by @iovlen. Flags for the beginning, middle, and end
+ * of the data stream are specified by @begFlags, @midFlags, and @endFlags, respectively.
+ * The destination address for the write operation is specified by @dest.
+ *
+ * Return: Total number of bytes written, or a negative error code on failure.
+ */
 static inline ssize_t dmaWriteVector(int32_t fd, struct iovec *iov, size_t iovlen,
                                      uint32_t begFlags, uint32_t midFlags, uint32_t endFlags, uint32_t dest) {
    uint32_t x;
@@ -159,7 +237,21 @@ static inline ssize_t dmaWriteVector(int32_t fd, struct iovec *iov, size_t iovle
    return(ret);
 }
 
-// Write Frame, memory mapped from iovector
+/**
+ * dmaWriteIndexVector - Write Frame, memory mapped from iovector.
+ * @fd: File descriptor for DMA operation.
+ * @iov: Pointer to array of iovec structures.
+ * @iovlen: Length of the iov array.
+ * @begFlags: Flags to use for the beginning of the DMA transaction.
+ * @midFlags: Flags to use for the middle of the DMA transaction.
+ * @endFlags: Flags to use for the end of the DMA transaction.
+ * @dest: Destination address for the DMA write.
+ *
+ * This function writes a frame to a device, using DMA, where the frame data
+ * is described by an array of iovec structures.
+ *
+ * Return: Total number of bytes written, or negative on failure.
+ */
 static inline ssize_t dmaWriteIndexVector(int32_t fd, struct iovec *iov, size_t iovlen,
                                           uint32_t begFlags, uint32_t midFlags, uint32_t endFlags, uint32_t dest) {
    uint32_t x;
@@ -169,185 +261,310 @@ static inline ssize_t dmaWriteIndexVector(int32_t fd, struct iovec *iov, size_t 
 
    ret = 0;
 
-   for (x=0; x < iovlen; x++) {
-      memset(&w,0,sizeof(struct DmaWriteData));
-      w.dest    = dest;
-      w.flags   = (x==0)?begFlags:((x==(iovlen-1))?endFlags:midFlags);
-      w.size    = iov[x].iov_len;
-      w.is32    = (sizeof(void *)==4);
-      w.index   = (uint32_t)(((uint64_t)iov[x].iov_base) & 0xFFFFFFFF);
+   for (x = 0; x < iovlen; x++) {
+      memset(&w, 0, sizeof(struct DmaWriteData));
+      w.dest = dest;
+      w.flags = (x == 0) ? begFlags : ((x == (iovlen - 1)) ? endFlags : midFlags);
+      w.size = iov[x].iov_len;
+      w.is32 = (sizeof(void *) == 4);
+      w.index = (uint32_t)(((uint64_t)iov[x].iov_base) & 0xFFFFFFFF);
 
       do {
-         res = write(fd,&w,sizeof(struct DmaWriteData));
+         res = write(fd, &w, sizeof(struct DmaWriteData));
 
-         if ( res < 0 ) return(res);
-         else if ( res == 0 ) usleep(10);
+         if (res < 0) return(res);
+         else if (res == 0) usleep(10);
          else ret += res;
       } while (res == 0);
    }
    return(ret);
 }
 
-// Receive Frame
-static inline ssize_t dmaRead(int32_t fd, void * buf, size_t maxSize, uint32_t * flags, uint32_t *error, uint32_t * dest) {
+/**
+ * dmaRead - Receive Frame.
+ * @fd: File descriptor for DMA operation.
+ * @buf: Buffer to store received data.
+ * @maxSize: Maximum size to read.
+ * @flags: Pointer to store flags after reading.
+ * @error: Pointer to store error code if any.
+ * @dest: Pointer to store destination address.
+ *
+ * This function reads a frame from a device using DMA.
+ *
+ * Return: Size of the data received, or negative on failure.
+ */
+static inline ssize_t dmaRead(int32_t fd, void *buf, size_t maxSize, uint32_t *flags, uint32_t *error, uint32_t *dest) {
    struct DmaReadData r;
    ssize_t ret;
 
-   memset(&r,0,sizeof(struct DmaReadData));
+   memset(&r, 0, sizeof(struct DmaReadData));
    r.size = maxSize;
-   r.is32 = (sizeof(void *)==4);
+   r.is32 = (sizeof(void *) == 4);
    r.data = (uint64_t)buf;
 
-   ret = read(fd,&r,sizeof(struct DmaReadData));
+   ret = read(fd, &r, sizeof(struct DmaReadData));
 
-   if ( ret <= 0 ) return(ret);
+   if (ret <= 0) return(ret);
 
-   if ( dest  != NULL ) *dest  = r.dest;
-   if ( flags != NULL ) *flags = r.flags;
-   if ( error != NULL ) *error = r.error;
+   if (dest != NULL) *dest = r.dest;
+   if (flags != NULL) *flags = r.flags;
+   if (error != NULL) *error = r.error;
 
    return(r.ret);
 }
 
-// Receive Frame, access memory mapped buffer
-// Returns receive size
-static inline ssize_t dmaReadIndex(int32_t fd, uint32_t * index, uint32_t * flags, uint32_t *error, uint32_t * dest) {
+/**
+ * dmaReadIndex - Receive Frame, access memory mapped buffer.
+ * @fd: File descriptor for DMA operation.
+ * @index: Pointer to store the index of the received data.
+ * @flags: Pointer to store flags after reading.
+ * @error: Pointer to store error code if any.
+ * @dest: Pointer to store destination address.
+ *
+ * This function reads a frame from a device using DMA, specifically accessing
+ * the memory-mapped buffer and retrieves the index of the received data.
+ *
+ * Return: Size of the data received, or negative on failure.
+ */
+static inline ssize_t dmaReadIndex(int32_t fd, uint32_t *index, uint32_t *flags, uint32_t *error, uint32_t *dest) {
    struct DmaReadData r;
    size_t ret;
 
-   memset(&r,0,sizeof(struct DmaReadData));
+   memset(&r, 0, sizeof(struct DmaReadData));
 
-   ret = read(fd,&r,sizeof(struct DmaReadData));
+   ret = read(fd, &r, sizeof(struct DmaReadData));
 
-   if ( ret <= 0 ) return(ret);
+   if (ret <= 0) return(ret);
 
-   if ( dest  != NULL ) *dest  = r.dest;
-   if ( flags != NULL ) *flags = r.flags;
-   if ( error != NULL ) *error = r.error;
+   if (dest != NULL) *dest = r.dest;
+   if (flags != NULL) *flags = r.flags;
+   if (error != NULL) *error = r.error;
 
    *index = r.index;
    return(r.ret);
 }
 
-// Receive Frame, access memory mapped buffer
-// Returns receive size
-static inline ssize_t dmaReadBulkIndex(int32_t fd, uint32_t count, int32_t *ret, uint32_t * index, uint32_t * flags, uint32_t *error, uint32_t * dest) {
+/**
+ * dmaReadBulkIndex - Receive frame and access memory-mapped buffer.
+ * @fd: File descriptor to read from.
+ * @count: Number of elements in the buffers.
+ * @ret: Pointer to store the return values.
+ * @index: Buffer to store the indices of the DMA read operations.
+ * @flags: Buffer to store flags of the DMA read operations.
+ * @error: Buffer to store error codes of the DMA read operations.
+ * @dest: Buffer to store destination addresses of the DMA read operations.
+ *
+ * This function reads bulk data from a DMA channel and extracts the metadata
+ * associated with each read operation, including return values, indices,
+ * flags, error codes, and destination addresses.
+ *
+ * Returns: The number of bytes read.
+ */
+static inline ssize_t dmaReadBulkIndex(int32_t fd, uint32_t count, int32_t *ret, uint32_t *index,
+                                       uint32_t *flags, uint32_t *error, uint32_t *dest) {
    struct DmaReadData r[count];
    size_t res;
    size_t x;
 
-   memset(r,0,count * sizeof(struct DmaReadData));
+   memset(r, 0, count * sizeof(struct DmaReadData));
 
-   res = read(fd,r,count * sizeof(struct DmaReadData));
+   res = read(fd, r, count * sizeof(struct DmaReadData));
 
    for (x = 0; x < res; ++x) {
-      if ( dest  != NULL ) dest[x]  = r[x].dest;
-      if ( flags != NULL ) flags[x] = r[x].flags;
-      if ( error != NULL ) error[x] = r[x].error;
+      if (dest != NULL) dest[x] = r[x].dest;
+      if (flags != NULL) flags[x] = r[x].flags;
+      if (error != NULL) error[x] = r[x].error;
 
       index[x] = r[x].index;
-      ret[x]   = r[x].ret;
+      ret[x] = r[x].ret;
    }
    return(res);
 }
 
-
-// Post Index
+/**
+ * dmaRetIndex - Post an index back to the DMA.
+ * @fd: File descriptor to use.
+ * @index: Index to be returned.
+ *
+ * This function posts a single index back to the DMA, indicating that
+ * the buffer associated with this index can be reused.
+ *
+ * Returns: Result of the IOCTL operation.
+ */
 static inline ssize_t dmaRetIndex(int32_t fd, uint32_t index) {
    uint32_t cmd = DMA_Ret_Index | 0x10000;
 
-   return(ioctl(fd,cmd,&index));
+   return(ioctl(fd, cmd, &index));
 }
 
-// Post Index List
+/**
+ * dmaRetIndexes - Post multiple indices back to the DMA.
+ * @fd: File descriptor to use.
+ * @count: Number of indices to be returned.
+ * @indexes: Array of indices to be returned.
+ *
+ * This function posts multiple indices back to the DMA, indicating that
+ * the buffers associated with these indices can be reused.
+ *
+ * Returns: Result of the IOCTL operation.
+ */
 static inline ssize_t dmaRetIndexes(int32_t fd, uint32_t count, uint32_t *indexes) {
    uint32_t cmd = DMA_Ret_Index | ((count << 16) & 0xFFFF0000);
 
-   return(ioctl(fd,cmd,indexes));
+   return(ioctl(fd, cmd, indexes));
 }
 
-// Get write buffer index
+/**
+ * dmaGetIndex - Get the current write buffer index.
+ * @fd: File descriptor to use.
+ *
+ * This function retrieves the current index for writing to the DMA buffer.
+ *
+ * Returns: The current write buffer index.
+ */
 static inline uint32_t dmaGetIndex(int32_t fd) {
-   return(ioctl(fd,DMA_Get_Index,0));
+   return(ioctl(fd, DMA_Get_Index, 0));
 }
 
-// Get read ready status
+/**
+ * dmaReadReady - Check if read is ready.
+ * @fd: File descriptor to use.
+ *
+ * This function checks if the DMA is ready for reading.
+ *
+ * Returns: Result of the IOCTL operation, indicating read readiness.
+ */
 static inline ssize_t dmaReadReady(int32_t fd) {
-   return(ioctl(fd,DMA_Read_Ready,0));
+   return(ioctl(fd, DMA_Read_Ready, 0));
 }
 
-// get rx buffer count
+/**
+ * dmaGetRxBuffCount - Get the receive buffer count.
+ * @fd: File descriptor to use.
+ *
+ * This function retrieves the count of receive buffers available.
+ *
+ * Returns: The count of receive buffers.
+ */
 static inline ssize_t dmaGetRxBuffCount(int32_t fd) {
-   return(ioctl(fd,DMA_Get_RxBuff_Count,0));
+   return(ioctl(fd, DMA_Get_RxBuff_Count, 0));
 }
 
-// get tx buffer count
+/**
+ * dmaGetTxBuffCount - Get the transmit buffer count.
+ * @fd: File descriptor to use.
+ *
+ * This function retrieves the count of transmit buffers available.
+ *
+ * Returns: The count of transmit buffers.
+ */
 static inline ssize_t dmaGetTxBuffCount(int32_t fd) {
-   return(ioctl(fd,DMA_Get_TxBuff_Count,0));
+   return(ioctl(fd, DMA_Get_TxBuff_Count, 0));
 }
 
-// get buffer size
+/**
+ * dmaGetBuffSize - Get the buffer size.
+ * @fd: File descriptor to use.
+ *
+ * This function retrieves the size of DMA buffers.
+ *
+ * Returns: The size of DMA buffers.
+ */
 static inline ssize_t dmaGetBuffSize(int32_t fd) {
-   return(ioctl(fd,DMA_Get_Buff_Size,0));
+   return(ioctl(fd, DMA_Get_Buff_Size, 0));
 }
 
-// Return user space mapping to dma buffers
-static inline void ** dmaMapDma(int32_t fd, uint32_t *count, uint32_t *size) {
-   void *   temp;
-   void **  ret;
+/**
+ * dmaMapDma - Map user space to DMA buffers.
+ * @fd: File descriptor to use.
+ * @count: Pointer to store the count of buffers.
+ * @size: Pointer to store the size of each buffer.
+ *
+ * This function maps DMA buffers into user space, allowing direct access.
+ *
+ * Returns: Pointer to an array of pointers to the mapped buffers, or NULL on failure.
+ */
+static inline void **dmaMapDma(int32_t fd, uint32_t *count, uint32_t *size) {
+   void *temp;
+   void **ret;
    uint32_t bCount;
    uint32_t gCount;
    uint32_t bSize;
-   off_t    offset;
+   off_t offset;
 
-   bSize  = ioctl(fd,DMA_Get_Buff_Size,0);
-   bCount = ioctl(fd,DMA_Get_Buff_Count,0);
+   bSize = ioctl(fd, DMA_Get_Buff_Size, 0);
+   bCount = ioctl(fd, DMA_Get_Buff_Count, 0);
 
-   if ( count != NULL ) *count = bCount;
-   if ( size  != NULL ) *size  = bSize;
+   if (count != NULL) *count = bCount;
+   if (size != NULL) *size = bSize;
 
-   if ( (ret = (void **)malloc(sizeof(void *) * bCount)) == 0 ) return(NULL);
+   if ((ret = (void **)malloc(sizeof(void *) * bCount)) == NULL) return(NULL);
 
    // Attempt to map
    gCount = 0;
-   while ( gCount < bCount ) {
+   while (gCount < bCount) {
       offset = (off_t)bSize * (off_t)gCount;
 
-      if ( (temp = mmap (0, bSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, offset)) == MAP_FAILED) break;
+      if ((temp = mmap(0, bSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, offset)) == MAP_FAILED) break;
       ret[gCount++] = temp;
    }
 
    // Map failed
-   if ( gCount != bCount ) {
-      while ( gCount != 0 ) munmap(ret[--gCount],bSize);
+   if (gCount != bCount) {
+      while (gCount != 0) munmap(ret[--gCount], bSize);
       free(ret);
       ret = NULL;
    }
    return(ret);
 }
 
-// Free space mapping to dma buffers
-static inline ssize_t dmaUnMapDma(int32_t fd, void ** buffer) {
-   uint32_t  bCount;
-   uint32_t  bSize;
-   uint32_t  x;
+/**
+ * dmaUnMapDma - Unmap user space from DMA buffers.
+ * @fd: File descriptor to use.
+ * @buffer: Array of pointers to the mapped buffers.
+ *
+ * This function unmaps DMA buffers from user space, releasing the resources.
+ *
+ * Returns: 0 on success.
+ */
+static inline ssize_t dmaUnMapDma(int32_t fd, void **buffer) {
+   uint32_t bCount;
+   uint32_t bSize;
+   uint32_t x;
 
-   bCount = ioctl(fd,DMA_Get_Buff_Count,0);
-   bSize  = ioctl(fd,DMA_Get_Buff_Size,0);
+   bCount = ioctl(fd, DMA_Get_Buff_Count, 0);
+   bSize = ioctl(fd, DMA_Get_Buff_Size, 0);
 
-   for (x=0; x < bCount; x++) munmap (buffer[x], bSize);
+   for (x = 0; x < bCount; x++) munmap(buffer[x], bSize);
 
    free(buffer);
    return(0);
 }
 
-// Set debug
+/**
+ * dmaSetDebug - Set debugging level for DMA operations.
+ * @fd: File descriptor for the DMA device.
+ * @level: Debugging level to be set.
+ *
+ * This function sets the specified debugging level for DMA operations
+ * using an IOCTL command.
+ *
+ * Return: Result from the IOCTL call.
+ */
 static inline ssize_t dmaSetDebug(int32_t fd, uint32_t level) {
-   return(ioctl(fd,DMA_Set_Debug,level));
+   return(ioctl(fd, DMA_Set_Debug, level));
 }
 
-// Assign interrupt handler
-static inline void dmaAssignHandler (int32_t fd, void (*handler)(int32_t)) {
+/**
+ * dmaAssignHandler - Assign a signal handler for asynchronous DMA operations.
+ * @fd: File descriptor for the DMA device.
+ * @handler: Function pointer to the signal handler.
+ *
+ * This function sets up a signal action structure to handle SIGIO signals
+ * with the specified handler function. It also sets the file descriptor to
+ * receive signals for asynchronous I/O.
+ */
+static inline void dmaAssignHandler(int32_t fd, void (*handler)(int32_t)) {
    struct sigaction act;
    int32_t oflags;
 
@@ -361,84 +578,169 @@ static inline void dmaAssignHandler (int32_t fd, void (*handler)(int32_t)) {
    fcntl(fd, F_SETFL, oflags | FASYNC);
 }
 
-// set mask
+/**
+ * dmaSetMask - Set DMA mask.
+ * @fd: File descriptor for the DMA device.
+ * @mask: DMA mask to be set.
+ *
+ * Sets a DMA mask using an IOCTL command.
+ *
+ * Return: Result from the IOCTL call.
+ */
 static inline ssize_t dmaSetMask(int32_t fd, uint32_t mask) {
-   return(ioctl(fd,DMA_Set_Mask,mask));
+   return(ioctl(fd, DMA_Set_Mask, mask));
 }
 
-// Init mask byte array
-static inline void dmaInitMaskBytes(uint8_t * mask) {
-   memset(mask,0,DMA_MASK_SIZE);
+/**
+ * dmaInitMaskBytes - Initialize DMA mask byte array.
+ * @mask: Pointer to the DMA mask byte array.
+ *
+ * Initializes the DMA mask byte array to zeros.
+ */
+static inline void dmaInitMaskBytes(uint8_t *mask) {
+   memset(mask, 0, DMA_MASK_SIZE);
 }
 
-// Add destination to mask byte array
-static inline void dmaAddMaskBytes(uint8_t * mask, uint32_t dest) {
+/**
+ * dmaAddMaskBytes - Add a destination to the DMA mask byte array.
+ * @mask: Pointer to the DMA mask byte array.
+ * @dest: Destination index to set in the mask.
+ *
+ * Adds a destination to the DMA mask byte array by setting the appropriate
+ * bit based on the destination index.
+ */
+static inline void dmaAddMaskBytes(uint8_t *mask, uint32_t dest) {
    uint32_t byte;
    uint32_t bit;
 
-   if ( dest < 8*(DMA_MASK_SIZE)) {
+   if (dest < 8 * (DMA_MASK_SIZE)) {
       byte = dest / 8;
-      bit  = dest % 8;
-      mask[byte] += (1 << bit);
+      bit = dest % 8;
+      mask[byte] |= (1 << bit);
    }
 }
 
-// set mask byte array to driver
-static inline ssize_t dmaSetMaskBytes(int32_t fd, uint8_t * mask) {
-   return(ioctl(fd,DMA_Set_MaskBytes,mask));
+/**
+ * dmaSetMaskBytes - Set mask byte array to the driver.
+ * @fd: File descriptor for the DMA device.
+ * @mask: Pointer to the DMA mask byte array.
+ *
+ * Sets the DMA mask byte array using an IOCTL command.
+ *
+ * Return: Result from the IOCTL call.
+ */
+static inline ssize_t dmaSetMaskBytes(int32_t fd, uint8_t *mask) {
+   return(ioctl(fd, DMA_Set_MaskBytes, mask));
 }
 
-// Check API version, return negative on error
+/**
+ * dmaCheckVersion - Check API version of the DMA driver.
+ * @fd: File descriptor for the DMA device.
+ *
+ * Checks the API version of the DMA driver to ensure compatibility.
+ *
+ * Return: 0 if the version matches, -1 otherwise.
+ */
 static inline ssize_t dmaCheckVersion(int32_t fd) {
    int32_t version;
-   version = ioctl(fd,DMA_Get_Version);
-   return((version == DMA_VERSION)?-0:-1);
+   version = ioctl(fd, DMA_Get_Version);
+   return((version == DMA_VERSION) ? 0 : -1);
 }
 
-// Write Register
+/**
+ * dmaWriteRegister - Write to a DMA register.
+ * @fd: File descriptor for the DMA device.
+ * @address: Register address.
+ * @data: Data to write.
+ *
+ * Writes data to a specified register address using an IOCTL command.
+ *
+ * Return: Result from the IOCTL call.
+ */
 static inline ssize_t dmaWriteRegister(int32_t fd, uint64_t address, uint32_t data) {
    struct DmaRegisterData reg;
 
    reg.address = address;
-   reg.data    = data;
-   return(ioctl(fd,DMA_Write_Register,&reg));
+   reg.data = data;
+   return(ioctl(fd, DMA_Write_Register, &reg));
 }
 
-// Read Register
-static inline ssize_t dmaReadRegister(int32_t fd, uint64_t address, uint32_t *data) {
+/**
+ * dmaReadRegister - Read a value from a DMA register.
+ * @fd: File descriptor for the DMA device.
+ * @address: The address of the register to be read.
+ * @data: Pointer to store the read data.
+ *
+ * This function reads a 32-bit value from a specified DMA register address.
+ * The read value is stored in the location pointed to by @data if @data is not NULL.
+ *
+ * Return: The result of the ioctl operation, indicating success or failure.
+ */
+static inline ssize_t dmaReadRegister(int32_t fd, uint64_t address, uint32_t *data)
+{
    struct DmaRegisterData reg;
    ssize_t res;
 
+   // Initialize register data structure
    reg.address = address;
    reg.data    = 0;
-   res = ioctl(fd,DMA_Read_Register,&reg);
 
-   if ( data != NULL ) *data = reg.data;
+   // Perform ioctl to read the register
+   res = ioctl(fd, DMA_Read_Register, &reg);
 
-   return(res);
+   // If data pointer is valid, update it with the read value
+   if (data != NULL)
+      *data = reg.data;
+
+   return res;
 }
 
-// Return user space mapping to a relative register space
-static inline void * dmaMapRegister(int32_t fd, off_t offset, uint32_t size) {
-   uint32_t bCount;
+/**
+ * dmaMapRegister - Map a DMA register space to user space.
+ * @fd: File descriptor for the DMA device.
+ * @offset: Offset from the start of the register space to be mapped.
+ * @size: Size of the memory region to map.
+ *
+ * This function calculates an internal offset based on the buffer size and count
+ * obtained from the DMA device. It then attempts to map a region of memory into
+ * the user space corresponding to this calculated offset plus the specified @offset.
+ *
+ * Return: A pointer to the mapped memory region in user space, or MAP_FAILED on failure.
+ */
+static inline void *dmaMapRegister(int32_t fd, off_t offset, uint32_t size)
+{
    uint32_t bSize;
+   uint32_t bCount;
    off_t    intOffset;
 
-   bSize  = ioctl(fd,DMA_Get_Buff_Size,0);
-   bCount = ioctl(fd,DMA_Get_Buff_Count,0);
+   // Obtain buffer size and count from the DMA device
+   bSize  = ioctl(fd, DMA_Get_Buff_Size, 0);
+   bCount = ioctl(fd, DMA_Get_Buff_Count, 0);
 
+   // Calculate internal offset
    intOffset = (bSize * bCount) + offset;
 
-   // Attempt to map
-   return(mmap (0, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, intOffset));
+   // Attempt to map the memory region into user space
+   return mmap(0, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, intOffset);
 }
 
-// Free space mapping to dma buffers
-static inline ssize_t dmaUnMapRegister(int32_t fd, void *ptr, uint32_t size) {
-   munmap (ptr, size);
-   return(0);
+/**
+ * dmaUnMapRegister - Unmap a DMA register space from user space.
+ * @fd: File descriptor for the DMA device. (Unused in this function, but kept for symmetry with map function)
+ * @ptr: Pointer to the start of the mapped memory region.
+ * @size: Size of the memory region to unmap.
+ *
+ * This function unmaps a previously mapped region of memory from the user space.
+ * The @fd parameter is not used but is included for symmetry with the dmaMapRegister function.
+ *
+ * Return: Always returns 0 indicating success.
+ */
+static inline ssize_t dmaUnMapRegister(int32_t fd, void *ptr, uint32_t size)
+{
+   // Unmap the memory region
+   munmap(ptr, size);
+   return 0;
 }
 
-#endif
-#endif
-
+#endif // !DMA_IN_KERNEL
+#endif // __DMA_DRIVER_H__

--- a/include/DmaDriver.h
+++ b/include/DmaDriver.h
@@ -616,7 +616,7 @@ static inline void dmaAddMaskBytes(uint8_t *mask, uint32_t dest) {
    if (dest < 8 * (DMA_MASK_SIZE)) {
       byte = dest / 8;
       bit = dest % 8;
-      mask[byte] |= (1 << bit);
+      mask[byte] += (1 << bit);
    }
 }
 

--- a/include/GpuAsync.h
+++ b/include/GpuAsync.h
@@ -82,7 +82,7 @@ static inline ssize_t gpuAddNvidiaMemory(int32_t fd, uint32_t write, uint64_t ad
  * returns a negative error code.
  **/
 static inline ssize_t gpuRemNvidiaMemory(int32_t fd) {
-   return(ioctl(fd, GPU_Rem_Nvidia_Memory, NULL));
+   return(ioctl(fd, GPU_Rem_Nvidia_Memory, 0));
 }
 
 #endif // !DMA_IN_KERNEL

--- a/include/GpuAsync.h
+++ b/include/GpuAsync.h
@@ -1,11 +1,14 @@
 /**
  *-----------------------------------------------------------------------------
- * Title      : GPU Async Header
- * ----------------------------------------------------------------------------
- * File       : GpuAsync.h
- * ----------------------------------------------------------------------------
+ * Company: SLAC National Accelerator Laboratory
+ *-----------------------------------------------------------------------------
  * Description:
- * Defintions and inline functions for using GPU Async features.
+ *    Provides definitions and inline functions for utilizing GPU asynchronous
+ *    features within the aes_stream_drivers package.
+ *
+ *    This code is specifically designed for managing NVIDIA GPU memory in a
+ *    Linux kernel module, offering functionality to add and remove memory
+ *    regions for GPU access.
  * ----------------------------------------------------------------------------
  * This file is part of the aes_stream_drivers package. It is subject to
  * the license terms in the LICENSE.txt file found in the top-level directory
@@ -16,40 +19,71 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
 #ifndef __GPU_ASYNC_H__
 #define __GPU_ASYNC_H__
+
 #include "DmaDriver.h"
 
-// Commands
-#define GPU_Add_Nvidia_Memory 0x8002
-#define GPU_Rem_Nvidia_Memory 0x8003
+/**
+ * GPU command codes
+ **/
+#define GPU_Add_Nvidia_Memory 0x8002   // Command to add NVIDIA GPU memory
+#define GPU_Rem_Nvidia_Memory 0x8003   // Command to remove NVIDIA GPU memory
 
-// NVidia Data
+/**
+ * struct GpuNvidiaData - Represents NVIDIA GPU memory data.
+ * @write: Write permission flag (non-zero for write access).
+ * @address: GPU memory address.
+ * @size: Size of the memory region in bytes.
+ *
+ * This structure is used for managing memory regions in NVIDIA GPUs,
+ * specifically for adding or removing access to these regions.
+ **/
 struct GpuNvidiaData {
-   uint32_t   write;
-   uint64_t   address;
-   uint32_t   size;
+   uint32_t write;    // Write permission flag
+   uint64_t address;  // GPU memory address
+   uint32_t size;     // Size of the memory region
 };
 
-// Everything below is hidden during kernel module compile
 #ifndef DMA_IN_KERNEL
 
-// Add NVIDIA Memory
+/**
+ * gpuAddNvidiaMemory - Adds a NVIDIA GPU memory region.
+ * @fd: File descriptor for the device.
+ * @write: Write access flag (1 for write access, 0 for read-only).
+ * @address: Memory address of the GPU region to add.
+ * @size: Size of the memory region to add.
+ *
+ * This function adds a specified memory region to the NVIDIA GPU, allowing
+ * for the region to be accessed as specified by the write flag.
+ *
+ * Return: On success, returns the result of the ioctl call. On failure,
+ * returns a negative error code.
+ **/
 static inline ssize_t gpuAddNvidiaMemory(int32_t fd, uint32_t write, uint64_t address, uint32_t size) {
    struct GpuNvidiaData dat;
 
-   dat.write    = write;
-   dat.address  = address;
-   dat.size     = size;
+   dat.write = write;
+   dat.address = address;
+   dat.size = size;
 
-   return(ioctl(fd,GPU_Add_Nvidia_Memory,&dat));
+   return(ioctl(fd, GPU_Add_Nvidia_Memory, &dat));
 }
 
-// Rem NVIDIA Memory
+/**
+ * gpuRemNvidiaMemory - Removes a NVIDIA GPU memory region.
+ * @fd: File descriptor for the device.
+ *
+ * This function removes a previously added memory region from the NVIDIA GPU,
+ * ceasing its accessibility.
+ *
+ * Return: On success, returns the result of the ioctl call. On failure,
+ * returns a negative error code.
+ **/
 static inline ssize_t gpuRemNvidiaMemory(int32_t fd) {
-   return(ioctl(fd,GPU_Rem_Nvidia_Memory,0));
+   return(ioctl(fd, GPU_Rem_Nvidia_Memory, NULL));
 }
 
-#endif
-#endif
-
+#endif // !DMA_IN_KERNEL
+#endif // __GPU_ASYNC_H__


### PR DESCRIPTION
### Description
- [applying 'Kernel-doc' style to include header files](https://github.com/slaclab/aes-stream-drivers/commit/1b0e4ca0dc098e2118262e98cf5c4db7fb0b6f27)
- Not applying 'Kernel-doc' style to FpgaProm.h, PgpDriver.h, and TemDriver.h
  - high probability of depreciation/removal in the future