### PR TITLE
comp_and_load_drivers.sh: Adding make clean to nvidia build

### DIFF
--- a/data_gpu/driver/comp_and_load_drivers.sh
+++ b/data_gpu/driver/comp_and_load_drivers.sh
@@ -54,7 +54,7 @@ cd "$NVIDIA_PATH" || { echo "Error: Failed to change directory to $NVIDIA_PATH";
 # Clean previous builds
 make clean
 # Build Nvidia driver
-make CC=$CC
+make CC=$CC -j $(nproc)
 
 if modinfo ecc >/dev/null 2>&1; then
     modprobe ecc || { echo "Error: Failed to insert ecc module."; exit 1; }

--- a/data_gpu/driver/comp_and_load_drivers.sh
+++ b/data_gpu/driver/comp_and_load_drivers.sh
@@ -51,6 +51,9 @@ echo "Using RET_DIR: $RET_DIR"
 
 # Go to nvidia path and build Nvidia driver
 cd "$NVIDIA_PATH" || { echo "Error: Failed to change directory to $NVIDIA_PATH"; exit 1; }
+# Clean previous builds
+make clean
+# Build Nvidia driver
 make CC=$CC
 
 if modinfo ecc >/dev/null 2>&1; then


### PR DESCRIPTION
### Description
- adding make clean before make incase the previous build using older kernel prior to reboot
- [adding parallel build suport](https://github.com/slaclab/aes-stream-drivers/pull/154/commits/f989577752c01836ffa52a3cb55d0b5ed8cc5221)