### PR TITLE
Misc fixes

### DIFF
--- a/common/driver/axi_version.c
+++ b/common/driver/axi_version.c
@@ -39,7 +39,7 @@
  */
 int32_t AxiVersion_Get(struct DmaDevice *dev, void *base, uint64_t arg) {
    struct AxiVersion axiVersion;
-   int32_t ret;
+   uint64_t ret;
 
    // Read the AXI version from the device
    AxiVersion_Read(dev, base, &axiVersion);

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -292,7 +292,7 @@ int Dma_Init(struct DmaDevice *dev) {
    dev_info(dev->device, "Init: Creating %i TX Buffers. Size=%i Bytes. Mode=%i.\n",
         dev->cfgTxCount, dev->cfgSize, dev->cfgMode);
    res = dmaAllocBuffers(dev, &(dev->txBuffers), dev->cfgTxCount, 0, DMA_TO_DEVICE);
-   tot = res * dev->cfgSize;
+   tot = (uint64_t)res * dev->cfgSize;
 
    dev_info(dev->device, "Init: Created  %i out of %i TX Buffers. %llu Bytes.\n", res, dev->cfgTxCount, tot);
 
@@ -315,7 +315,7 @@ int Dma_Init(struct DmaDevice *dev) {
    dev_info(dev->device, "Init: Creating %i RX Buffers. Size=%i Bytes. Mode=%i.\n",
         dev->cfgRxCount, dev->cfgSize, dev->cfgMode);
    res = dmaAllocBuffers(dev, &(dev->rxBuffers), dev->cfgRxCount, dev->txBuffers.count, DMA_BIDIRECTIONAL);
-   tot = res * dev->cfgSize;
+   tot = (uint64_t)res * dev->cfgSize;
 
    dev_info(dev->device, "Init: Created  %i out of %i RX Buffers. %llu Bytes.\n", res, dev->cfgRxCount, tot);
 
@@ -1176,7 +1176,7 @@ int Dma_Mmap(struct file *filp, struct vm_area_struct *vma) {
       return ret;
    } else {
       // Map register space
-      base = dev->cfgSize * (dev->rxBuffers.count + dev->txBuffers.count);
+      base = (off_t)dev->cfgSize * (dev->rxBuffers.count + dev->txBuffers.count);
       relMap = offset - base;
       physical = dev->baseAddr + relMap;
 

--- a/data_dev/app/src/dmaRate.cpp
+++ b/data_dev/app/src/dmaRate.cpp
@@ -53,8 +53,8 @@ static char doc[] = "";
 #define STRING(N) #N
 #define XSTRING(N) STRING(N)
 static struct argp_option options[] = {
-   {"path", 'p', "PATH", OPTION_ARG_OPTIONAL, "Path of datadev device. Default=" DEF_DEV_PATH, 0},
-   {"count", 'c', "COUNT", OPTION_ARG_OPTIONAL, "Total iterations. Default=" XSTRING(DEF_COUNT), 0},
+   {"path", 'p', "PATH", 0, "Path of datadev device. Default=" DEF_DEV_PATH, 0},
+   {"count", 'c', "COUNT", 0, "Total iterations. Default=" XSTRING(DEF_COUNT), 0},
    {0}
 };
 

--- a/data_dev/app/src/dmaWrite.cpp
+++ b/data_dev/app/src/dmaWrite.cpp
@@ -55,11 +55,11 @@ static char doc[] = "Dest is passed as an integer.";
 
 // Options structure
 static struct argp_option options[] = {
-   { "path",    'p', "PATH",   OPTION_ARG_OPTIONAL, "Path of datadev device to use. Default=/dev/datadev_0.", 0 },
-   { "prbsdis", 'd', 0,        OPTION_ARG_OPTIONAL, "Disable PRBS generation.", 0 },
-   { "size",    's', "SIZE",   OPTION_ARG_OPTIONAL, "Size of data to generate. Default=1000", 0 },
-   { "count",   'c', "COUNT",  OPTION_ARG_OPTIONAL, "Number of frames to generate. Default=1", 0 },
-   { "indexen", 'i', 0,        OPTION_ARG_OPTIONAL, "Use index based transmit buffers.", 0 },
+   { "path",    'p', "PATH",   0, "Path of datadev device to use. Default=/dev/datadev_0.", 0 },
+   { "prbsdis", 'd', 0,        0, "Disable PRBS generation.", 0 },
+   { "size",    's', "SIZE",   0, "Size of data to generate. Default=1000", 0 },
+   { "count",   'c', "COUNT",  0, "Number of frames to generate. Default=1", 0 },
+   { "indexen", 'i', 0,        0, "Use index based transmit buffers.", 0 },
    { 0 }
 };
 

--- a/data_dev/app/src/setDebug.cpp
+++ b/data_dev/app/src/setDebug.cpp
@@ -51,7 +51,7 @@ static char doc[] = "\n   Debug level is either 0 or 1.";
 
 // Option descriptions
 static struct argp_option options[] = {
-   { "path", 'p', "PATH", OPTION_ARG_OPTIONAL, "Path of datadev device to use. Default=/dev/datadev_0.", 0 },
+   { "path", 'p', "PATH", 0, "Path of datadev device to use. Default=/dev/datadev_0.", 0 },
    { 0 }
 };
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

* Fix some misc type conversion issues
* Fix option parsing in the datadev app utils. `OPTION_ARG_OPTIONAL` apparently tells argp to treat the option's value as optional, not the option itself. It also tweaks the option parsing in such a way that it breaks.