### PR TITLE
More sanity checks for comp_and_load_drivers.sh

### DIFF
--- a/data_gpu/driver/comp_and_load_drivers.sh
+++ b/data_gpu/driver/comp_and_load_drivers.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Provide defaults for CC
+[ -z "$CC" ] && CC=gcc
+
 # Function to check if the script is run with sudo
 check_sudo() {
     if [ "$EUID" -ne 0 ]; then
@@ -7,11 +10,12 @@ check_sudo() {
         exit 1
     fi
 }
-
-# Function to check if gcc-12 is installed
-check_gcc_12_installed() {
-    if ! command -v gcc-12 >/dev/null 2>&1; then
-        echo "Error: gcc-12 is not installed. Please install gcc-12 and try again." >&2
+# Checks that GCC matches what the kernel was built with
+check_gcc_version() {
+    _GCC_VER="$($CC --version | grep -Eo "\s[0-9]+\.[0-9]+\.[0-9]+\s" | awk '{$1=$1};1')"
+    if ! cat /proc/version | grep -Eoq "gcc version $_GCC_VER"; then
+        echo "Error: GCC version 'gcc version $_GCC_VER' does not match what the kernel was built with: '$(cat /proc/version | grep -Eo "gcc version [0-9]+\.[0-9]+\.[0-9]+")'"
+        echo "  You can specify an alternative compiler by setting the 'CC' environment variable"
         exit 1
     fi
 }
@@ -19,8 +23,8 @@ check_gcc_12_installed() {
 # Check if the script is run with sudo
 check_sudo
 
-# Call the gcc-12 check function early in the script to ensure it's available
-check_gcc_12_installed
+# Check that our GCC matches what the kernel was built with
+check_gcc_version
 
 # Function to find the latest Nvidia version directory
 get_latest_nvidia_path() {
@@ -57,9 +61,11 @@ echo "Using Nvidia path: $NVIDIA_PATH"
 
 cd $NVIDIA_PATH
 
-make CC=gcc-12
+make
 
-modprobe ecc || { echo "Error: Failed to insert ecc module."; exit 1; }
+if modinfo ecc >/dev/null 2>&1; then
+    modprobe ecc || { echo "Error: Failed to insert ecc module."; exit 1; }
+fi
 
 /usr/sbin/insmod nvidia.ko NVreg_OpenRmEnableUnsupportedGpus=1 NVreg_EnableStreamMemOPs=1 || { echo "Error: Failed to insert nvidia.ko."; exit 1; }
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

Added more sanity checks to comp_and_load_drivers.sh

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

* Ensure the compiler version we're building the NVIDIA drivers and datagpu with match what the kernel was built with.
* Don't enforce gcc-12, only enforce what the kernel was built with
* Only load the ecc module if it exists. On older kernels (i.e. RHEL7's 3.10.X), ecc doesn't exist and isn't needed by the nvidia driver. 

The script is a bit sloppy because I'm not great with bash :) 