### PR TITLE
Bug fix for running with Linux Version 3

### DIFF
--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -121,7 +121,7 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
                dev_err(dev->device, "dmaAllocBuffers(BUFF_STREAM): DMA mapping failed\n");
             }
          } else {
-            // DMA mapping failed
+            // Memory allocation failed
             dev_err(list->dev->device, "dmaAllocBuffers(BUFF_STREAM): kmalloc Memory allocation failed\n");
          }
 #else

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -19,12 +19,14 @@
  * ----------------------------------------------------------------------------
 **/
 
-#include <dma_buffer.h>
 #include <asm/io.h>
 #include <linux/dma-mapping.h>
 #include <linux/sort.h>
 #include <linux/sched.h>
 #include <linux/slab.h>
+#include <linux/version.h>
+
+#include <dma_buffer.h>
 #include <dma_common.h>
 
 /**
@@ -106,12 +108,22 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
 
       // Streaming buffer type, standard kernel memory
       else if ( list->dev->cfgMode & BUFF_STREAM ) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
+         buff->buffAddr = kmalloc(list->dev->cfgSize, GFP_KERNEL);
+         if (buff->buffAddr != NULL) {
+            buff->buffHandle = dma_map_single(list->dev->device, buff->buffAddr, list->dev->cfgSize, direction);
+            // Check for mapping error
+            if ( dma_mapping_error(list->dev->device,buff->buffHandle) ) {
+               buff->buffHandle = 0;
+            }
+         }
+#else
          buff->buffAddr = dma_alloc_pages(list->dev->device, list->dev->cfgSize, &buff->buffHandle, direction, GFP_KERNEL);
-
          // Check for mapping error
          if (buff->buffAddr == NULL) {
             dev_err(dev->device, "dmaAllocBuffers: dma_alloc_pages failed\n");
          }
+#endif
       }
 
       // ACP type with permanent handle mapping, dma capable kernel memory

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -120,6 +120,9 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
                // DMA mapping failed
                dev_err(dev->device, "dmaAllocBuffers(BUFF_STREAM): DMA mapping failed\n");
             }
+         } else {
+            // DMA mapping failed
+            dev_err(list->dev->device, "dmaAllocBuffers(BUFF_STREAM): kmalloc Memory allocation failed\n");
          }
 #else
          buff->buffAddr = dma_alloc_pages(list->dev->device, list->dev->cfgSize, &buff->buffHandle, direction, GFP_KERNEL);

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -114,14 +114,18 @@ size_t dmaAllocBuffers ( struct DmaDevice *dev, struct DmaBufferList *list,
             buff->buffHandle = dma_map_single(list->dev->device, buff->buffAddr, list->dev->cfgSize, direction);
             // Check for mapping error
             if ( dma_mapping_error(list->dev->device,buff->buffHandle) ) {
+               // DMA mapping was successful 
                buff->buffHandle = 0;
+            } else {
+               // DMA mapping failed
+               dev_err(dev->device, "dmaAllocBuffers(BUFF_STREAM): DMA mapping failed\n");
             }
          }
 #else
          buff->buffAddr = dma_alloc_pages(list->dev->device, list->dev->cfgSize, &buff->buffHandle, direction, GFP_KERNEL);
          // Check for mapping error
          if (buff->buffAddr == NULL) {
-            dev_err(dev->device, "dmaAllocBuffers: dma_alloc_pages failed\n");
+            dev_err(dev->device, "dmaAllocBuffers(BUFF_STREAM): dma_alloc_pages failed\n");
          }
 #endif
       }


### PR DESCRIPTION
### Description
- casing on kernel version to determine if dma_alloc_pages existed yet
- Identical behavior before we started to update for security and vulnerabilities: 
  - https://github.com/slaclab/aes-stream-drivers/blob/716df20ecb09a1419de7402f9458288084b464be/common/driver/dma_buffer.c#L96-L104