### PR TITLE
adding more IOCTL for RX buffer diagnostics & whitespace removal

### DIFF
--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -824,6 +824,56 @@ ssize_t Dma_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
          return(dev->rxBuffers.count);
          break;
 
+      // Get rx buffer in User count
+      case DMA_Get_RxBuffinUser_Count:
+         userCnt    = 0;
+         for (x=dev->rxBuffers.baseIdx; x < (dev->rxBuffers.baseIdx + dev->rxBuffers.count); x++) {
+            buff = dmaGetBufferList(&(dev->rxBuffers),x);
+            if (  buff->userHas   ) userCnt++;
+         }
+         return(userCnt);
+         break;
+
+      // Get rx buffer in HW count
+      case DMA_Get_RxBuffinHW_Count:
+         hwCnt    = 0;
+         for (x=dev->rxBuffers.baseIdx; x < (dev->rxBuffers.baseIdx + dev->rxBuffers.count); x++) {
+            buff = dmaGetBufferList(&(dev->rxBuffers),x);
+            if ( buff->inHw &&  (!buff->inQ)   ) hwCnt++;
+         }
+         return(hwCnt);
+         break;
+
+      // Get rx buffer in Pre-HW Queue count
+      case DMA_Get_RxBuffinPreHWQ_Count:
+         hwQCnt    = 0;
+         for (x=dev->rxBuffers.baseIdx; x < (dev->rxBuffers.baseIdx + dev->rxBuffers.count); x++) {
+            buff = dmaGetBufferList(&(dev->rxBuffers),x);
+            if ( buff->inHw &&  buff->inQ   ) hwQCnt++;
+         }
+         return(hwQCnt);
+         break;
+
+      // Get rx buffer in SW Queue count
+      case DMA_Get_RxBuffinSWQ_Count:
+         qCnt    = 0;
+         for (x=dev->rxBuffers.baseIdx; x < (dev->rxBuffers.baseIdx + dev->rxBuffers.count); x++) {
+            buff = dmaGetBufferList(&(dev->rxBuffers),x);
+            if ( (!buff->inHw) &&  buff->inQ   ) qCnt++;
+         }
+         return(qCnt);
+         break;
+
+      // Get rx buffer missing count
+      case DMA_Get_RxBuffMiss_Count:
+         miss    = 0;
+         for (x=dev->rxBuffers.baseIdx; x < (dev->rxBuffers.baseIdx + dev->rxBuffers.count); x++) {
+            buff = dmaGetBufferList(&(dev->rxBuffers),x);
+            if ( (buff->userHas==NULL) && (buff->inHw==0) &&  (buff->inQ==0)   ) miss++;
+         }
+         return(miss);
+         break;
+
       // Get tx buffer count
       case DMA_Get_TxBuff_Count:
          return(dev->txBuffers.count);

--- a/include/DmaDriver.h
+++ b/include/DmaDriver.h
@@ -56,6 +56,11 @@
 #define DMA_Get_TxBuffinPreHWQ_Count 0x1011
 #define DMA_Get_TxBuffinSWQ_Count   0x1012
 #define DMA_Get_TxBuffMiss_Count    0x1013
+#define DMA_Get_RxBuffinUser_Count  0x1014
+#define DMA_Get_RxBuffinHW_Count    0x1015
+#define DMA_Get_RxBuffinPreHWQ_Count 0x1016
+#define DMA_Get_RxBuffinSWQ_Count   0x1017
+#define DMA_Get_RxBuffMiss_Count    0x1018
 
 /* Mask size */
 #define DMA_MASK_SIZE 512

--- a/rce_hp_buffers/driver/src/rce_hp.c
+++ b/rce_hp_buffers/driver/src/rce_hp.c
@@ -6,12 +6,12 @@
  * Author     : Ryan Herbst, rherbst@slac.stanford.edu
  * Created    : 2017-08-11
  * ----------------------------------------------------------------------------
