### PR TITLE
bug fixes and updates to common/driver

### DIFF
--- a/common/driver/axi_version.c
+++ b/common/driver/axi_version.c
@@ -72,36 +72,36 @@ void AxiVersion_Read(struct DmaDevice *dev, void * base, struct AxiVersion *aVer
    uint32_t x;
 
    // Read firmware version, scratch pad, and uptime count
-   aVer->firmwareVersion = ioread32(&(reg->firmwareVersion));
-   aVer->scratchPad      = ioread32(&(reg->scratchPad));
-   aVer->upTimeCount     = ioread32(&(reg->upTimeCount));
+   aVer->firmwareVersion = readl(&(reg->firmwareVersion));
+   aVer->scratchPad      = readl(&(reg->scratchPad));
+   aVer->upTimeCount     = readl(&(reg->upTimeCount));
 
    // Read feature descriptor values
    for (x = 0; x < 2; x++) {
-      ((uint32_t *)aVer->fdValue)[x] = ioread32(&(reg->fdValue[x]));
+      ((uint32_t *)aVer->fdValue)[x] = readl(&(reg->fdValue[x]));
    }
 
    // Read user-defined values
    for (x = 0; x < 64; x++) {
-      aVer->userValues[x] = ioread32(&(reg->userValues[x]));
+      aVer->userValues[x] = readl(&(reg->userValues[x]));
    }
 
    // Read device ID
-   aVer->deviceId = ioread32(&(reg->deviceId));
+   aVer->deviceId = readl(&(reg->deviceId));
 
    // Read git hash
    for (x = 0; x < 40; x++) {
-      ((uint32_t *)aVer->gitHash)[x] = ioread32(&(reg->gitHash[x]));
+      ((uint32_t *)aVer->gitHash)[x] = readl(&(reg->gitHash[x]));
    }
 
    // Read device DNA value
    for (x = 0; x < 4; x++) {
-      ((uint32_t *)aVer->dnaValue)[x] = ioread32(&(reg->dnaValue[x]));
+      ((uint32_t *)aVer->dnaValue)[x] = readl(&(reg->dnaValue[x]));
    }
 
    // Read build string
    for (x = 0; x < 64; x++) {
-      ((uint32_t *)aVer->buildString)[x] = ioread32(&(reg->buildString[x]));
+      ((uint32_t *)aVer->buildString)[x] = readl(&(reg->buildString[x]));
    }
 }
 
@@ -172,5 +172,5 @@ void AxiVersion_SetUserReset(void *base, bool state) {
       val = 0x0;  // Clear user reset
    }
 
-   iowrite32(val, &(reg->userReset));  // Write the value to the userReset register
+   writel(val, &(reg->userReset));  // Write the value to the userReset register
 }

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -138,18 +138,18 @@ inline void AxisG2_WriteFree ( struct DmaBuffer *buff, struct AxisG2Reg *reg, ui
       wrData[1]  = (buff->buffHandle >>  8) & 0xFFFFFFFF;
 
       // Write the second part to the device's write FIFO B
-      iowrite32(wrData[1], &(reg->writeFifoB));
+      writel(wrData[1], &(reg->writeFifoB));
    }
    // If not using 128-bit descriptors, write the buffer handle directly
    // to the device's DMA address table based on the buffer index
    else {
       // For 64-bit descriptors
-      iowrite32(buff->buffHandle, &(reg->dmaAddr[buff->index]));
+      writel(buff->buffHandle, &(reg->dmaAddr[buff->index]));
    }
 
    // Write the first part (or the entire buffer index for 32-bit descriptors)
    // to the device's write FIFO A
