### PR TITLE
Fix cfgMode=1 (`BUFF_COHERENT` mode)

### DIFF
--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -1174,15 +1174,14 @@ int Dma_Mmap(struct file *filp, struct vm_area_struct *vma) {
          // Mark the user pages as uncache-minus. io_remap_pfn_range will not do this for us, even though
          //  we ask for coherent memory.
          if ((ret = set_memory_uc((uintptr_t)buff->buffAddr, vsize >> PAGE_SHIFT)) == 0) {
-            ret = io_remap_pfn_range(vma, vma->vm_start, virt_to_phys((void*)buff->buffAddr) >> PAGE_SHIFT, 
+            ret = io_remap_pfn_range(vma, vma->vm_start, virt_to_phys((void*)buff->buffAddr) >> PAGE_SHIFT,
                                      vsize, pgprot_noncached(vma->vm_page_prot));
 
             // Track this region so we can restore the previous protection flags when it's unmapped
             vma->vm_ops = &DmaVmOps;
             vma->vm_private_data = buff->buffAddr;
-         }
-         else {
-            dev_warn(dev->device, 
+         } else {
+            dev_warn(dev->device,
                "map: Failed to set virtual memory range as uncache-minus start 0x%.8lx, end 0x%.8lx, offset %li, size %li, index %i, Ret=%i\n",
                vma->vm_start, vma->vm_end, offset, vsize, idx, ret);
          }
@@ -1235,7 +1234,7 @@ int Dma_Mmap(struct file *filp, struct vm_area_struct *vma) {
  * @vma: Virtual memory area to unmap
  * 
  * The primary purpose of this is to restore the write-back protection mode
- * before returning the page(s) to the free pool. In Dma_Mmap, we set 
+ * before returning the page(s) to the free pool. In Dma_Mmap, we set
  * the uncache-minus flag (UC-) on the user pages.
  *
  * Return: None.

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -223,5 +223,6 @@ int Dma_SeqShow(struct seq_file *s, void *v);
 int Dma_SetMaskBytes(struct DmaDevice *dev, struct DmaDesc *desc, uint8_t * mask);
 int32_t Dma_WriteRegister(struct DmaDevice *dev, uint64_t arg);
 int32_t Dma_ReadRegister(struct DmaDevice *dev, uint64_t arg);
+void Dma_UnMapMem(struct vm_area_struct * area);
 
 #endif  // __DMA_COMMON_H__


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

Fix cfgMode=1 uncache-minus/write-back memory mismatch.

Added -n flag to comp_and_load_drivers.sh to skip rebuild of the NVIDIA drivers.

### Details

`dmaMapDma` uses `mmap` to map user space memory to DMA memory. In `Dma_Mmap`, we are using `dma_mmap_coherent`/`io_remap_pfn_range` to map the user pages to DMA memory. These functions will not touch the protection flags of the user pages (which are write-back by default), leading to the mismatch in protection flags and the warnings.

We need to mark the user pages as uncache-minus (in x86 terminology) using `set_memory_uc`, and mark them as write-back using `set_memory_wb` before they're freed.

It may also be possible to solve this issue in user-space using the `MAP_SYNC` flag with `mmap`. However, `MAP_SYNC` is only available in Linux 4.15 and later.

The [Linux x86 PAT (Page attribute table) docs](https://www.kernel.org/doc/Documentation/x86/pat.txt) say:

> ...
> Drivers wanting to export some pages to userspace do it by using mmap
> interface and a combination of
> 1) pgprot_noncached()
> 2) io_remap_pfn_range() or remap_pfn_range() or vmf_insert_pfn()
> 
> ...
> Note that this set of APIs only works with IO (non RAM) regions. **If driver
> wants to export a RAM region, it has to do set_memory_uc() or set_memory_wc()
> as step 0 above and also track the usage of those pages and use set_memory_wb()
> before the page is freed to free pool.**

Needs testing on ARM, so far I have only tested on daq-tst-dev06 with kernel 3.10

The issue can be reproduced on aes-stream-drivers v6.4.0 with [this code](https://gist.github.com/JJL772/5a2816fd2fd2b32dbd9c6d110979218e)

### Related

Closes #168 