### PR TITLE
Add 'GPU Async En' flag to /proc/ interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,11 @@ Contains shared kernel and application libraries
 
 #### data_dev/
 
-Contains driver and application code for TID-AIR generic DAQ PCIe cards
+Contains driver and application code for TID-AIR generic DAQ PCIe cards, optionally with GPUDirect RDMA support (for use with NVIDIA GPUs)
 
 /etc/modprobe.d/datadev.conf
 
 options datadev cfgTxCount=1024 cfgRxCount=1024 cfgSize=131072 cfgMode=1 cfgCont=1
-
-#### data_gpu/
-
-Contains driver and application code for TID-AIR generic DAQ PCIe cards with DirectGPU Async Support
-
-/etc/modprobe.d/datagpu.conf
-
-options datagpu cfgTxCount=1024 cfgRxCount=1024 cfgSize=131072 cfgMode=1 cfgCont=1
 
 #### include/
 

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -816,6 +816,7 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
    seq_printf(s, "      Driver Load Count : %u\n", ((readl(&(reg->enableVer)))>>8)&0xFF);
    seq_printf(s, "               IRQ Hold : %u\n", (readl(&(reg->irqHoldOff))));
    seq_printf(s, "              BG Enable : 0x%x\n", hwData->bgEnable);
+   seq_printf(s, "           GPU Async En : %i\n", dev->gpuEn);
 
    for ( x=0; x < 8; x++ ) {
       if ( (hwData->bgEnable >> x) & 0x1 ) {


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

Apparently I forgot to add an explicit "GPU is enabled/disabled" flag to /proc/. You could still tell if the fw supports gpu-async or not depending on if the "GPU Async" section is displayed. This just makes it more explicit.