-   iowrite32(wrData[0], &(reg->writeFifoA));
+   writel(wrData[0], &(reg->writeFifoA));
 }
 
 /**
@@ -189,8 +189,8 @@ inline void AxisG2_WriteTx(struct DmaBuffer *buff, struct AxisG2Reg *reg, uint32
       rdData[3]  = (buff->buffHandle >>  8) & 0xFFFFFFFF; // Addr bits[39:8]
 
       // Write to FIFO registers for 128-bit descriptor
-      iowrite32(rdData[3], &(reg->readFifoD));
-      iowrite32(rdData[2], &(reg->readFifoC));
+      writel(rdData[3], &(reg->readFifoD));
+      writel(rdData[2], &(reg->readFifoC));
    } else {
       // For 64-bit descriptors
       rdData[0] |= (buff->index <<  4) & 0x0000FFF0; // Buffer ID
@@ -199,12 +199,12 @@ inline void AxisG2_WriteTx(struct DmaBuffer *buff, struct AxisG2Reg *reg, uint32
       rdData[1] |= (buff->dest << 24) & 0xFF000000; // Destination ID
 
       // Write buffer handle to DMA address table
-      iowrite32(buff->buffHandle, &(reg->dmaAddr[buff->index]));
+      writel(buff->buffHandle, &(reg->dmaAddr[buff->index]));
    }
 
    // Write to FIFO registers
-   iowrite32(rdData[1], &(reg->readFifoB));
-   iowrite32(rdData[0], &(reg->readFifoA));
+   writel(rdData[1], &(reg->readFifoB));
+   writel(rdData[0], &(reg->readFifoA));
 }
 
 /**
@@ -315,7 +315,7 @@ uint32_t AxisG2_Process (struct DmaDevice * dev, struct AxisG2Reg *reg, struct A
 
             // Background operation handling
             if ( (hwData->bgEnable >> buff->id) & 0x1 ) {
-               iowrite32(0x1,&(reg->bgCount[buff->id]));
+               writel(0x1,&(reg->bgCount[buff->id]));
             }
          }
 
@@ -370,7 +370,7 @@ irqreturn_t AxisG2_Irq(int irq, void *dev_id)
    hwData = (struct AxisG2Data *)dev->hwData;
 
    // Disable interrupt
-   iowrite32(0x0, &(reg->intEnable));
+   writel(0x0, &(reg->intEnable));
 
    // Log interrupt occurrence if debugging is enabled
    if (dev->debug > 0) {
@@ -414,7 +414,7 @@ void AxisG2_Init(struct DmaDevice *dev) {
    hwData->dev = dev;
 
    // Determine operation mode (64-bit or 128-bit) based on hardware version
-   hwData->desc128En = ((ioread32(&(reg->enableVer)) & 0x10000) != 0);
+   hwData->desc128En = ((readl(&(reg->enableVer)) & 0x10000) != 0);
 
    // Initialize buffer counters
    hwData->hwWrBuffCnt = 0;
@@ -428,7 +428,7 @@ void AxisG2_Init(struct DmaDevice *dev) {
    }
 
    // Calculate and set the addressable space based on register settings
-   hwData->addrCount = (1 << ioread32(&(reg->addrWidth)));
+   hwData->addrCount = (1 << readl(&(reg->addrWidth)));
    size = hwData->addrCount*(hwData->desc128En?16:8);
 
    // Allocate DMA buffers based on configuration mode
@@ -449,14 +449,14 @@ void AxisG2_Init(struct DmaDevice *dev) {
    dev_info(dev->device,"Init: Write ring at: sw 0x%llx -> hw 0x%llx.\n",(uint64_t)hwData->writeAddr,(uint64_t)hwData->writeHandle);
 
    // Initialize read ring buffer addresses and indices
-   iowrite32(hwData->readHandle&0xFFFFFFFF,&(reg->rdBaseAddrLow));
-   iowrite32((hwData->readHandle >> 32)&0xFFFFFFFF,&(reg->rdBaseAddrHigh));
+   writel(hwData->readHandle&0xFFFFFFFF,&(reg->rdBaseAddrLow));
+   writel((hwData->readHandle >> 32)&0xFFFFFFFF,&(reg->rdBaseAddrHigh));
    memset(hwData->readAddr,0,size);
    hwData->readIndex = 0;
 
    // Initialize write ring buffer addresses and indices
-   iowrite32(hwData->writeHandle&0xFFFFFFFF,&(reg->wrBaseAddrLow));
-   iowrite32((hwData->writeHandle>>32)&0xFFFFFFFF,&(reg->wrBaseAddrHigh));
+   writel(hwData->writeHandle&0xFFFFFFFF,&(reg->wrBaseAddrLow));
+   writel((hwData->writeHandle>>32)&0xFFFFFFFF,&(reg->wrBaseAddrHigh));
    memset(hwData->writeAddr,0,size);
    hwData->writeIndex = 0;
 
@@ -469,21 +469,21 @@ void AxisG2_Init(struct DmaDevice *dev) {
    x = 0;
    if (dev->cfgMode & BUFF_ARM_ACP) x |= 0xA600; // Buffer write and read cache policy
    if (dev->cfgMode & AXIS2_RING_ACP) x |= 0x00A6; // Descriptor write cache policy
-   iowrite32(x, &(reg->cacheConfig));
+   writel(x, &(reg->cacheConfig));
 
    // Set maximum transfer size
-   iowrite32(dev->cfgSize,&(reg->maxSize));
+   writel(dev->cfgSize,&(reg->maxSize));
 
    // Reset FIFOs to clear any residual data
-   iowrite32(0x1,&(reg->fifoReset));
-   iowrite32(0x0,&(reg->fifoReset));
+   writel(0x1,&(reg->fifoReset));
+   writel(0x0,&(reg->fifoReset));
 
    // Enable continuous mode and disable drop mode
-   iowrite32(0x1,&(reg->contEnable));
-   iowrite32(0x0,&(reg->dropEnable));
+   writel(0x1,&(reg->contEnable));
+   writel(0x0,&(reg->dropEnable));
 
    // Set IRQ holdoff time if supported by hardware version
-   if ( ((ioread32(&(reg->enableVer)) >> 24) & 0xFF) >= 3 ) iowrite32(dev->cfgIrqHold,&(reg->irqHoldOff));
+   if ( ((readl(&(reg->enableVer)) >> 24) & 0xFF) >= 3 ) writel(dev->cfgIrqHold,&(reg->irqHoldOff));
 
    // Push RX buffers to hardware and map
    for (x=dev->rxBuffers.baseIdx; x < (dev->rxBuffers.baseIdx + dev->rxBuffers.count); x++) {
@@ -505,10 +505,10 @@ void AxisG2_Init(struct DmaDevice *dev) {
 
    // Initialize buffer group settings if supported by hardware version
    hwData->bgEnable = 0;
-   if ( ((ioread32(&(reg->enableVer)) >> 24) & 0xFF) >= 4 ) {
+   if ( ((readl(&(reg->enableVer)) >> 24) & 0xFF) >= 4 ) {
       for (x =0; x < 8; x++) {
          if ( dev->cfgBgThold[x] != 0 ) hwData->bgEnable |= (1 << x);
-         iowrite32(dev->cfgBgThold[x],&(reg->bgThold[x]));
+         writel(dev->cfgBgThold[x],&(reg->bgThold[x]));
       }
    }
 
@@ -533,8 +533,8 @@ void AxisG2_Enable(struct DmaDevice *dev) {
    hwData = (struct AxisG2Data *)dev->hwData;
 
    // Enable the device by setting the enable version and online registers
-   iowrite32(0x1, &(reg->enableVer));
-   iowrite32(0x1, &(reg->online));
+   writel(0x1, &(reg->enableVer));
+   writel(0x1, &(reg->online));
 
    // Check if descriptor 128-bit enable flag is set
    if (hwData->desc128En) {
@@ -561,15 +561,15 @@ void AxisG2_Enable(struct DmaDevice *dev) {
 
    // Enable interrupt handling if not disabled by configuration
    if (!dev->cfgIrqDis) {
-      iowrite32(0x1, &(reg->intEnable));
+      writel(0x1, &(reg->intEnable));
    }
 
    // Re-enable the device and online status to ensure settings take effect
-   iowrite32(0x1, &(reg->enableVer));
-   iowrite32(0x1, &(reg->online));
+   writel(0x1, &(reg->enableVer));
+   writel(0x1, &(reg->online));
 
    // Re-enable interrupt handling as a final step
-   iowrite32(0x1, &(reg->intEnable));
+   writel(0x1, &(reg->intEnable));
 }
 
 /**
@@ -590,7 +590,7 @@ void AxisG2_Clear(struct DmaDevice *dev) {
    hwData = (struct AxisG2Data *)dev->hwData;
 
    // Disable interrupts to prevent further device activity.
-   iowrite32(0x0, &(reg->intEnable));
+   writel(0x0, &(reg->intEnable));
 
    // Stop and destroy the work queue if enabled.
    if (hwData->wqEnable) {
@@ -605,11 +605,11 @@ void AxisG2_Clear(struct DmaDevice *dev) {
    }
 
    // Disable RX and TX to stop data transfers.
-   iowrite32(0x0, &(reg->enableVer));
-   iowrite32(0x0, &(reg->online));
+   writel(0x0, &(reg->enableVer));
+   writel(0x0, &(reg->online));
 
    // Clear FIFOs to reset the device's internal state.
-   iowrite32(0x1, &(reg->fifoReset));
+   writel(0x1, &(reg->fifoReset));
 
    // Free allocated buffers depending on the device configuration.
    if (dev->cfgMode & AXIS2_RING_ACP) {
@@ -674,13 +674,13 @@ void AxisG2_RetRxBuffer(struct DmaDevice *dev, struct DmaBuffer **buff, uint32_t
       if (hwData->bgEnable != 0) {
          for (x = 0; x < count; x++) {
             if ((hwData->bgEnable >> buff[x]->id) & 0x1) {
-               iowrite32(0x1, &(reg->bgCount[buff[x]->id]));
+               writel(0x1, &(reg->bgCount[buff[x]->id]));
             }
          }
       }
 
       // Force an interrupt to process the returned buffers
-      iowrite32(0x1, &(reg->forceInt));
+      writel(0x1, &(reg->forceInt));
    }
 }
 
@@ -725,7 +725,7 @@ int32_t AxisG2_SendBuffer(struct DmaDevice *dev, struct DmaBuffer **buff, uint32
    // For 128-bit descriptors, push to software queue and force an interrupt
    if (hwData->desc128En) {
       dmaQueuePushList(&(hwData->rdQueue), buff, count);
-      iowrite32(0x1, &(reg->forceInt));
+      writel(0x1, &(reg->forceInt));
    }
 
    return count;
@@ -755,7 +755,7 @@ int32_t AxisG2_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg)
          // Lock the device command execution context
          spin_lock(&dev->commandLock);
          // Acknowledge the read request
-         iowrite32(0x1, &(reg->acknowledge));
+         writel(0x1, &(reg->acknowledge));
          // Unlock after command execution
          spin_unlock(&dev->commandLock);
          return 0;
@@ -763,7 +763,7 @@ int32_t AxisG2_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg)
 
       case AXIS_Write_ReqMissed:
          // Return the number of missed write requests
-         return ioread32(&(reg->wrReqMissed));
+         return readl(&(reg->wrReqMissed));
          break;
 
       default:
@@ -795,28 +795,28 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
 
    seq_printf(s,"\n");
    seq_printf(s,"---------- DMA Firmware General ----------\n");
-   seq_printf(s,"          Int Req Count : %u\n",(ioread32(&(reg->intReqCount))));
-// seq_printf(s,"        Hw Dma Wr Index : %u\n",(ioread32(&(reg->hwWrIndex))));
+   seq_printf(s,"          Int Req Count : %u\n",(readl(&(reg->intReqCount))));
+// seq_printf(s,"        Hw Dma Wr Index : %u\n",(readl(&(reg->hwWrIndex))));
 // seq_printf(s,"        Sw Dma Wr Index : %u\n",hwData->writeIndex);
-// seq_printf(s,"        Hw Dma Rd Index : %u\n",(ioread32(&(reg->hwRdIndex))));
+// seq_printf(s,"        Hw Dma Rd Index : %u\n",(readl(&(reg->hwRdIndex))));
 // seq_printf(s,"        Sw Dma Rd Index : %u\n",hwData->readIndex);
-// seq_printf(s,"     Missed Wr Requests : %u\n",(ioread32(&(reg->wrReqMissed))));
+// seq_printf(s,"     Missed Wr Requests : %u\n",(readl(&(reg->wrReqMissed))));
 // seq_printf(s,"       Missed IRQ Count : %u\n",hwData->missedIrq);
    seq_printf(s,"         Continue Count : %u\n",hwData->contCount);
    seq_printf(s,"          Address Count : %i\n",hwData->addrCount);
    seq_printf(s,"    Hw Write Buff Count : %i\n",hwData->hwWrBuffCnt);
    seq_printf(s,"     Hw Read Buff Count : %i\n",hwData->hwRdBuffCnt);
-   seq_printf(s,"           Cache Config : 0x%x\n",(ioread32(&(reg->cacheConfig))));
+   seq_printf(s,"           Cache Config : 0x%x\n",(readl(&(reg->cacheConfig))));
    seq_printf(s,"            Desc 128 En : %i\n",hwData->desc128En);
-   seq_printf(s,"            Enable Ver  : 0x%x\n",(ioread32(&(reg->enableVer))));
-   seq_printf(s,"      Driver Load Count : %u\n",((ioread32(&(reg->enableVer)))>>8)&0xFF);
-   seq_printf(s,"               IRQ Hold : %u\n",(ioread32(&(reg->irqHoldOff))));
+   seq_printf(s,"            Enable Ver  : 0x%x\n",(readl(&(reg->enableVer))));
+   seq_printf(s,"      Driver Load Count : %u\n",((readl(&(reg->enableVer)))>>8)&0xFF);
+   seq_printf(s,"               IRQ Hold : %u\n",(readl(&(reg->irqHoldOff))));
    seq_printf(s,"              BG Enable : 0x%x\n",hwData->bgEnable);
 
    for ( x=0; x < 8; x++ ) {
       if ( (hwData->bgEnable >> x) & 0x1 ) {
-         seq_printf(s,"         BG %i Threshold : %u\n",x,ioread32(&(reg->bgThold[x])));
-         seq_printf(s,"             BG %i Count : %u\n",x,ioread32(&(reg->bgCount[x])));
+         seq_printf(s,"         BG %i Threshold : %u\n",x,readl(&(reg->bgThold[x])));
+         seq_printf(s,"             BG %i Count : %u\n",x,readl(&(reg->bgCount[x])));
       }
    }
 }
@@ -845,7 +845,7 @@ void AxisG2_WqTask_IrqForce(struct work_struct *work) {
    reg = (struct AxisG2Reg *)hwData->dev->reg;
 
    // Force an interrupt
-   iowrite32(0x1, &(reg->forceInt));
+   writel(0x1, &(reg->forceInt));
 
    // If work queue is enabled, re-queue the work with a delay
    if (hwData->wqEnable)
@@ -930,5 +930,5 @@ void AxisG2_WqTask_Service(struct work_struct *work) {
    }
 
    // Acknowledge interrupt and enable next interrupt
-   iowrite32(0x30000 + handleCount, &(reg->intAckAndEnable));
+   writel(0x30000 + handleCount, &(reg->intAckAndEnable));
 }

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -440,8 +440,8 @@ void AxisG2_Init(struct DmaDevice *dev) {
       hwData->writeHandle = virt_to_phys(hwData->writeAddr);
    } else {
       // Allocate coherent DMA buffers for read and write operations
-      hwData->readAddr = dma_alloc_coherent(dev->device, size, &(hwData->readHandle), GFP_DMA32 | GFP_KERNEL);
-      hwData->writeAddr = dma_alloc_coherent(dev->device, size, &(hwData->writeHandle), GFP_DMA32 | GFP_KERNEL);
+      hwData->readAddr = dma_alloc_coherent(dev->device, size, &(hwData->readHandle), GFP_DMA | GFP_KERNEL);
+      hwData->writeAddr = dma_alloc_coherent(dev->device, size, &(hwData->writeHandle), GFP_DMA | GFP_KERNEL);
    }
 
    // Log buffer addresses

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -409,7 +409,7 @@ void AxisG2_Init(struct DmaDevice *dev) {
    memset(dev->destMask,0xFF,DMA_MASK_SIZE);
 
    // Allocate and initialize hardware data structure
-   hwData = (struct AxisG2Data *)kmalloc(sizeof(struct AxisG2Data),GFP_KERNEL);
+   hwData = (struct AxisG2Data *)kzalloc(sizeof(struct AxisG2Data),GFP_KERNEL);
    dev->hwData = hwData;
    hwData->dev = dev;
 
@@ -424,7 +424,7 @@ void AxisG2_Init(struct DmaDevice *dev) {
    if ( hwData->desc128En ) {
       dmaQueueInit(&hwData->wrQueue,dev->rxBuffers.count);
       dmaQueueInit(&hwData->rdQueue,dev->txBuffers.count + dev->rxBuffers.count);
-      hwData->buffList = (struct DmaBuffer **)kmalloc(BUFF_LIST_SIZE * sizeof(struct DmaBuffer *),GFP_ATOMIC);
+      hwData->buffList = (struct DmaBuffer **)kzalloc(BUFF_LIST_SIZE * sizeof(struct DmaBuffer *),GFP_ATOMIC);
    }
 
    // Calculate and set the addressable space based on register settings
@@ -434,9 +434,9 @@ void AxisG2_Init(struct DmaDevice *dev) {
    // Allocate DMA buffers based on configuration mode
    if(dev->cfgMode & AXIS2_RING_ACP) {
       // Allocate read and write buffers in contiguous physical memory
-      hwData->readAddr   = kmalloc(size, GFP_DMA | GFP_KERNEL);
+      hwData->readAddr   = kzalloc(size, GFP_DMA | GFP_KERNEL);
       hwData->readHandle = virt_to_phys(hwData->readAddr);
-      hwData->writeAddr   = kmalloc(size, GFP_DMA | GFP_KERNEL);
+      hwData->writeAddr   = kzalloc(size, GFP_DMA | GFP_KERNEL);
       hwData->writeHandle = virt_to_phys(hwData->writeAddr);
    } else {
       // Allocate coherent DMA buffers for read and write operations

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -106,16 +106,13 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
 
       // Streaming buffer type, standard kernel memory
       else if ( list->dev->cfgMode & BUFF_STREAM ) {
-         buff->buffAddr = kzalloc(list->dev->cfgSize, GFP_KERNEL);
+         dev_info(dev->device,"dmaAllocBuffers: BUFF_STREAM\n");
+         // Allocate consistent memory directly using dma_alloc_coherent
+         buff->buffAddr = dma_alloc_coherent(list->dev->device, list->dev->cfgSize, &buff->buffHandle, GFP_KERNEL);
 
-         if (buff->buffAddr != NULL) {
-            buff->buffHandle = dma_map_single(list->dev->device,buff->buffAddr,
-                                             list->dev->cfgSize,direction);
-
-            // Map error
-            if ( dma_mapping_error(list->dev->device,buff->buffHandle) ) {
-               buff->buffHandle = 0;
-            }
+         // Check for mapping error
+         if (buff->buffAddr == NULL) {
+            dev_err(dev->device,"dmaAllocBuffers: dma_alloc_coherent failed\n");
          }
       }
 

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -101,7 +101,7 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
       // Coherent buffer, map dma coherent buffers
       if ( list->dev->cfgMode & BUFF_COHERENT ) {
          buff->buffAddr =
-            dma_alloc_coherent(list->dev->device, list->dev->cfgSize, &(buff->buffHandle), GFP_DMA32 | GFP_KERNEL);
+            dma_alloc_coherent(list->dev->device, list->dev->cfgSize, &(buff->buffHandle), GFP_DMA | GFP_KERNEL);
       }
 
       // Streaming buffer type, standard kernel memory

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -114,7 +114,7 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
          }
       }
 
-      // ACP type with permament handle mapping, dma capable kernel memory
+      // ACP type with permanent handle mapping, dma capable kernel memory
       else if ( list->dev->cfgMode & BUFF_ARM_ACP ) {
          buff->buffAddr = kzalloc(list->dev->cfgSize, GFP_DMA | GFP_KERNEL);
          if (buff->buffAddr != NULL)

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -64,14 +64,14 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
    if ( count == 0 ) return(0);
 
    // Allocate first level pointers
-   if ((list->indexed = (struct DmaBuffer ***) kmalloc(sizeof(struct DmaBuffer**) * list->subCount, GFP_KERNEL)) == NULL ) {
+   if ((list->indexed = (struct DmaBuffer ***) kzalloc(sizeof(struct DmaBuffer**) * list->subCount, GFP_KERNEL)) == NULL ) {
       dev_err(dev->device,"dmaAllocBuffers: Failed to allocate indexed list pointer. Count=%u.\n",list->subCount);
       goto cleanup_forced_exit;
    }
 
    // Allocate sub lists
    for (x=0; x < list->subCount; x++) {
-      if ((list->indexed[x] = (struct DmaBuffer **) kmalloc((sizeof(struct DmaBuffer *) * BUFFERS_PER_LIST), GFP_KERNEL)) == NULL) {
+      if ((list->indexed[x] = (struct DmaBuffer **) kzalloc((sizeof(struct DmaBuffer *) * BUFFERS_PER_LIST), GFP_KERNEL)) == NULL) {
          dev_err(dev->device,"dmaAllocBuffers: Failed to allocate sub list. Idx=%u.\n",x);
          goto cleanup_list_heads;
       }
@@ -80,14 +80,14 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
    // Sorted lists are not always available. Disable for streaming mode or when we have too many buffers for
    // a single sorted list
    if ( (list->subCount == 1) && ((list->dev->cfgMode & BUFF_STREAM) == 0) ) {
-      list->sorted = (struct DmaBuffer **) kmalloc(sizeof(struct DmaBuffer**) * count, GFP_KERNEL);
+      list->sorted = (struct DmaBuffer **) kzalloc(sizeof(struct DmaBuffer**) * count, GFP_KERNEL);
    }
 
    // Allocate buffers
    for (x=0; x < count; x++) {
       sl  = x / BUFFERS_PER_LIST;
       sli = x % BUFFERS_PER_LIST;
-      if ( (buff = (struct DmaBuffer *) kmalloc(sizeof(struct DmaBuffer), GFP_KERNEL)) == NULL) {
+      if ( (buff = (struct DmaBuffer *) kzalloc(sizeof(struct DmaBuffer), GFP_KERNEL)) == NULL) {
          dev_err(dev->device,"dmaAllocBuffers: Failed to create buffer structure index %ui. Unloading.\n",x);
          goto cleanup_buffers;
       }
@@ -106,7 +106,7 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
 
       // Streaming buffer type, standard kernel memory
       else if ( list->dev->cfgMode & BUFF_STREAM ) {
-         buff->buffAddr = kmalloc(list->dev->cfgSize, GFP_KERNEL);
+         buff->buffAddr = kzalloc(list->dev->cfgSize, GFP_KERNEL);
 
          if (buff->buffAddr != NULL) {
             buff->buffHandle = dma_map_single(list->dev->device,buff->buffAddr,
@@ -121,7 +121,7 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
 
       // ACP type with permament handle mapping, dma capable kernel memory
       else if ( list->dev->cfgMode & BUFF_ARM_ACP ) {
-         buff->buffAddr = kmalloc(list->dev->cfgSize, GFP_DMA | GFP_KERNEL);
+         buff->buffAddr = kzalloc(list->dev->cfgSize, GFP_DMA | GFP_KERNEL);
          if (buff->buffAddr != NULL)
             buff->buffHandle = virt_to_phys(buff->buffAddr);
       }
@@ -627,14 +627,14 @@ size_t dmaQueueInit(struct DmaQueue *queue, uint32_t count) {
    queue->write = 0;
 
    // Allocate memory for the queue pointers
-   queue->queue = (struct DmaBuffer ***)kmalloc(queue->subCount * sizeof(struct DmaBuffer **), GFP_KERNEL);
+   queue->queue = (struct DmaBuffer ***)kzalloc(queue->subCount * sizeof(struct DmaBuffer **), GFP_KERNEL);
    if (queue->queue == NULL) {
       goto cleanup_force_exit;
    }
 
    // Allocate memory for each sub-queue
    for (x = 0; x < queue->subCount; x++) {
-      queue->queue[x] = (struct DmaBuffer **)kmalloc(BUFFERS_PER_LIST * sizeof(struct DmaBuffer *), GFP_KERNEL);
+      queue->queue[x] = (struct DmaBuffer **)kzalloc(BUFFERS_PER_LIST * sizeof(struct DmaBuffer *), GFP_KERNEL);
       if (queue->queue[x] == NULL) {
          goto cleanup_sub_queue;
       }

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -106,8 +106,6 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
 
       // Streaming buffer type, standard kernel memory
       else if ( list->dev->cfgMode & BUFF_STREAM ) {
-         dev_info(dev->device,"dmaAllocBuffers: BUFF_STREAM\n");
-         // Allocate consistent memory directly using dma_alloc_coherent
          buff->buffAddr = dma_alloc_coherent(list->dev->device, list->dev->cfgSize, &buff->buffHandle, GFP_KERNEL);
 
          // Check for mapping error

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -1454,7 +1454,7 @@ int32_t Dma_WriteRegister(struct DmaDevice *dev, uint64_t arg)
    }
 
    // Write data to the register
-   iowrite32(rData.data, dev->base + rData.address);
+   writel(rData.data, dev->base + rData.address);
 
    return 0;
 }
@@ -1489,7 +1489,7 @@ int32_t Dma_ReadRegister(struct DmaDevice *dev, uint64_t arg)
    }
 
    // Read register value
-   rData.data = ioread32(dev->base + rData.address);
+   rData.data = readl(dev->base + rData.address);
 
    // Attempt to copy the updated DmaRegisterData structure back to user space
    if ((ret = copy_to_user((void *)arg, &rData, sizeof(struct DmaRegisterData)))) {

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -1096,7 +1096,7 @@ int Dma_Mmap(struct file *filp, struct vm_area_struct *vma)
       }
       // Map streaming buffer or ARM ACP
       else if (dev->cfgMode & BUFF_STREAM || dev->cfgMode & BUFF_ARM_ACP) {
-         ret = remap_pfn_range(vma, vma->vm_start,
+         ret = io_remap_pfn_range(vma, vma->vm_start,
                                virt_to_phys((void *)buff->buffAddr) >> PAGE_SHIFT,
                                vsize, vma->vm_page_prot);
       } else {

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -462,9 +462,9 @@ int Dma_Open(struct inode *inode, struct file *filp) {
    dev = container_of(inode->i_cdev, struct DmaDevice, charDev);
 
    // Allocate and initialize the DMA descriptor
-   desc = (struct DmaDesc *)kmalloc(sizeof(struct DmaDesc), GFP_KERNEL);
+   desc = (struct DmaDesc *)kzalloc(sizeof(struct DmaDesc), GFP_KERNEL);
    if (!desc) {
-      dev_err(dev->device, "Open: kmalloc failed\n");
+      dev_err(dev->device, "Open: kzalloc failed\n");
       return -ENOMEM; // Return an error if allocation fails
    }
 
@@ -608,8 +608,8 @@ ssize_t Dma_Read(struct file *filp, char *buffer, size_t count, loff_t *f_pos)
    }
 
    rCnt = count / sizeof(struct DmaReadData);
-   rd = (struct DmaReadData *)kmalloc(rCnt * sizeof(struct DmaReadData), GFP_KERNEL);
-   buff = (struct DmaBuffer **)kmalloc(rCnt * sizeof(struct DmaBuffer *), GFP_KERNEL);
+   rd = (struct DmaReadData *)kzalloc(rCnt * sizeof(struct DmaReadData), GFP_KERNEL);
+   buff = (struct DmaBuffer **)kzalloc(rCnt * sizeof(struct DmaBuffer *), GFP_KERNEL);
 
    // Copy the read structure from user space
    if ((ret = copy_from_user(rd, buffer, rCnt * sizeof(struct DmaReadData)))) {
@@ -914,10 +914,10 @@ ssize_t Dma_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
          cnt = (cmd >> 16) & 0xFFFF;
 
          if ( cnt == 0 ) return(0);
-         indexes = kmalloc(cnt * sizeof(uint32_t),GFP_KERNEL);
+         indexes = kzalloc(cnt * sizeof(uint32_t),GFP_KERNEL);
          if (copy_from_user(indexes,(void *)arg,(cnt * sizeof(uint32_t)))) return(-1);
 
-         buffList = (struct DmaBuffer **)kmalloc(cnt * sizeof(struct DmaBuffer *),GFP_KERNEL);
+         buffList = (struct DmaBuffer **)kzalloc(cnt * sizeof(struct DmaBuffer *),GFP_KERNEL);
          bCnt = 0;
 
          for (x=0; x < cnt; x++) {

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -39,7 +39,7 @@ void Gpu_Init(struct DmaDevice *dev, uint32_t offset)
    struct GpuData *gpuData;
 
    /* Allocate memory for GPU utility data */
