### PR TITLE
migrating CI from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/aes_ci.yml
+++ b/.github/workflows/aes_ci.yml
@@ -19,7 +19,7 @@ jobs:
 # ----------------------------------------------------------------------------
   test_and_document:
     name: Test And Generate Documentation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
       # This step checks out a copy of your repository.
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install dependencies
         run: |
@@ -57,8 +57,8 @@ jobs:
     strategy:
       fail-fast: false # I want to see all build errors
       matrix:
-        container: [ "ubuntu:22.04", "rockylinux:9", "debian:experimental", "ghcr.io/jjl772/centos7-vault" ]
-    runs-on: ubuntu-22.04
+        container: [ "ubuntu:22.04", "ubuntu:24.04", "rockylinux:9", "debian:experimental", "ghcr.io/jjl772/centos7-vault" ]
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     steps:
       # FIXME: using checkout@v1 due to nodejs version issues in centos7
@@ -113,7 +113,7 @@ jobs:
   generate_dkms:
     name: Generate DKMS
     needs: [gen_release]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
@@ -129,7 +129,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Description
- The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025
- But while I am at upgrading all the Github workflows, we might as well upgrade this 22.04 to 24.04 as well
