### PR TITLE
Add missing `device_destroy` call

### DIFF
--- a/Yocto/recipes-kernel/aximemorymap/files/aximemorymap.c
+++ b/Yocto/recipes-kernel/aximemorymap/files/aximemorymap.c
@@ -236,6 +236,9 @@ int Map_Init(void) {
 void Map_Exit(void) {
    struct MemMap *tmp, *next;
 
+   // Destroy the device (removes device file)
+   device_destroy(gCl, dev.devNum);
+
    // Unregister Device Driver
    unregister_chrdev_region(dev.devNum, 1);
 


### PR DESCRIPTION
`device_destroy` not called in `Map_Exit` leads to error when loading, then removing, then re-loading the module.

### Description
Add `device_destroy` call to `Map_Exit` to ensure the device file is properly removed when removing the `axi_memory_map` kernel module.

### Details
Loading the `axi_memory_map` kernel module using `insmod`, then un-loading with `rmmod` does not properly remove the device file at `/dev/axi_memory_map`. This led to an error when re-loading the module a second time with `insmod`.