### PR TITLE
Bump DMA_VERSION to 7

### DIFF
--- a/include/DmaDriver.h
+++ b/include/DmaDriver.h
@@ -31,7 +31,7 @@
 #endif
 
 /* API Version */
-#define DMA_VERSION 0x06
+#define DMA_VERSION 0x07
 
 /* Error values */
 #define DMA_ERR_FIFO 0x01


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

Per @slacrherbst's request, bumping DMA version to 7 due to API changes in #195 

This will correspond to release v7.0.0 of aes-stream-drivers.
