### PR TITLE
Fix kernel version checks for RHEL9

### DIFF
--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -29,6 +29,10 @@
 #include <linux/version.h>
 #include <linux/slab.h>
 
+#ifndef RHEL_RELEASE_VERSION
+#define RHEL_RELEASE_VERSION(...) 0
+#endif
+
 /**
  * struct DmaFunctions - Define interface routines for DMA operations
  * @owner:          Pointer to the module owner of this structure
@@ -242,10 +246,11 @@ int Dma_Init(struct DmaDevice *dev) {
    if (gCl == NULL) {
       dev_info(dev->device, "Init: Creating device class\n");
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-      gCl = class_create(THIS_MODULE, dev->devName);
-#else
+      // RHEL9.4+ backported this breaking change from kernel 6.4.0
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
       gCl = class_create(dev->devName);
+#else
+      gCl = class_create(THIS_MODULE, dev->devName);
 #endif
 
       if (gCl == NULL) {
@@ -1230,7 +1235,8 @@ int Dma_ProcOpen(struct inode *inode, struct file *file) {
    struct seq_file *sf;
    struct DmaDevice *dev;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
+   // PDE_DATA removed in kernel 5.17, backported to RHEL 9.X (9.1 is a guess here, please change if not accurate)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0) || (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 1))
    dev = (struct DmaDevice *)pde_data(inode);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 10, 0)
    dev = (struct DmaDevice *)PDE_DATA(inode);


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

RedHat has been inexplicably cherry-picking breaking changes from later kernel versions. Unfortunately this means that `KERNEL_VERSION_CODE` checks are insufficient to ensure compatibility in some cases, and we need to check if we're building for RHEL 9.X.

Since I do not have easy access to the RHEL 9 kernel Git history, I don't know when they cherry-picked the `PDE_DATA` commit (hence the guess of RHEL 9.1)

Relevant Linux commits that they cherry picked:
- [Remove PDE Data](https://github.com/torvalds/linux/commit/359745d78351c6f5442435f81549f0207ece28aa) First appears in kernel v5.17-rc1
- [Remove module* parameter from class_create](https://github.com/torvalds/linux/commit/1aaba11da9aa7d7d6b52a74d45b31cac118295a1) First appears in kernel v6.4-rc1


Tested the build on rocky 9.4 and Debian with kernel 6.12.3