### PR TITLE
Report error if the PCI device is missing an IRQ

### DIFF
--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -251,6 +251,13 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    // Assign the IRQ number from the pci_dev structure
    dev->irq = pcidev->irq;
 
+   // Check that we actually have an IRQ
+   if (dev->irq == 0) {
+      pr_err("%s: No IRQ associated with PCI device\n", MOD_NAME);
+      probeReturn = -EINVAL;
+      goto err_post_en;
+   }
+
    // Set basic device context
    dev->pcidev = pcidev;          // PCI device structure
    dev->device = &(pcidev->dev);  // Device structure


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

Report an error and return failure in `DataDev_Probe` if the PCIE device is missing an IRQ.

@ruck314 is it ever valid to have a device without an associated IRQ? If so, this can be made into a warning.

### JIRA

https://jira.slac.stanford.edu/browse/ESROGUE-713