- * This file is part of the aes_stream_drivers package. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the aes_stream_drivers package, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -42,8 +42,8 @@ void RceHp_Init(struct DmaDevice *dev) {
    reg = (struct RceHpReg *)dev->reg;
 
    // Clear Buffers
-   iowrite32(0x1,&(reg->bufferClear)); 
-   iowrite32(0x0,&(reg->bufferClear)); 
+   iowrite32(0x1,&(reg->bufferClear));
+   iowrite32(0x0,&(reg->bufferClear));
 
    // Set buffer size
    iowrite32(dev->cfgSize,&(reg->bufferSize));
@@ -51,7 +51,7 @@ void RceHp_Init(struct DmaDevice *dev) {
    // Push buffers to hardware
    for (x=dev->rxBuffers.baseIdx; x < (dev->rxBuffers.baseIdx + dev->rxBuffers.count); x++) {
       buff = dmaGetBufferList(&(dev->rxBuffers),x);
-      if ( dmaBufferToHw(buff) < 0 ) 
+      if ( dmaBufferToHw(buff) < 0 )
          dev_warn(dev->device,"Init: Failed to map dma buffer.\n");
       else iowrite32(buff->buffHandle,&(reg->bufferAlloc));
    }

--- a/rce_hp_buffers/driver/src/rce_top.c
+++ b/rce_hp_buffers/driver/src/rce_top.c
@@ -9,12 +9,12 @@
  * Description:
  * Top level module types and functions.
  * ----------------------------------------------------------------------------
- * This file is part of the aes_stream_drivers package. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the aes_stream_drivers package, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/

--- a/rce_memmap/driver/src/rce_map.c
+++ b/rce_memmap/driver/src/rce_map.c
@@ -9,12 +9,12 @@
  * Description:
  * Top level module types and functions.
  * ----------------------------------------------------------------------------
- * This file is part of the aes_stream_drivers package. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the aes_stream_drivers package, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -48,7 +48,7 @@ module_exit(Map_Exit);
 // Global device
 struct MapDevice dev;
 
-// Global variable for the device class 
+// Global variable for the device class
 struct class * gCl;
 
 // Define interface routines
@@ -106,7 +106,7 @@ int Map_Init(void) {
    if (cdev_add(&(dev.charDev), dev.devNum, 1) == -1) {
       printk(KERN_ERR MOD_NAME " Init: Failed to add device file.\n");
       return -1;
-   }                                  
+   }
 
    // Map initial space
    if ( (dev.maps = (struct MemMap *)kmalloc(sizeof(struct MemMap),GFP_KERNEL)) == NULL ) {
@@ -189,7 +189,7 @@ uint8_t * Map_Find(uint32_t addr) {
    while (cur != NULL) {
 
       // Current pointer matches
-      if ( (addr >= cur->addr) && (addr < (cur->addr + MAP_SIZE)) ) 
+      if ( (addr >= cur->addr) && (addr < (cur->addr + MAP_SIZE)) )
          return((uint8_t*)(cur->base + (addr-cur->addr)));
 
       // Next address is too high, insert new structure

--- a/rce_stream/driver/src/axis_gen1.c
+++ b/rce_stream/driver/src/axis_gen1.c
@@ -10,12 +10,12 @@
  * Description:
  * Access functions for Gen1 AXIS DMA
  * ----------------------------------------------------------------------------
- * This file is part of the aes_stream_drivers package. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the aes_stream_drivers package, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -69,8 +69,8 @@ irqreturn_t AxisG1_Irq(int irq, void *dev_id) {
             // Read handle
             if (((handle = ioread32(&(reg->txFree))) & 0x80000000) != 0 ) {
                handle &= 0x7FFFFFFC;
-              
-               if ( dev->debug > 0 ) 
+
+               if ( dev->debug > 0 )
                   dev_info(dev->device,"Irq: Return TX Status Value 0x%.8x.\n",handle);
 
                // Attempt to find buffer in tx pool and return. otherwise return rx entry to hw.
@@ -88,7 +88,7 @@ irqreturn_t AxisG1_Irq(int irq, void *dev_id) {
                handle &= 0x7FFFFFFC;
 
                // Read size
-               do { 
+               do {
                   size = ioread32(&(reg->rxPend));
                } while ((size & 0x80000000) == 0);
 
@@ -100,7 +100,7 @@ irqreturn_t AxisG1_Irq(int irq, void *dev_id) {
                else size &= 0xFFFFFF;
 
                // Get status
-               do { 
+               do {
                   status = ioread32(&(reg->rxPend));
                } while ((status & 0x80000000) == 0);
 
@@ -129,14 +129,14 @@ irqreturn_t AxisG1_Irq(int irq, void *dev_id) {
                      dev_info(dev->device,"Irq: DMA overflow error detected.\n");
                      buff->error |= DMA_ERR_LEN;
                   }
-               
+
                   if ( dev->debug > 0 ) {
                      dev_info(dev->device,"Irq: Rx size=%i, Dest=%i, Flags=0x%x, Error=0x%x.\n",
                         buff->size, buff->dest, buff->flags, buff->error);
                   }
 
                   // Lock mask records
-                  // This ensures close does not occur while irq routine is 
+                  // This ensures close does not occur while irq routine is
                   // pushing data to desc rx queue
                   spin_lock(&dev->maskLock);
 
@@ -181,12 +181,12 @@ void AxisG1_Init(struct DmaDevice *dev) {
    struct AxisG1Reg *reg;
    reg = (struct AxisG1Reg *)dev->reg;
 
-   // Set MAX RX                      
+   // Set MAX RX
    iowrite32(dev->cfgSize,&(reg->maxRxSize));
-                                      
-   // Clear FIFOs                     
-   iowrite32(0x1,&(reg->fifoClear)); 
-   iowrite32(0x0,&(reg->fifoClear)); 
+
+   // Clear FIFOs
+   iowrite32(0x1,&(reg->fifoClear));
+   iowrite32(0x0,&(reg->fifoClear));
 
    // Enable rx and tx
    iowrite32(0x1,&(reg->rxEnable));
@@ -195,7 +195,7 @@ void AxisG1_Init(struct DmaDevice *dev) {
    // Push RX buffers to hardware
    for (x=dev->rxBuffers.baseIdx; x < (dev->rxBuffers.baseIdx + dev->rxBuffers.count); x++) {
       buff = dmaGetBufferList(&(dev->rxBuffers),x);
-      if ( dmaBufferToHw(buff) < 0 ) 
+      if ( dmaBufferToHw(buff) < 0 )
          dev_warn(dev->device,"Init: Failed to map dma buffer.\n");
       else iowrite32(buff->buffHandle,&(reg->rxFree));
    }
@@ -305,7 +305,7 @@ int32_t AxisG1_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
          break;
 
       default:
-         dev_warn(dev->device,"Command: Invalid command=%i\n",cmd); 
+         dev_warn(dev->device,"Command: Invalid command=%i\n",cmd);
          return(-1);
          break;
    }


### PR DESCRIPTION
### Description
- [whitespace clean up](https://github.com/slaclab/aes-stream-drivers/commit/2d7b5fe40a061733844d253d17461df4e7dc9982)
- [adding more IOCTL for RX buffer diagnostics](https://github.com/slaclab/aes-stream-drivers/commit/148c872e471742a2d9e17721c12fee367311535e)