### PR TITLE
Adjust dkms configuration to support building datagpu against nvidia drivers

### DIFF
--- a/data_gpu/driver/Makefile
+++ b/data_gpu/driver/Makefile
@@ -13,8 +13,15 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
+-include Makefile.local
+
 # Args to this Makefile
-NVIDIA_DRIVERS ?= ""
+ifeq ($(NVIDIA_DRIVERS),)
+$(error NVIDIA_DRIVERS is not set, please generate Makefile.local using build-nvidia.sh, or supply NVIDIA_DRIVERS on the command line)
+endif
+
+$(info Using NVIDIA_DRIVERS=$(NVIDIA_DRIVERS))
+
 CC ?= ""
 
 # Define the module name.

--- a/data_gpu/driver/build-nvidia.sh
+++ b/data_gpu/driver/build-nvidia.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -e
+
+while test $# -gt 0; do
+	case $1 in
+	-v)
+		VERSION="$2"
+		shift 2;
+		;;
+	-s)
+		SRCTREE="$2"
+		shift 2;
+		;;
+	*)
+		echo "USAGE: $0 -s src_tree -v kver"
+		exit 1
+		;;
+	esac
+done
+
+if [ $EUID -ne 0 ]; then
+    echo "This script must be run as root!"
+    exit 1
+fi
+
+if [ -z "$VERSION" ] || [ -z "$SRCTREE" ]; then
+	echo "USAGE: $0 -s src_tree -v kver"
+	exit 1
+fi
+
+# Determine the NVIDIA module version installed for this kernel
+NVIDIA_VER=$(dkms status nvidia -k $VERSION | tr '/' '-' | awk -F, '{ print $1 }')
+
+# Generate a local Makefile that contains the configuration
+echo "NVIDIA_DRIVERS=$SRCTREE/$NVIDIA_VER" > Makefile.local
+
+echo "--> Building NVIDIA drivers version $NVIDIA_VER"
+
+make -C "$SRCTREE/$NVIDIA_VER" -j$(nproc)
+

--- a/data_gpu/driver/dkms.conf
+++ b/data_gpu/driver/dkms.conf
@@ -1,9 +1,12 @@
-MAKE="make"
+PRE_BUILD="./build-nvidia.sh -s $source_tree -v $kernelver"
 CLEAN="make clean"
+MAKE="make"
 BUILT_MODULE_NAME=datagpu
 BUILT_MODULE_LOCATION=.
-DEST_MODULE_LOCATION="/updates"
+DEST_MODULE_LOCATION="/kernel/modules/misc"
 PACKAGE_NAME=datagpu-dkms
 REMAKE_INITRD=no
 AUTOINSTALL="yes"
+BUILD_DEPENDS="nvidia"
+NO_WEAK_MODULES="yes"
 #PACKAGE_VERSION=


### PR DESCRIPTION

<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

This PR provides a working dkms configuration for the datagpu driver.

### Details

dkms doesn't really support dependencies properly, so we still need to build the nvidia drivers manually. 

The `build-nvidia.sh` script is run before the build starts, and that takes care of building the nvidia drivers. This script will also generate Makefile.local which defines NVIDIA_DRIVERS.

Makefile.local is optional and only used to communicate the location of the nvidia drivers. I could also avoid this by copying the `NVIDIA_DRIVERS` logic into the Makefile, but I wanted to avoid duplication.

`BUILD_DEPENDS` only declares a sort of "soft" dependency on the nvidia module. This dkms will fail during build if the nvidia drivers are not installed, since dkms will silently ignore `BUILD_DEPENDS` in that case.

This was tested locally by running `dkms install`, then fixing the broken symlinks in `src/` and running `dkms build`. 