-   gpuData = (struct GpuData *)kmalloc(sizeof(struct GpuData), GFP_KERNEL);
+   gpuData = (struct GpuData *)kzalloc(sizeof(struct GpuData), GFP_KERNEL);
    if (!gpuData)
       return; // Handle memory allocation failure if necessary
 

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -164,11 +164,11 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
 
          // Update buffer count and write DMA addresses to device
          if (buffer->write){
-            iowrite32(buffer->dmaMapping->dma_addresses[0], data->base+0x100+data->writeBuffers.count*16);
-            iowrite32(mapSize,data->base+0x108+data->writeBuffers.count*16);
+            writel(buffer->dmaMapping->dma_addresses[0], data->base+0x100+data->writeBuffers.count*16);
+            writel(mapSize,data->base+0x108+data->writeBuffers.count*16);
             data->writeBuffers.count++;
          } else {
-            iowrite32(buffer->dmaMapping->dma_addresses[0], data->base+0x200+data->readBuffers.count*16);
+            writel(buffer->dmaMapping->dma_addresses[0], data->base+0x200+data->readBuffers.count*16);
             data->readBuffers.count++;
          }
       }
@@ -189,7 +189,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
       x |= (data->readBuffers.count-1) << 16;
    }
 
-   iowrite32(x,data->base+0x008);
+   writel(x,data->base+0x008);
    return(0);
 }
 
