### PR TITLE
Fix debian CI

### DIFF
--- a/scripts/filter-clangdb.py
+++ b/scripts/filter-clangdb.py
@@ -27,8 +27,10 @@ parser.add_argument('-w', dest='WRITE', action='store_true', help='Write in plac
 parser.add_argument('--strip', action='append', help='Arguments to strip (only arg names, not the whole values)')
 args = parser.parse_args()
 
+# Unsupported args
 to_strip = [
-    '-mrecord-mcount'
+    '-mrecord-mcount',
+    '-fsanitize=bounds-strict',
 ]
 
 if not os.path.exists(args.f):


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

Strips the unsupported -fsanitize=bounds-strict option that is causing debian experimental CI to fail.