### PR TITLE
Corrected buffer offset address to align it with the firmware in AxiPcieGpuAsyncControl.vhd

### DIFF
--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -171,8 +171,8 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
          // Update buffer count and write DMA addresses to device
          if (buffer->write) {
             writel(buffer->dmaMapping->dma_addresses[0] & 0xFFFFFFFF, data->base+0x100+data->writeBuffers.count*16);
-            writel((buffer->dmaMapping->dma_addresses[0] >> 32) & 0xFFFFFFFF, data->base+0x104+data->writeBuffers.count*16); 
-            writel(mapSize - BUFFER_OFFSET, data->base+0x108+data->writeBuffers.count*16); // subtracted BUFFER_OFFSET to align the mapSize with maxSize in firmware
+            writel((buffer->dmaMapping->dma_addresses[0] >> 32) & 0xFFFFFFFF, data->base+0x104+data->writeBuffers.count*16);
+            writel(mapSize - BUFFER_OFFSET, data->base+0x108+data->writeBuffers.count*16);  // Subtracted BUFFER_OFFSET to align the mapSize with maxSize in firmware
             data->writeBuffers.count++;
          } else {
             writel(buffer->dmaMapping->dma_addresses[0] & 0xFFFFFFFF, data->base+0x200+data->readBuffers.count*16);

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -172,7 +172,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
          if (buffer->write) {
             writel(buffer->dmaMapping->dma_addresses[0] & 0xFFFFFFFF, data->base+0x100+data->writeBuffers.count*16);
             writel((buffer->dmaMapping->dma_addresses[0] >> 32) & 0xFFFFFFFF, data->base+0x104+data->writeBuffers.count*16);
-            writel(mapSize, data->base+0x108+data->writeBuffers.count*16);
+            writel(mapSize - BUFFER_OFFSET, data->base+0x108+data->writeBuffers.count*16);
             data->writeBuffers.count++;
          } else {
             writel(buffer->dmaMapping->dma_addresses[0] & 0xFFFFFFFF, data->base+0x200+data->readBuffers.count*16);

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -171,8 +171,8 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
          // Update buffer count and write DMA addresses to device
          if (buffer->write) {
             writel(buffer->dmaMapping->dma_addresses[0] & 0xFFFFFFFF, data->base+0x100+data->writeBuffers.count*16);
-            writel((buffer->dmaMapping->dma_addresses[0] >> 32) & 0xFFFFFFFF, data->base+0x104+data->writeBuffers.count*16);
-            writel(mapSize - BUFFER_OFFSET, data->base+0x108+data->writeBuffers.count*16);
+            writel((buffer->dmaMapping->dma_addresses[0] >> 32) & 0xFFFFFFFF, data->base+0x104+data->writeBuffers.count*16); 
+            writel(mapSize - BUFFER_OFFSET, data->base+0x108+data->writeBuffers.count*16); // subtracted BUFFER_OFFSET to align the mapSize with maxSize in firmware
             data->writeBuffers.count++;
          } else {
             writel(buffer->dmaMapping->dma_addresses[0] & 0xFFFFFFFF, data->base+0x200+data->readBuffers.count*16);

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -47,7 +47,7 @@
 /**
  * BUFFER_OFFSET_SHIFT - Shift for buffer offset address boundary
  */
-#define BUFFER_OFFSET_SHIFT   8
+#define BUFFER_OFFSET_SHIFT   5
 
 /**
  * BUFFER_OFFSET_SIZE - Size of buffer offset boundary

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -57,7 +57,7 @@
 /**
  * BUFFER_OFFSET - Offset for setting correct buffer size (maxSize)
  */
-#define BUFFER_OFFSET  (BUFFER_OFFSET_SIZE - 1)
+#define BUFFER_OFFSET  (BUFFER_OFFSET_SIZE)
 
 /**
  * MAX_GPU_BUFFERS - Maximum number of GPU buffers allowed

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -45,6 +45,21 @@
 #define GPU_BOUND_MASK    (~GPU_BOUND_OFFSET)
 
 /**
+ * BUFFER_OFFSET_SHIFT - Shift for buffer offset address boundary
+ */
+#define BUFFER_OFFSET_SHIFT   8
+
+/**
+ * BUFFER_OFFSET_SIZE - Size of buffer offset boundary
+ */
+#define BUFFER_OFFSET_SIZE    ((u64)1 << BUFFER_OFFSET_SHIFT)
+
+/**
+ * BUFFER_OFFSET - Offset for setting correct buffer size (maxSize)
+ */
+#define BUFFER_OFFSET  (BUFFER_OFFSET_SIZE - 1)
+
+/**
  * MAX_GPU_BUFFERS - Maximum number of GPU buffers allowed
  */
 #define MAX_GPU_BUFFERS   16


### PR DESCRIPTION
### Description
Added the correct offset to be subtracted from the 'mapSize' to align the 'mapSize' with 'maxSize' in firmware: https://github.com/slaclab/axi-pcie-core/blob/main/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd#L299

### Details
Because the DATA_BYTE_C (32 bytes) is added to the descriptor address here: https://github.com/slaclab/axi-pcie-core/blob/main/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd#L307,
we should subtract the same offset when we set the 'maxSize': https://github.com/slaclab/axi-pcie-core/blob/main/protocol/gpuAsync/rtl/AxiPcieGpuAsyncControl.vhd#L299