### PR TITLE
Fix warning

### DIFF
--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -223,5 +223,6 @@ int Dma_SeqShow(struct seq_file *s, void *v);
 int Dma_SetMaskBytes(struct DmaDevice *dev, struct DmaDesc *desc, uint8_t * mask);
 int32_t Dma_WriteRegister(struct DmaDevice *dev, uint64_t arg);
 int32_t Dma_ReadRegister(struct DmaDevice *dev, uint64_t arg);
+void Dma_UnmapReg(struct DmaDevice *dev);
 
 #endif  // __DMA_COMMON_H__


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

Fixes that 'no prototype' warning from `Dma_UnmapReg`