### PR TITLE
Change ioctl return codes

### DIFF
--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -403,7 +403,7 @@ int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
          return AxisG2_Command(dev, cmd, arg);
          break;
    }
-   return -EBADRQC;
+   return -EINVAL;
 }
 
 /**

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -389,6 +389,8 @@ int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
       case GPU_Rem_Nvidia_Memory:
       case GPU_Set_Write_Enable:
          return dev->gpuEn ? Gpu_Command(dev, cmd, arg) : -ENOTSUPP;
+      case GPU_Is_Gpu_Async_Supp:
+         return dev->gpuEn ? 1 : 0;
 #endif
 
       case AVER_Get:

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -377,8 +377,8 @@ void DataDev_Remove(struct pci_dev *pcidev) {
  * function for further processing. The function returns the result of
  * the command execution, which could be a success indicator or an error code.
  *
- * Return: the result of the command execution. Returns -1 if the command
- * is not recognized.
+ * Return: the result of the command execution. Returns -EBADRQC (bad request number)
+ * if the command is not recognized.
  */
 int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
    switch (cmd) {
@@ -388,7 +388,7 @@ int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
       case GPU_Add_Nvidia_Memory:
       case GPU_Rem_Nvidia_Memory:
       case GPU_Set_Write_Enable:
-         return dev->gpuEn ? Gpu_Command(dev, cmd, arg) : -1;
+         return dev->gpuEn ? Gpu_Command(dev, cmd, arg) : -ENOTSUPP;
 #endif
 
       case AVER_Get:
@@ -401,7 +401,7 @@ int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
          return AxisG2_Command(dev, cmd, arg);
          break;
    }
-   return -1;
+   return -EBADRQC;
 }
 
 /**

--- a/include/GpuAsync.h
+++ b/include/GpuAsync.h
@@ -31,6 +31,7 @@
 #define GPU_Add_Nvidia_Memory 0x8002   // Command to add NVIDIA GPU memory
 #define GPU_Rem_Nvidia_Memory 0x8003   // Command to remove NVIDIA GPU memory
 #define GPU_Set_Write_Enable  0x8004   // Set Write Enable Flag
+#define GPU_Is_Gpu_Async_Supp 0x8005   // Check if GPU Async is supported by firmware
 
 /**
  * struct GpuNvidiaData - Represents NVIDIA GPU memory data.
@@ -101,6 +102,17 @@ static inline ssize_t gpuRemNvidiaMemory(int32_t fd) {
 static inline ssize_t gpuSetWriteEn(int32_t fd, uint32_t idx) {
    uint32_t lidx = idx;
    return(ioctl(fd, GPU_Set_Write_Enable, &lidx));
+}
+
+/**
+ * gpuIsGpuAsyncSupported - Check if the firmware supports GPU Async
+ * @fd: File descriptor for the device
+ *
+ * Return: 1 if the firmware supports GPU Async, 0 if it doesn't.
+ * Returns -EINVAL if the driver was compiled without GPUAsync support
+ */
+static inline bool gpuIsGpuAsyncSupported(int32_t fd) {
+   return ioctl(fd, GPU_Is_Gpu_Async_Supp);
 }
 
 #endif  // !DMA_IN_KERNEL

--- a/include/GpuAsync.h
+++ b/include/GpuAsync.h
@@ -60,7 +60,8 @@ struct GpuNvidiaData {
  * for the region to be accessed as specified by the write flag.
  *
  * Return: On success, returns the result of the ioctl call. On failure,
- * returns a negative error code.
+ * returns a negative error code. Returns -ENOTSUPP if the firmware does not
+ * support GPUDirect.
  **/
 static inline ssize_t gpuAddNvidiaMemory(int32_t fd, uint32_t write, uint64_t address, uint32_t size) {
    struct GpuNvidiaData dat;
@@ -80,7 +81,8 @@ static inline ssize_t gpuAddNvidiaMemory(int32_t fd, uint32_t write, uint64_t ad
  * ceasing its accessibility.
  *
  * Return: On success, returns the result of the ioctl call. On failure,
- * returns a negative error code.
+ * returns a negative error code. Returns -ENOTSUPP if the firmware does not
+ * support GPUDirect.
  **/
 static inline ssize_t gpuRemNvidiaMemory(int32_t fd) {
    return(ioctl(fd, GPU_Rem_Nvidia_Memory, 0));
@@ -94,6 +96,7 @@ static inline ssize_t gpuRemNvidiaMemory(int32_t fd) {
  * This function enables a DMA buffer for DMA operations.
  *
  * Return: 0 on success, negative error code on failure.
+ * Returns -ENOTSUPP if the firmware does not support GPUDirect.
  */
 static inline ssize_t gpuSetWriteEn(int32_t fd, uint32_t idx) {
    uint32_t lidx = idx;


### PR DESCRIPTION

### Description

* Added new IOCTL to check if the firmware has GPU Async support

* Return -EINVAL for invalid IOCTL numbers.
Return -ENOTSUPP (not supported) for GPU IOCTLs when they're not supported by firmware.

The idea here is to allow software to determine what went wrong, instead of returning a generic error (-1).

Should I bump the DMA_VERSION for this change? The DAQ and other software components may need to be updated if they're explicitly checking for `-1` error returns.
