### PR TITLE
Buffer size correction removed

### DIFF
--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -185,7 +185,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
          if (buffer->write) {
             writel(buffer->dmaMapping->dma_addresses[0] & 0xFFFFFFFF, data->base+0x100+data->writeBuffers.count*16);
             writel((buffer->dmaMapping->dma_addresses[0] >> 32) & 0xFFFFFFFF, data->base+0x104+data->writeBuffers.count*16);
-            writel(mapSize, data->base+0x108+data->writeBuffers.count*16); 
+            writel(mapSize, data->base+0x108+data->writeBuffers.count*16);
             data->writeBuffers.count++;
          } else {
             writel(buffer->dmaMapping->dma_addresses[0] & 0xFFFFFFFF, data->base+0x200+data->readBuffers.count*16);

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -185,7 +185,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
          if (buffer->write) {
             writel(buffer->dmaMapping->dma_addresses[0] & 0xFFFFFFFF, data->base+0x100+data->writeBuffers.count*16);
             writel((buffer->dmaMapping->dma_addresses[0] >> 32) & 0xFFFFFFFF, data->base+0x104+data->writeBuffers.count*16);
-            writel(mapSize - BUFFER_OFFSET, data->base+0x108+data->writeBuffers.count*16);  // Subtracted BUFFER_OFFSET to align the mapSize with maxSize in firmware
+            writel(mapSize, data->base+0x108+data->writeBuffers.count*16); 
             data->writeBuffers.count++;
          } else {
             writel(buffer->dmaMapping->dma_addresses[0] & 0xFFFFFFFF, data->base+0x200+data->readBuffers.count*16);

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -45,21 +45,6 @@
 #define GPU_BOUND_MASK    (~GPU_BOUND_OFFSET)
 
 /**
- * BUFFER_OFFSET_SHIFT - Shift for buffer offset address boundary
- */
-#define BUFFER_OFFSET_SHIFT   5
-
-/**
- * BUFFER_OFFSET_SIZE - Size of buffer offset boundary
- */
-#define BUFFER_OFFSET_SIZE    ((u64)1 << BUFFER_OFFSET_SHIFT)
-
-/**
- * BUFFER_OFFSET - Offset for setting correct buffer size (maxSize)
- */
-#define BUFFER_OFFSET  (BUFFER_OFFSET_SIZE)
-
-/**
  * MAX_GPU_BUFFERS - Maximum number of GPU buffers allowed
  */
 #define MAX_GPU_BUFFERS   16


### PR DESCRIPTION
Buffer size correction removed from the driver; it is now corrected in the firmware

### Description
Previously, the buffer size was subtracted by an offset to cancel out the addition by the same value in the firmware. Now the correction is made to the firmware, so no need to do it here.