@@ -242,7 +242,7 @@ int32_t Gpu_RemNvidia(struct DmaDevice *dev, uint64_t arg)
    // Reset the buffer counts and disable specific functionality by writing to a register
    data->writeBuffers.count = 0;
    data->readBuffers.count = 0;
-   iowrite32(0, data->base + 0x008);
+   writel(0, data->base + 0x008);
 
    return 0;
 }

--- a/rce_memmap/driver/src/rce_map.c
+++ b/rce_memmap/driver/src/rce_map.c
@@ -33,14 +33,6 @@
 #include <linux/slab.h>
 #include <linux/version.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 25)
-  /* 'ioremap_nocache' was deprecated in kernels >= 5.6, so instead we use 'ioremap' which
-  is no-cache by default since kernels 2.6.25. */
-#    define IOREMAP_NO_CACHE(address, size) ioremap(address, size)
-#else /* KERNEL_VERSION < 2.6.25 */
-#    define IOREMAP_NO_CACHE(address, size) ioremap_nocache(address, size)
-#endif
-
 // Module Name
 #define MOD_NAME "rce_memmap"
 
@@ -125,7 +117,7 @@ int Map_Init(void) {
    dev.maps->next = NULL;
 
    // Map space
-   dev.maps->base = IOREMAP_NO_CACHE(dev.maps->addr, MAP_SIZE);
+   dev.maps->base = ioremap_wc(dev.maps->addr, MAP_SIZE);
    if (! dev.maps->base ) {
       printk(KERN_ERR MOD_NAME " Init: Could not map memory addr %p with size 0x%x.\n",(void *)dev.maps->addr,MAP_SIZE);
       kfree(dev.maps);
@@ -213,7 +205,7 @@ uint8_t * Map_Find(uint32_t addr) {
          new->addr = (addr / MAP_SIZE) * MAP_SIZE;
 
          // Map space
-         new->base = IOREMAP_NO_CACHE(new->addr, MAP_SIZE);
+         new->base = ioremap_wc(new->addr, MAP_SIZE);
          if (! new->base ) {
             printk(KERN_ERR MOD_NAME " Map_Find: Could not map memory addr %p (%p) with size 0x%x.\n",(void *)new->addr,(void*)addr,MAP_SIZE);
             kfree(new);


### PR DESCRIPTION
### Description
- [use readl() and writel() instead of ioread32() and iowrite32()](https://github.com/slaclab/aes-stream-drivers/commit/bbe01ed47f7488985b40eeac6b7a64481f595575)
  - These changes replace the direct I/O access functions with the recommended memory-mapped I/O functions, improving portability and security within the kernel module.
- [Switching to kzalloc to automatically zero out the allocated memory can be beneficial for several reasons:](https://github.com/slaclab/aes-stream-drivers/commit/ed9ef5bd4acdbf8ea14e1542521b18f6fa62b008)
  - Security: Automatically zeroing memory can help prevent the unintentional leak of sensitive information from previously used memory blocks.
  - Stability: Initializing memory to zero can prevent bugs related to uninitialized memory usage.
  - Simplicity: Using kzalloc simplifies the code by combining allocation and initialization into a single operation, reducing the risk of forgetting to explicitly zero the memory.
- [changing GFP_DMA32 to GFP_DMA](https://github.com/slaclab/aes-stream-drivers/pull/123/commits/62dc642a0faa6e0ff8b7639c970573e2a1ac75f8)
  - Using `GFP_DMA` for DMA allocations in a kernel code that runs on a 32-bit system should not inherently cause an error just because of the flag's usage. The `GFP_DMA` flag is used to indicate that the allocated memory is DMA-able, and it's generally used for devices that require direct access to physical memory without going through the CPU's caching mechanisms. This flag is not specifically tied to 32-bit or 64-bit addressing; it's more about the requirements of the device and the DMA (Direct Memory Access) system.
- [remap_pfn_range() is deprecated in favor of functions like ioremap_pfn_range()](https://github.com/slaclab/aes-stream-drivers/pull/123/commits/31d35cad292c53897ba0062c19f4129a851ce465)
- [dma_map_single() being depreciated in future and switching to dma_alloc_coherent()](https://github.com/slaclab/aes-stream-drivers/pull/123/commits/5a73302790c203f6a021faf418385e14a72426c7)
  - offers simplified management, potentially better performance, reduced fragmentation, and safer memory access for your DMA operations
- [replacing IOREMAP_NO_CACHE with ioremap_wc](https://github.com/slaclab/aes-stream-drivers/pull/123/commits/0ac92ad7f1ebe0e38ff7ca25a81a3064f57b5b8f)
  - This change adapts the code to be compliant with the new kernel requirements by using ioremap_wc for write-combining mappings, which is recommended for device memory mappings that do not require caching. This adjustment ensures that the driver remains functional and efficient under the updated kernel API.
  - The ioremap_wc() function was first introduced in the Linux kernel version 2.6.15, released on January 21, 2006.