### PR TITLE
Fix kernel panic on device removal

### DIFF
--- a/data_gpu/driver/src/data_gpu_top.c
+++ b/data_gpu/driver/src/data_gpu_top.c
@@ -310,11 +310,11 @@ void DataGpu_Remove(struct pci_dev *pcidev) {
    /* Decrement the global count of DMA devices. */
    gDmaDevCount--;
 
-   /* Disable the PCI device to prevent further access. */
-   pci_disable_device(pcidev);
-
    /* Clean up DMA resources specific to this device. */
    Dma_Clean(dev);
+
+   /* Disable the PCI device to prevent further access. */
+   pci_disable_device(pcidev);
 
    /* Log the successful removal of the device. */
    pr_info("%s: Remove: Driver is unloaded.\n", MOD_NAME);


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

`Dma_Clean` must be called to unregister IRQs before calling `pci_disable_device`.

### Details

This matches the behavior in data_dev.
