### PR TITLE
Updating MAX_DMA_DEVICES from 4 to 32 for the PCIe related drivers

### DIFF
--- a/data_dev/driver/src/data_dev_top.h
+++ b/data_dev/driver/src/data_dev_top.h
@@ -25,7 +25,7 @@
 #include <dma_common.h>
 
 /** Maximum number of DMA devices supported. */
-#define MAX_DMA_DEVICES 4
+#define MAX_DMA_DEVICES 32
 
 /** PCI vendor and device identifiers. */
 #define PCI_VENDOR_ID_SLAC 0x1a4a

--- a/data_gpu/driver/src/data_gpu_top.h
+++ b/data_gpu/driver/src/data_gpu_top.h
@@ -25,7 +25,7 @@
 #include <dma_common.h>
 
 /* Maximum number of DMA devices */
-#define MAX_DMA_DEVICES 4
+#define MAX_DMA_DEVICES 32
 
 /* PCI IDs */
 #define PCI_VENDOR_ID_SLAC 0x1a4a


### PR DESCRIPTION
### Description
- [Update data_dev_top.h: MAX_DMA_DEVICES from 4 to 32](https://github.com/slaclab/aes-stream-drivers/commit/e5e394f4e9670acfdf925c9453206ff433b3cb59)
- [Update data_gpu_top.h: MAX_DMA_DEVICES from 4 to 32](https://github.com/slaclab/aes-stream-drivers/commit/a7ac09b865847d15965ca216679b0224f935eccb)