### PR TITLE
Add missing include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 **/pgpcard.mod.c
 **/bin/*
 **/load
+
+compile_commands.json

--- a/include/DmaDriver.h
+++ b/include/DmaDriver.h
@@ -26,6 +26,7 @@
     #include <linux/types.h>
 #else
     #include <stdint.h>
+    #include <string>
 #endif
 
 /* API Version */


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

Just a quick fix for a build error in user code. `std::string` is now used in `dmaGetGitVersion`, but `<string>` was never included. It's a bit cumbersome to add `#include <string>` above every instance of `#include <DmaDriver.h>`