### PR TITLE
Update rce_top.c

### DIFF
--- a/rce_stream/driver/src/rce_top.c
+++ b/rce_stream/driver/src/rce_top.c
@@ -30,7 +30,11 @@
 #include <linux/of_platform.h>
 #include <linux/of_address.h>
 #include <linux/of_irq.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
 #include <linux/dma-map-ops.h>
+#endif
 
 // Init Configuration values
 int cfgTxCount0 = 8;


### PR DESCRIPTION
### Description
- Related to #89
  - Adding support for kernel 5.15
- But this change was not backwards compatible with older kernels
