### PR TITLE
Move 'DMA mapping failed' print to the failure handling case of the c…

### DIFF
--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -113,11 +113,9 @@ size_t dmaAllocBuffers(struct DmaDevice *dev, struct DmaBufferList *list,
             buff->buffHandle = dma_map_single(list->dev->device, buff->buffAddr, list->dev->cfgSize, direction);
             // Check for mapping error
             if ( dma_mapping_error(list->dev->device, buff->buffHandle) ) {
-               // DMA mapping was successful
-               buff->buffHandle = 0;
-            } else {
                // DMA mapping failed
                dev_err(dev->device, "dmaAllocBuffers(BUFF_STREAM): DMA mapping failed\n");
+               buff->buffHandle = 0;
             }
          } else {
             // Memory allocation failed


### PR DESCRIPTION
…onditional

<!--- Provide a one sentence summary of your changes in the Title above -->
Printing of 'DMA mapping failed' was being done when dma_mapping_error() returned false instead of when it returned true.

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
The change was to move the 'DMA mapping failed' print to the case when dma_mapping_error() returned true.  This avoids this print appearing for each DMA buffer registered in dmesg output and in /var/log/messages.
