### PR TITLE
Allocate non-coherent DMA pages in stream mode

### DIFF
--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -106,11 +106,11 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
 
       // Streaming buffer type, standard kernel memory
       else if ( list->dev->cfgMode & BUFF_STREAM ) {
-         buff->buffAddr = dma_alloc_coherent(list->dev->device, list->dev->cfgSize, &buff->buffHandle, GFP_KERNEL);
+         buff->buffAddr = dma_alloc_pages(list->dev->device, list->dev->cfgSize, &buff->buffHandle, direction, GFP_KERNEL);
 
          // Check for mapping error
          if (buff->buffAddr == NULL) {
-            dev_err(dev->device,"dmaAllocBuffers: dma_alloc_coherent failed\n");
+            dev_err(dev->device, "dmaAllocBuffers: dma_alloc_pages failed\n");
          }
       }
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

The previous fix allocated coherent (non-cachable) memory in stream mode, which may negatively affect performance.

### Details

Originally the code was doing `kzalloc` with `GFP_KERNEL` and passing the resulting pointer to `dma_map_single`. Then, it was changed to `dma_alloc_coherent`.

`dma_alloc_pages` will give us the non-coherent memory we want.
