### PR TITLE
adding PCIe[BUS:NUM:SLOT:FUNC] to the proc messages

### DIFF
--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -443,7 +443,6 @@ void DataDev_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
       Gpu_Show(s, dev);
    }
 #endif
-
 }
 
 /**

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -417,6 +417,16 @@ int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
  */
 void DataDev_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
    struct AxiVersion aVer;
+   struct pci_dev *pdev = dev->pcidev;
+
+   // Show PCI Bus-Device-Function
+   if (pdev) {
+      seq_printf(s, "PCIe[BUS:NUM:SLOT:FUNC] : %04x:%02x:%02x.%x\n",
+                  pci_domain_nr(pdev->bus),
+                  pdev->bus->number,
+                  PCI_SLOT(pdev->devfn),
+                  PCI_FUNC(pdev->devfn));
+   }
 
    // Read AXI version from device
    AxiVersion_Read(dev, dev->base + AVER_OFF, &aVer);
@@ -433,6 +443,7 @@ void DataDev_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
       Gpu_Show(s, dev);
    }
 #endif
+
 }
 
 /**

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -421,7 +421,7 @@ void DataDev_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
 
    // Show PCI Bus-Device-Function
    if (pdev) {
-      seq_printf(s, "PCIe[BUS:NUM:SLOT:FUNC] : %04x:%02x:%02x.%x\n",
+      seq_printf(s, "PCIe[BUS:NUM:SLOT.FUNC] : %04x:%02x:%02x.%x\n",
                   pci_domain_nr(pdev->bus),
                   pdev->bus->number,
                   PCI_SLOT(pdev->devfn),


### PR DESCRIPTION
### Description
- This provides information needed at the userspace for doing the re-scan of the PCIe if the link is lost due to a reprogramming/reboot of the FPGA
- Originally, I tried to implement this with sysfs (e.g. `cat /sys/class/datadev/datadev_0/pci_bdf`). But I couldn't figure out how to not cause a kernel panic error when you `/sbin/rmmod datadev` --> `/sbin/insmod datadev.ko` & " sysfs: cannot create duplicate filename '/devices/virtual/datadev'"
  - Here's that original code for reference:  [pci_bdf_show](https://github.com/slaclab/aes-stream-drivers/tree/pci_bdf_show)

```bash
$ cat /proc/datadev_0
PCIe[BUS:NUM:SLOT.FUNC] : 0000:01:00.0
---------- Firmware Axi Version -----------
     Firmware Version : 0x3130000
           ScratchPad : 0x0
        Up Time Count : 724
             Git Hash : 2d7ab8af6de6e2d470cbaed3b52e741331894e96
            DNA Value : 0x0000000040020000013abfc44d000345
         Build String : Lcls2XilinxC1100Pgp4_6Gbps: Vivado v2025.1, rdsrv403 (Ubuntu 22.04.5 LTS), Built Tue Jul  1 05:50:26 PM PDT 2025 by ruckman
...
...
...
```