### PR TITLE
Avoid allocations during runtime

### DIFF
--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -477,10 +477,16 @@ int Dma_Open(struct inode *inode, struct file *filp) {
    }
 
    // Allocate scratch data buffers
-   desc->readDataScratch = (struct DmaReadData*)kzalloc(sizeof(struct DmaReadData) * READ_DATA_SCRATCH_CNT, GFP_KERNEL);
-   desc->indexScratch = (uint32_t*)kzalloc(sizeof(uint32_t) * INDEX_SCRATCH_CNT, GFP_KERNEL);
+   desc->readScratchCount = dev->cfgRxCount;
+   desc->readDataScratch = (struct DmaReadData*)kzalloc(sizeof(struct DmaReadData) * desc->readScratchCount, GFP_KERNEL);
 
-   if (!desc->readDataScratch || !desc->indexScratch) {
+   desc->indexScratchCount = MAX(dev->cfgRxCount, dev->cfgTxCount);
+   desc->indexScratch = (uint32_t*)kzalloc(sizeof(uint32_t) * desc->indexScratchCount, GFP_KERNEL);
+
+   desc->buffListScratchCount = MAX(dev->cfgRxCount, dev->cfgTxCount);
+   desc->buffListScratch = (struct DmaBuffer**)kzalloc(sizeof(struct DmaBuffer*) * desc->buffListScratchCount, GFP_KERNEL);
+
+   if (!desc->readDataScratch || !desc->indexScratch || !desc->buffListScratch) {
       dev_err(dev->device, "Open: kzalloc for scratch area(s) failed\n");
       kfree(desc);
       return -ENOMEM;
@@ -610,14 +616,16 @@ static ssize_t Dma_Read_Internal(struct file *filp, __user char *buffer, size_t 
    struct DmaDevice *dev = desc->dev;
 
    // Sanity check!
-   if (rCnt > READ_DATA_SCRATCH_CNT) {
-      dev_err(dev->device, "Dma_Read_Internal: Programming error: rCnt > READ_DATA_SCRATCH_CNT (%d)\n",
-         READ_DATA_SCRATCH_CNT);
+   if (rCnt > desc->readScratchCount) {
+      dev_err(dev->device, "Dma_Read_Internal: Programming error: rCnt > desc->readScratchCount (%d)\n",
+         desc->readScratchCount);
       return -1;
    }
 
    //struct DmaBuffer* buff[NUM_BUFFERS_AT_ONCE] = {0};
-   struct DmaReadData rd[READ_DATA_SCRATCH_CNT] = {0};
+   //struct DmaReadData rd[READ_DATA_SCRATCH_CNT] = {0};
+
+   struct DmaReadData* rd = desc->readDataScratch;
 
    // Copy the read structure from user space
    if ((ret = copy_from_user(rd, buffer, rCnt * sizeof(struct DmaReadData)))) {
@@ -732,7 +740,7 @@ ssize_t Dma_Read(struct file *filp, __user char *buffer, size_t count, loff_t *f
 
    // Read at most READ_DATA_SCRATCH_CNT per iteration. Avoids allocations in the driver.
    for (; rem > 0;) {
-      size_t toRead = MIN(rem, READ_DATA_SCRATCH_CNT);
+      size_t toRead = MIN(rem, desc->readScratchCount);
       ret = Dma_Read_Internal(filp, buffer, toRead);
 
       // If failed, this will be a partial read. This should only happen in exceptionally rare
@@ -887,17 +895,17 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
       return -1;
    }
 
-   for (int i = 0; i < cnt; i += INDEX_SCRATCH_CNT) {
-      uint32_t indexes[INDEX_SCRATCH_CNT] = {0};
-      struct DmaBuffer* buffList[INDEX_SCRATCH_CNT] = {0};
+   mutex_lock(&desc->mutex);
 
+   for (uint32_t i = 0; i < cnt; i += desc->indexScratchCount) {
       // Limit the number to free per iteration
-      const size_t toFree = MIN(INDEX_SCRATCH_CNT, cnt - i);
+      const size_t toFree = MIN(desc->indexScratchCount, cnt - i);
 
       // This should really never happen because we already checked with access_ok
-      if (copy_from_user(indexes, arg, (toFree * sizeof(uint32_t)))) {
+      if (copy_from_user(desc->indexScratch, arg, (toFree * sizeof(uint32_t)))) {
          dev_warn(dev->device, "Ret_Indexes: copy_from_user failed. buf=%p, bytes=%ld\n",
             arg, toFree * sizeof(uint32_t));
+         mutex_unlock(&desc->mutex);
          return -1;
       }
 
@@ -905,15 +913,15 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
 
       for (uint32_t x = 0; x < toFree; x++) {
          // Attempt to find buffer in RX list
-         if ( (buff = dmaGetBufferList(&(dev->rxBuffers), indexes[x])) != NULL ) {
+         if ( (buff = dmaGetBufferList(&(dev->rxBuffers), desc->indexScratch[x])) != NULL ) {
             // Only return if owned by current desc
             if ( buff->userHas == desc ) {
                buff->userHas = NULL;
-               buffList[bCnt++] = buff;
+               desc->buffListScratch[bCnt++] = buff;
             }
    
          // Attempt to find in tx list
-         } else if ( (buff = dmaGetBufferList(&(dev->txBuffers), indexes[x])) != NULL ) {
+         } else if ( (buff = dmaGetBufferList(&(dev->txBuffers), desc->indexScratch[x])) != NULL ) {
             // Only return if owned by current desc
             if ( buff->userHas == desc ) {
                buff->userHas = NULL;
@@ -922,15 +930,21 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
                dmaQueuePush(&(dev->tq), buff);
             }
          } else {
-            dev_warn(dev->device, "Command: Invalid index posted: %i.\n", indexes[x]);
+            dev_warn(dev->device, "Command: Invalid index posted: %i.\n", desc->indexScratch[x]);
+            mutex_unlock(&desc->mutex);
             return -1;
          }
       }
 
       // Return receive buffers
-      dev->hwFunc->retRxBuffer(dev, buffList, bCnt);
+      dev->hwFunc->retRxBuffer(dev, desc->buffListScratch, bCnt);
+      
+      // Clear these for subsequent operations, just in case.
+      memset(desc->buffListScratch, 0, sizeof(struct DmaBuffer*) * desc->buffListScratchCount);
+      memset(desc->indexScratch, 0, sizeof(uint32_t) * desc->indexScratchCount);
    }
 
+   mutex_unlock(&desc->mutex);
    return 0;
 
 #if 0

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -620,6 +620,7 @@ ssize_t Dma_Read(struct file *filp, __user char *buffer, size_t count, loff_t *f
    __user void *dp = NULL;
    struct DmaDesc *desc = (struct DmaDesc *)filp->private_data;
    struct DmaDevice *dev = desc->dev;
+   struct DmaReadData *rd = NULL;
 
    mutex_lock(&desc->mutex);
 
@@ -644,14 +645,18 @@ ssize_t Dma_Read(struct file *filp, __user char *buffer, size_t count, loff_t *f
    }
 
    // Check that we can actually access the user buffers
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
+   if (!access_ok(buffer, rCnt * sizeof(struct DmaReadData), VERIFY_WRITE)) {
+#else
    if (!access_ok(buffer, rCnt * sizeof(struct DmaReadData))) {
+#endif
       dev_warn(dev->device, "Read: Unable to access user buffer. buffer=%p, size=%ld\n",
          buffer, rCnt * sizeof(struct DmaReadData));
       mutex_unlock(&desc->mutex);
       return -EFAULT;
    }
 
-   struct DmaReadData* rd = desc->readDataScratch;
+   rd = desc->readDataScratch;
 
    // Copy the read structure from user space
    if ((copied = copy_from_user(rd, buffer, rCnt * sizeof(struct DmaReadData)))) {
@@ -839,12 +844,18 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
    struct DmaDevice * dev;
    struct DmaBuffer * buff;
    uint32_t cnt = (cmd >> 16) & 0xFFFF;
+   uint32_t x = 0;
+   uint32_t bCnt = 0;
 
    desc = (struct DmaDesc *)filp->private_data;
    dev  = desc->dev;
 
    // Ensure the buffer is readable
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
+   if (!access_ok(arg, cnt * sizeof(uint32_t), VERIFY_READ)) {
+#else
    if (!access_ok(arg, cnt * sizeof(uint32_t))) {
+#endif
       dev_warn(dev->device, "Ret_Indexes: Invalid user buffer provided. buffer=%p, size=%ld\n",
          arg, cnt * sizeof(uint32_t));
       return -EFAULT;
@@ -867,9 +878,8 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
       return -1;
    }
 
-   uint32_t bCnt = 0;
-
-   for (uint32_t x = 0; x < cnt; x++) {
+   bCnt = 0;
+   for (x = 0; x < cnt; x++) {
       // Attempt to find buffer in RX list
       if ( (buff = dmaGetBufferList(&(dev->rxBuffers), desc->indexScratch[x])) != NULL ) {
          // Only return if owned by current desc

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -476,6 +476,19 @@ int Dma_Open(struct inode *inode, struct file *filp) {
       return -ENOMEM;  // Return an error if allocation fails
    }
 
+   // Allocate scratch data buffers
+   desc->readDataScratch = (struct DmaReadData*)kzalloc(sizeof(struct DmaReadData) * READ_DATA_SCRATCH_CNT, GFP_KERNEL);
+   desc->indexScratch = (uint32_t*)kzalloc(sizeof(uint32_t) * INDEX_SCRATCH_CNT, GFP_KERNEL);
+
+   if (!desc->readDataScratch || !desc->indexScratch) {
+      dev_err(dev->device, "Open: kzalloc for scratch area(s) failed\n");
+      kfree(desc);
+      return -ENOMEM;
+   }
+
+   // Init the mutex
+   mutex_init(&desc->mutex);
+
    memset(desc, 0, sizeof(struct DmaDesc));
    dmaQueueInit(&(desc->q), dev->cfgRxCount);
    desc->async_queue = NULL;
@@ -581,6 +594,100 @@ int Dma_Release(struct inode *inode, struct file *filp) {
 }
 
 /**
+ * Dma_Read_Internal - Read at most NUM_BUFFERS from the file
+ * @filp: File structure, where we will grab private_data from
+ * @buffer: The userspace buffer we want to write data to
+ * @rCnt: The number of buffers to read this iteration. This is not a byte count. Must not be
+ *  greater than NUM_BUFFERS_AT_ONCE
+ * @returns Number of bytes read, or -1 on failure
+ */
+static ssize_t Dma_Read_Internal(struct file *filp, __user char *buffer, size_t rCnt) {
+   __user void *dp;
+   uint64_t ret;
+   //ssize_t bCnt;
+   ssize_t x;
+   struct DmaDesc *desc = (struct DmaDesc *)filp->private_data;
+   struct DmaDevice *dev = desc->dev;
+
+   // Sanity check!
+   if (rCnt > READ_DATA_SCRATCH_CNT) {
+      dev_err(dev->device, "Dma_Read_Internal: Programming error: rCnt > READ_DATA_SCRATCH_CNT (%d)\n",
+         READ_DATA_SCRATCH_CNT);
+      return -1;
+   }
+
+   //struct DmaBuffer* buff[NUM_BUFFERS_AT_ONCE] = {0};
+   struct DmaReadData rd[READ_DATA_SCRATCH_CNT] = {0};
+
+   // Copy the read structure from user space
+   if ((ret = copy_from_user(rd, buffer, rCnt * sizeof(struct DmaReadData)))) {
+      dev_warn(dev->device, "Read: failed to copy struct from user space ret=%llu, user=%p kern=%p\n",
+               ret, buffer, rd);
+      return -1;
+   }
+
+   // Get buffers from the DMA queue
+   //bCnt = dmaQueuePopList(&(desc->q), buff, rCnt);
+
+   for (x = 0; x < rCnt; x++) {
+      // Grab the latest buffer
+      struct DmaBuffer* buff = dmaQueuePop(&desc->q);
+
+      // Report frame error
+      if (buff->error)
+         dev_warn(dev->device, "Read: error encountered 0x%x.\n", buff->error);
+
+      // Copy associated data to the read structure
+      rd[x].dest = buff->dest;
+      rd[x].flags = buff->flags;
+      rd[x].index = buff->index;
+      rd[x].error = buff->error;
+      rd[x].ret = (int32_t)buff->size;
+
+      // Convert pointer based on architecture
+      if (sizeof(void *) == 4 || rd[x].is32)
+         dp = (__user void *)(rd[x].data & 0xFFFFFFFF);
+      else
+         dp = (__user void *)rd[x].data;
+
+      // Use index if pointer is zero
+      if (dp == NULL) {
+         buff->userHas = desc;
+      } else {
+         // Warn if user buffer is too small
+         if (rd[x].size < buff->size) {
+            dev_warn(dev->device, "Read: user buffer is too small. Rx=%i, User=%i.\n",
+                     buff->size, (int32_t)rd[x].size);
+            rd[x].error |= DMA_ERR_MAX;
+            rd[x].ret = -1;
+
+         // Copy data to user space
+         } else if ((ret = copy_to_user(dp, buff->buffAddr, buff->size))) {
+            dev_warn(dev->device, "Read: failed to copy data to user space ret=%llu, user=%p kern=%p size=%u.\n",
+                     ret, dp, buff->buffAddr, buff->size);
+            rd[x].ret = -1;
+         }
+
+         // Return entry to RX queue
+         dev->hwFunc->retRxBuffer(dev, &buff, 1);
+      }
+
+      // Debug information
+      if (dev->debug > 0) {
+         dev_info(dev->device, "Read: Ret=%i, Dest=%i, Flags=0x%.8x, Error=%i.\n",
+                  rd[x].ret, rd[x].dest, rd[x].flags, rd[x].error);
+      }
+   }
+
+   // Copy the read structure back to user space
+   if ((ret = copy_to_user(buffer, rd, rCnt * sizeof(struct DmaReadData)))) {
+      dev_warn(dev->device, "Read: failed to copy struct to user space ret=%llu, user=%p kern=%p\n",
+               ret, buffer, &rd);
+   }
+   return x;
+}
+
+/**
  * Dma_Read - Read data from a DMA buffer
  * @filp: The file pointer associated with the device
  * @buffer: User space buffer to read the data into
@@ -594,105 +701,63 @@ int Dma_Release(struct inode *inode, struct file *filp) {
  * Return: The number of read structures on success or an error code on failure.
  */
 ssize_t Dma_Read(struct file *filp, __user char *buffer, size_t count, loff_t *f_pos) {
-   struct DmaBuffer **buff;
-   struct DmaReadData *rd;
-   __user void *dp;
-   uint64_t ret;
-   size_t rCnt;
-   ssize_t bCnt;
-   ssize_t x;
-   struct DmaDesc *desc;
-   struct DmaDevice *dev;
+   size_t rCnt = 0;
+   size_t rem = 0;
+   ssize_t bCnt = 0;
+   ssize_t ret = 0;
+   struct DmaDesc *desc = (struct DmaDesc *)filp->private_data;
+   struct DmaDevice *dev = desc->dev;
 
-   desc = (struct DmaDesc *)filp->private_data;
-   dev = desc->dev;
+   mutex_lock(&desc->mutex);
 
    // Verify the size of the passed structure
    if ((count % sizeof(struct DmaReadData)) != 0) {
       dev_warn(dev->device, "Read: Called with incorrect size. Got=%li, Exp=%li\n",
                count, sizeof(struct DmaReadData));
+      mutex_unlock(&desc->mutex);
       return -1;
    }
 
+   // Number of buffers to read, in total
    rCnt = count / sizeof(struct DmaReadData);
-   rd = (struct DmaReadData *)kzalloc(rCnt * sizeof(struct DmaReadData), GFP_KERNEL);
-   if (!rd) {
-      dev_warn(dev->device, "Read: Failed to allocate DmaReadData block of %ld bytes\n",
-         (ulong)(rCnt * sizeof(struct DmaReadData)));
-      return -ENOMEM;
+   rem = rCnt;
+
+   // Check that we can actually access the user buffers
+   if (!access_ok(buffer, rCnt * sizeof(struct DmaReadData))) {
+      dev_warn(dev->device, "Read: Unable to access user buffer. buffer=%p, size=%ld\n",
+         buffer, rCnt * sizeof(struct DmaReadData));
+      mutex_unlock(&desc->mutex);
+      return -EFAULT;
    }
 
-   buff = (struct DmaBuffer **)kzalloc(rCnt * sizeof(struct DmaBuffer *), GFP_KERNEL);
-   if (!buff) {
-      dev_warn(dev->device, "Read: Failed to allocate DmaBuffer descriptor block of %ld bytes\n",
-         (ulong)(rCnt * sizeof(struct DmaBuffer*)));
-      kfree(rd);
-      return -ENOMEM;
-   }
-   // Copy the read structure from user space
-   if ((ret = copy_from_user(rd, buffer, rCnt * sizeof(struct DmaReadData)))) {
-      dev_warn(dev->device, "Read: failed to copy struct from user space ret=%llu, user=%p kern=%p\n",
-               ret, buffer, rd);
-      return -1;
-   }
+   // Read at most READ_DATA_SCRATCH_CNT per iteration. Avoids allocations in the driver.
+   for (; rem > 0;) {
+      size_t toRead = MIN(rem, READ_DATA_SCRATCH_CNT);
+      ret = Dma_Read_Internal(filp, buffer, toRead);
 
-   // Get buffers from the DMA queue
-   bCnt = dmaQueuePopList(&(desc->q), buff, rCnt);
-
-   for (x = 0; x < bCnt; x++) {
-      // Report frame error
-      if (buff[x]->error)
-         dev_warn(dev->device, "Read: error encountered 0x%x.\n", buff[x]->error);
-
-      // Copy associated data to the read structure
-      rd[x].dest = buff[x]->dest;
-      rd[x].flags = buff[x]->flags;
-      rd[x].index = buff[x]->index;
-      rd[x].error = buff[x]->error;
-      rd[x].ret = (int32_t)buff[x]->size;
-
-      // Convert pointer based on architecture
-      if (sizeof(void *) == 4 || rd[x].is32)
-         dp = (__user void *)(rd[x].data & 0xFFFFFFFF);
-      else
-         dp = (__user void *)rd[x].data;
-
-      // Use index if pointer is zero
-      if (dp == NULL) {
-          buff[x]->userHas = desc;
-      } else {
-         // Warn if user buffer is too small
-         if (rd[x].size < buff[x]->size) {
-            dev_warn(dev->device, "Read: user buffer is too small. Rx=%i, User=%i.\n",
-                     buff[x]->size, (int32_t)rd[x].size);
-            rd[x].error |= DMA_ERR_MAX;
-            rd[x].ret = -1;
-
-         // Copy data to user space
-         } else if ((ret = copy_to_user(dp, buff[x]->buffAddr, buff[x]->size))) {
-            dev_warn(dev->device, "Read: failed to copy data to user space ret=%llu, user=%p kern=%p size=%u.\n",
-                     ret, dp, buff[x]->buffAddr, buff[x]->size);
-            rd[x].ret = -1;
-         }
-
-         // Return entry to RX queue
-         dev->hwFunc->retRxBuffer(dev, &(buff[x]), 1);
+      // If failed, this will be a partial read. This should only happen in exceptionally rare
+      // circumstances. We've already checked the user buffers earlier with access_ok.
+      if (ret < 0) {
+         dev_warn(dev->device, "Read: Dma_Read_Internal failed. ret=%ld, rem=%ld, rCnt=%ld\n",
+            ret, rem, rCnt);
+         break;
       }
 
-      // Debug information
-      if (dev->debug > 0) {
-         dev_info(dev->device, "Read: Ret=%i, Dest=%i, Flags=0x%.8x, Error=%i.\n",
-                  rd[x].ret, rd[x].dest, rd[x].flags, rd[x].error);
-      }
-   }
-   kfree(buff);
+      bCnt += ret;
 
-   // Copy the read structure back to user space
-   if ((ret = copy_to_user(buffer, rd, rCnt * sizeof(struct DmaReadData)))) {
-      dev_warn(dev->device, "Read: failed to copy struct to user space ret=%llu, user=%p kern=%p\n",
-               ret, buffer, &rd);
+      // Adjust remaining and buffer count
+      if (toRead > rem) {
+         rem = 0; // Paranoia; this should never happen
+      }
+      else {
+         rem -= toRead;
+      }
+
+      // Adjust buffer offset based on what was read
+      buffer += sizeof(struct DmaReadData) * toRead;
    }
-   kfree(rd);
+
+   mutex_unlock(&desc->mutex);
    return bCnt;
 }
 
@@ -755,9 +820,9 @@ ssize_t Dma_Write(struct file *filp, __user const char *buffer, size_t count, lo
 
    // Convert pointer based on architecture or request
    if (sizeof(void *) == 4 || wr.is32) {
-       dp = (__user void *)(wr.data & 0xFFFFFFFF);
+      dp = (__user void *)(wr.data & 0xFFFFFFFF);
    } else {
-       dp = (__user void *)wr.data;
+      dp = (__user void *)wr.data;
    }
 
    // Use index if pointer is null
@@ -801,6 +866,128 @@ ssize_t Dma_Write(struct file *filp, __user const char *buffer, size_t count, lo
 }
 
 /**
+ * Dma_Ret_Indexes - Return indexes to the hardware
+ * @filp: File pointer
+ * @cmd: IOCTL command to execute
+ * @arg: user destination buffer
+ */
+static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg) {
+   struct DmaDesc   * desc;
+   struct DmaDevice * dev;
+   struct DmaBuffer * buff;
+   uint32_t cnt = (cmd >> 16) & 0xFFFF;
+
+   desc = (struct DmaDesc *)filp->private_data;
+   dev  = desc->dev;
+
+   // Ensure the buffer is readable
+   if (!access_ok(arg, cnt * sizeof(uint32_t))) {
+      dev_warn(dev->device, "Ret_Indexes: Invalid user buffer provided. buffer=%p, size=%ld\n",
+         arg, cnt * sizeof(uint32_t));
+      return -1;
+   }
+
+   for (int i = 0; i < cnt; i += INDEX_SCRATCH_CNT) {
+      uint32_t indexes[INDEX_SCRATCH_CNT] = {0};
+      struct DmaBuffer* buffList[INDEX_SCRATCH_CNT] = {0};
+
+      // Limit the number to free per iteration
+      const size_t toFree = MIN(INDEX_SCRATCH_CNT, cnt - i);
+
+      // This should really never happen because we already checked with access_ok
+      if (copy_from_user(indexes, arg, (toFree * sizeof(uint32_t)))) {
+         dev_warn(dev->device, "Ret_Indexes: copy_from_user failed. buf=%p, bytes=%ld\n",
+            arg, toFree * sizeof(uint32_t));
+         return -1;
+      }
+
+      uint32_t bCnt = 0;
+
+      for (uint32_t x = 0; x < toFree; x++) {
+         // Attempt to find buffer in RX list
+         if ( (buff = dmaGetBufferList(&(dev->rxBuffers), indexes[x])) != NULL ) {
+            // Only return if owned by current desc
+            if ( buff->userHas == desc ) {
+               buff->userHas = NULL;
+               buffList[bCnt++] = buff;
+            }
+   
+         // Attempt to find in tx list
+         } else if ( (buff = dmaGetBufferList(&(dev->txBuffers), indexes[x])) != NULL ) {
+            // Only return if owned by current desc
+            if ( buff->userHas == desc ) {
+               buff->userHas = NULL;
+   
+               // Return entry to TX queue
+               dmaQueuePush(&(dev->tq), buff);
+            }
+         } else {
+            dev_warn(dev->device, "Command: Invalid index posted: %i.\n", indexes[x]);
+            return -1;
+         }
+      }
+
+      // Return receive buffers
+      dev->hwFunc->retRxBuffer(dev, buffList, bCnt);
+   }
+
+   return 0;
+
+#if 0
+   if ( cnt == 0 ) return 0;
+   indexes = kzalloc(cnt * sizeof(uint32_t), GFP_KERNEL);
+   if (!indexes) {
+      dev_warn(dev->device, "Command: Failed to allocate index block of %ld bytes\n",
+         (ulong)(cnt * sizeof(uint32_t)));
+      return -ENOMEM;
+   }
+   if (copy_from_user(indexes, (__user void *)arg, (cnt * sizeof(uint32_t)))) return -1;
+
+   buffList = (struct DmaBuffer **)kzalloc(cnt * sizeof(struct DmaBuffer *), GFP_KERNEL);
+   if (!buffList) {
+      dev_warn(dev->device, "Command: Failed to allocate DmaBuffer block of %ld bytes\n",
+         (ulong)(cnt * sizeof(struct DmaBuffer*)));
+      kfree(indexes);
+      return -ENOMEM;
+   }
+   bCnt = 0;
+
+   for (x=0; x < cnt; x++) {
+      // Attempt to find buffer in RX list
+      if ( (buff = dmaGetBufferList(&(dev->rxBuffers), indexes[x])) != NULL ) {
+         // Only return if owned by current desc
+         if ( buff->userHas == desc ) {
+            buff->userHas = NULL;
+            buffList[bCnt++] = buff;
+         }
+
+      // Attempt to find in tx list
+      } else if ( (buff = dmaGetBufferList(&(dev->txBuffers), indexes[x])) != NULL ) {
+         // Only return if owned by current desc
+         if ( buff->userHas == desc ) {
+            buff->userHas = NULL;
+
+            // Return entry to TX queue
+            dmaQueuePush(&(dev->tq), buff);
+         }
+      } else {
+         dev_warn(dev->device, "Command: Invalid index posted: %i.\n", indexes[x]);
+         kfree(indexes);
+         kfree(buffList);
+         return -1;
+      }
+   }
+
+   // Return receive buffers
+   dev->hwFunc->retRxBuffer(dev, buffList, bCnt);
+
+   kfree(buffList);
+   kfree(indexes);
+   return 0;
+#endif
+}
+
+/**
  * Dma_Ioctl - Perform commands on DMA device
  * @filp: pointer to the file structure
  * @cmd: command to execute
@@ -819,17 +1006,13 @@ ssize_t Dma_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
    struct DmaDesc   * desc;
    struct DmaDevice * dev;
    struct DmaBuffer * buff;
-   struct DmaBuffer ** buffList;
 
    uint32_t   x;
-   uint32_t   cnt;
-   uint32_t   bCnt;
    uint32_t   userCnt;
    uint32_t   hwCnt;
    uint32_t   hwQCnt;
    uint32_t   qCnt;
    uint32_t   miss;
-   uint32_t * indexes;
 
    desc = (struct DmaDesc *)filp->private_data;
    dev  = desc->dev;
@@ -987,63 +1170,7 @@ ssize_t Dma_Ioctl(struct file *filp, uint32_t cmd, unsigned long arg) {
 
       // Return buffer index
       case DMA_Ret_Index:
-         cnt = (cmd >> 16) & 0xFFFF;
-
-         if ( cnt == 0 ) return 0;
-         indexes = kzalloc(cnt * sizeof(uint32_t), GFP_KERNEL);
-         if (!indexes) {
-            dev_warn(dev->device, "Command: Failed to allocate index block of %ld bytes\n",
-               (ulong)(cnt * sizeof(uint32_t)));
-            return -ENOMEM;
-         }
-
-         if (copy_from_user(indexes, (__user void *)arg, (cnt * sizeof(uint32_t)))) {
-            dev_warn(dev->device, "Command: copy_from_user failed\n");
-            kfree(indexes);
-            return -EFAULT;
-         }
-
-         buffList = (struct DmaBuffer **)kzalloc(cnt * sizeof(struct DmaBuffer *), GFP_KERNEL);
-         if (!buffList) {
-            dev_warn(dev->device, "Command: Failed to allocate DmaBuffer block of %ld bytes\n",
-               (ulong)(cnt * sizeof(struct DmaBuffer*)));
-            kfree(indexes);
-            return -ENOMEM;
-         }
-         bCnt = 0;
-
-         for (x=0; x < cnt; x++) {
-            // Attempt to find buffer in RX list
-            if ( (buff = dmaGetBufferList(&(dev->rxBuffers), indexes[x])) != NULL ) {
-               // Only return if owned by current desc
-               if ( buff->userHas == desc ) {
-                  buff->userHas = NULL;
-                  buffList[bCnt++] = buff;
-               }
-
-            // Attempt to find in tx list
-            } else if ( (buff = dmaGetBufferList(&(dev->txBuffers), indexes[x])) != NULL ) {
-               // Only return if owned by current desc
-               if ( buff->userHas == desc ) {
-                  buff->userHas = NULL;
-
-                  // Return entry to TX queue
-                  dmaQueuePush(&(dev->tq), buff);
-               }
-            } else {
-               dev_warn(dev->device, "Command: Invalid index posted: %i.\n", indexes[x]);
-               kfree(indexes);
-               kfree(buffList);
-               return -1;
-            }
-         }
-
-         // Return receive buffers
-         dev->hwFunc->retRxBuffer(dev, buffList, bCnt);
-
-         kfree(buffList);
-         kfree(indexes);
-         return 0;
+         return Dma_Ret_Indexes(filp, cmd, (__user void*)arg);
          break;
 
       // Request a write buffer index

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -477,13 +477,13 @@ int Dma_Open(struct inode *inode, struct file *filp) {
    }
 
    // Allocate scratch data buffers
-   desc->readScratchCount = dev->cfgRxCount;
+   desc->readScratchCount = dev->cfgRxCount + dev->cfgTxCount;
    desc->readDataScratch = (struct DmaReadData*)kzalloc(sizeof(struct DmaReadData) * desc->readScratchCount, GFP_KERNEL);
 
-   desc->indexScratchCount = MAX(dev->cfgRxCount, dev->cfgTxCount);
+   desc->indexScratchCount = dev->cfgRxCount + dev->cfgTxCount;
    desc->indexScratch = (uint32_t*)kzalloc(sizeof(uint32_t) * desc->indexScratchCount, GFP_KERNEL);
 
-   desc->buffListScratchCount = MAX(dev->cfgRxCount, dev->cfgTxCount);
+   desc->buffListScratchCount = dev->cfgRxCount + dev->cfgTxCount;
    desc->buffListScratch = (struct DmaBuffer**)kzalloc(sizeof(struct DmaBuffer*) * desc->buffListScratchCount, GFP_KERNEL);
 
    if (!desc->readDataScratch || !desc->indexScratch || !desc->buffListScratch) {
@@ -495,7 +495,6 @@ int Dma_Open(struct inode *inode, struct file *filp) {
    // Init the mutex
    mutex_init(&desc->mutex);
 
-   memset(desc, 0, sizeof(struct DmaDesc));
    dmaQueueInit(&(desc->q), dev->cfgRxCount);
    desc->async_queue = NULL;
    desc->dev = dev;
@@ -600,46 +599,74 @@ int Dma_Release(struct inode *inode, struct file *filp) {
 }
 
 /**
- * Dma_Read_Internal - Read at most NUM_BUFFERS from the file
- * @filp: File structure, where we will grab private_data from
- * @buffer: The userspace buffer we want to write data to
- * @rCnt: The number of buffers to read this iteration. This is not a byte count. Must not be
- *  greater than NUM_BUFFERS_AT_ONCE
- * @returns Number of bytes read, or -1 on failure
+ * Dma_Read - Read data from a DMA buffer
+ * @filp: The file pointer associated with the device
+ * @buffer: User space buffer to read the data into
+ * @count: The size of the data to read
+ * @f_pos: The offset within the file
+ *
+ * This function is called when the device is read from. It reads data from a DMA buffer
+ * into a user space buffer. It verifies the size of the passed structure, allocates
+ * necessary buffers, copies data from kernel space to user space, and handles errors.
+ *
+ * Return: The number of read structures on success or an error code on failure.
  */
-static ssize_t Dma_Read_Internal(struct file *filp, __user char *buffer, size_t rCnt) {
-   __user void *dp;
-   uint64_t ret;
-   //ssize_t bCnt;
-   ssize_t x;
+ssize_t Dma_Read(struct file *filp, __user char *buffer, size_t count, loff_t *f_pos) {
+   size_t rCnt = 0;
+   size_t rem = 0;
+   ssize_t bCnt = 0;
+   size_t copied = 0;
+   ssize_t x = 0;
+   __user void *dp = NULL;
    struct DmaDesc *desc = (struct DmaDesc *)filp->private_data;
    struct DmaDevice *dev = desc->dev;
 
-   // Sanity check!
-   if (rCnt > desc->readScratchCount) {
-      dev_err(dev->device, "Dma_Read_Internal: Programming error: rCnt > desc->readScratchCount (%d)\n",
-         desc->readScratchCount);
+   mutex_lock(&desc->mutex);
+
+   // Verify the size of the passed structure
+   if ((count % sizeof(struct DmaReadData)) != 0) {
+      dev_warn(dev->device, "Read: Called with incorrect size. Got=%li, Exp=%li\n",
+               count, sizeof(struct DmaReadData));
+      mutex_unlock(&desc->mutex);
       return -1;
    }
 
-   //struct DmaBuffer* buff[NUM_BUFFERS_AT_ONCE] = {0};
-   //struct DmaReadData rd[READ_DATA_SCRATCH_CNT] = {0};
+   // Number of buffers to read, in total
+   rCnt = count / sizeof(struct DmaReadData);
+   rem = rCnt;
+
+   // Check that we can read that many buffers
+   if (rCnt > desc->readScratchCount || rCnt > desc->buffListScratchCount) {
+      dev_warn(dev->device, "Read: attempted to read too many buffers. rCnt=%zu > max=%d\n",
+         rCnt, MIN(desc->readScratchCount, desc->buffListScratchCount));
+      mutex_unlock(&desc->mutex);
+      return -1;
+   }
+
+   // Check that we can actually access the user buffers
+   if (!access_ok(buffer, rCnt * sizeof(struct DmaReadData))) {
+      dev_warn(dev->device, "Read: Unable to access user buffer. buffer=%p, size=%ld\n",
+         buffer, rCnt * sizeof(struct DmaReadData));
+      mutex_unlock(&desc->mutex);
+      return -EFAULT;
+   }
 
    struct DmaReadData* rd = desc->readDataScratch;
 
    // Copy the read structure from user space
-   if ((ret = copy_from_user(rd, buffer, rCnt * sizeof(struct DmaReadData)))) {
-      dev_warn(dev->device, "Read: failed to copy struct from user space ret=%llu, user=%p kern=%p\n",
-               ret, buffer, rd);
+   if ((copied = copy_from_user(rd, buffer, rCnt * sizeof(struct DmaReadData)))) {
+      dev_warn(dev->device, "Read: failed to copy struct from user space ret=%zu, user=%p kern=%p\n",
+               copied, buffer, rd);
+      mutex_unlock(&desc->mutex);
       return -1;
    }
 
    // Get buffers from the DMA queue
-   //bCnt = dmaQueuePopList(&(desc->q), buff, rCnt);
+   bCnt = dmaQueuePopList(&(desc->q), desc->buffListScratch, rCnt);
 
-   for (x = 0; x < rCnt; x++) {
+   for (x = 0; x < bCnt; x++) {
       // Grab the latest buffer
-      struct DmaBuffer* buff = dmaQueuePop(&desc->q);
+      struct DmaBuffer* buff = desc->buffListScratch[x];
 
       // Report frame error
       if (buff->error)
@@ -670,9 +697,9 @@ static ssize_t Dma_Read_Internal(struct file *filp, __user char *buffer, size_t 
             rd[x].ret = -1;
 
          // Copy data to user space
-         } else if ((ret = copy_to_user(dp, buff->buffAddr, buff->size))) {
-            dev_warn(dev->device, "Read: failed to copy data to user space ret=%llu, user=%p kern=%p size=%u.\n",
-                     ret, dp, buff->buffAddr, buff->size);
+         } else if ((copied = copy_to_user(dp, buff->buffAddr, buff->size))) {
+            dev_warn(dev->device, "Read: failed to copy data to user space ret=%zu, user=%p kern=%p size=%u.\n",
+                     copied, dp, buff->buffAddr, buff->size);
             rd[x].ret = -1;
          }
 
@@ -688,85 +715,13 @@ static ssize_t Dma_Read_Internal(struct file *filp, __user char *buffer, size_t 
    }
 
    // Copy the read structure back to user space
-   if ((ret = copy_to_user(buffer, rd, rCnt * sizeof(struct DmaReadData)))) {
-      dev_warn(dev->device, "Read: failed to copy struct to user space ret=%llu, user=%p kern=%p\n",
-               ret, buffer, &rd);
-   }
-   return x;
-}
-
-/**
- * Dma_Read - Read data from a DMA buffer
- * @filp: The file pointer associated with the device
- * @buffer: User space buffer to read the data into
- * @count: The size of the data to read
- * @f_pos: The offset within the file
- *
- * This function is called when the device is read from. It reads data from a DMA buffer
- * into a user space buffer. It verifies the size of the passed structure, allocates
- * necessary buffers, copies data from kernel space to user space, and handles errors.
- *
- * Return: The number of read structures on success or an error code on failure.
- */
-ssize_t Dma_Read(struct file *filp, __user char *buffer, size_t count, loff_t *f_pos) {
-   size_t rCnt = 0;
-   size_t rem = 0;
-   ssize_t bCnt = 0;
-   ssize_t ret = 0;
-   struct DmaDesc *desc = (struct DmaDesc *)filp->private_data;
-   struct DmaDevice *dev = desc->dev;
-
-   mutex_lock(&desc->mutex);
-
-   // Verify the size of the passed structure
-   if ((count % sizeof(struct DmaReadData)) != 0) {
-      dev_warn(dev->device, "Read: Called with incorrect size. Got=%li, Exp=%li\n",
-               count, sizeof(struct DmaReadData));
-      mutex_unlock(&desc->mutex);
-      return -1;
-   }
-
-   // Number of buffers to read, in total
-   rCnt = count / sizeof(struct DmaReadData);
-   rem = rCnt;
-
-   // Check that we can actually access the user buffers
-   if (!access_ok(buffer, rCnt * sizeof(struct DmaReadData))) {
-      dev_warn(dev->device, "Read: Unable to access user buffer. buffer=%p, size=%ld\n",
-         buffer, rCnt * sizeof(struct DmaReadData));
-      mutex_unlock(&desc->mutex);
-      return -EFAULT;
-   }
-
-   // Read at most READ_DATA_SCRATCH_CNT per iteration. Avoids allocations in the driver.
-   for (; rem > 0;) {
-      size_t toRead = MIN(rem, desc->readScratchCount);
-      ret = Dma_Read_Internal(filp, buffer, toRead);
-
-      // If failed, this will be a partial read. This should only happen in exceptionally rare
-      // circumstances. We've already checked the user buffers earlier with access_ok.
-      if (ret < 0) {
-         dev_warn(dev->device, "Read: Dma_Read_Internal failed. ret=%ld, rem=%ld, rCnt=%ld\n",
-            ret, rem, rCnt);
-         break;
-      }
-
-      bCnt += ret;
-
-      // Adjust remaining and buffer count
-      if (toRead > rem) {
-         rem = 0; // Paranoia; this should never happen
-      }
-      else {
-         rem -= toRead;
-      }
-
-      // Adjust buffer offset based on what was read
-      buffer += sizeof(struct DmaReadData) * toRead;
+   if ((copied = copy_to_user(buffer, rd, rCnt * sizeof(struct DmaReadData)))) {
+      dev_warn(dev->device, "Read: failed to copy struct to user space ret=%zu, user=%p kern=%p\n",
+               copied, buffer, &rd);
    }
 
    mutex_unlock(&desc->mutex);
-   return bCnt;
+   return x;
 }
 
 /**
@@ -892,113 +847,62 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
    if (!access_ok(arg, cnt * sizeof(uint32_t))) {
       dev_warn(dev->device, "Ret_Indexes: Invalid user buffer provided. buffer=%p, size=%ld\n",
          arg, cnt * sizeof(uint32_t));
+      return -EFAULT;
+   }
+   
+   // Reject returns that are too large for the scratch buffer
+   if (cnt > desc->indexScratchCount) {
+      dev_warn(dev->device, "Ret_Indexes: Tried to return too many indexes (%d > %d)\n",
+         cnt, (int)desc->indexScratchCount);
       return -1;
    }
 
    mutex_lock(&desc->mutex);
 
-   for (uint32_t i = 0; i < cnt; i += desc->indexScratchCount) {
-      // Limit the number to free per iteration
-      const size_t toFree = MIN(desc->indexScratchCount, cnt - i);
-
-      // This should really never happen because we already checked with access_ok
-      if (copy_from_user(desc->indexScratch, arg, (toFree * sizeof(uint32_t)))) {
-         dev_warn(dev->device, "Ret_Indexes: copy_from_user failed. buf=%p, bytes=%ld\n",
-            arg, toFree * sizeof(uint32_t));
-         mutex_unlock(&desc->mutex);
-         return -1;
-      }
-
-      uint32_t bCnt = 0;
-
-      for (uint32_t x = 0; x < toFree; x++) {
-         // Attempt to find buffer in RX list
-         if ( (buff = dmaGetBufferList(&(dev->rxBuffers), desc->indexScratch[x])) != NULL ) {
-            // Only return if owned by current desc
-            if ( buff->userHas == desc ) {
-               buff->userHas = NULL;
-               desc->buffListScratch[bCnt++] = buff;
-            }
-   
-         // Attempt to find in tx list
-         } else if ( (buff = dmaGetBufferList(&(dev->txBuffers), desc->indexScratch[x])) != NULL ) {
-            // Only return if owned by current desc
-            if ( buff->userHas == desc ) {
-               buff->userHas = NULL;
-   
-               // Return entry to TX queue
-               dmaQueuePush(&(dev->tq), buff);
-            }
-         } else {
-            dev_warn(dev->device, "Command: Invalid index posted: %i.\n", desc->indexScratch[x]);
-            mutex_unlock(&desc->mutex);
-            return -1;
-         }
-      }
-
-      // Return receive buffers
-      dev->hwFunc->retRxBuffer(dev, desc->buffListScratch, bCnt);
-      
-      // Clear these for subsequent operations, just in case.
-      memset(desc->buffListScratch, 0, sizeof(struct DmaBuffer*) * desc->buffListScratchCount);
-      memset(desc->indexScratch, 0, sizeof(uint32_t) * desc->indexScratchCount);
+   // This should really never happen because we already checked with access_ok
+   if (copy_from_user(desc->indexScratch, arg, (cnt * sizeof(uint32_t)))) {
+      dev_warn(dev->device, "Ret_Indexes: copy_from_user failed. buf=%p, bytes=%ld\n",
+         arg, cnt * sizeof(uint32_t));
+      mutex_unlock(&desc->mutex);
+      return -1;
    }
 
-   mutex_unlock(&desc->mutex);
-   return 0;
+   uint32_t bCnt = 0;
 
-#if 0
-   if ( cnt == 0 ) return 0;
-   indexes = kzalloc(cnt * sizeof(uint32_t), GFP_KERNEL);
-   if (!indexes) {
-      dev_warn(dev->device, "Command: Failed to allocate index block of %ld bytes\n",
-         (ulong)(cnt * sizeof(uint32_t)));
-      return -ENOMEM;
-   }
-   if (copy_from_user(indexes, (__user void *)arg, (cnt * sizeof(uint32_t)))) return -1;
-
-   buffList = (struct DmaBuffer **)kzalloc(cnt * sizeof(struct DmaBuffer *), GFP_KERNEL);
-   if (!buffList) {
-      dev_warn(dev->device, "Command: Failed to allocate DmaBuffer block of %ld bytes\n",
-         (ulong)(cnt * sizeof(struct DmaBuffer*)));
-      kfree(indexes);
-      return -ENOMEM;
-   }
-   bCnt = 0;
-
-   for (x=0; x < cnt; x++) {
+   for (uint32_t x = 0; x < cnt; x++) {
       // Attempt to find buffer in RX list
-      if ( (buff = dmaGetBufferList(&(dev->rxBuffers), indexes[x])) != NULL ) {
+      if ( (buff = dmaGetBufferList(&(dev->rxBuffers), desc->indexScratch[x])) != NULL ) {
          // Only return if owned by current desc
          if ( buff->userHas == desc ) {
             buff->userHas = NULL;
-            buffList[bCnt++] = buff;
+            desc->buffListScratch[bCnt++] = buff;
          }
-
+   
       // Attempt to find in tx list
-      } else if ( (buff = dmaGetBufferList(&(dev->txBuffers), indexes[x])) != NULL ) {
+      } else if ( (buff = dmaGetBufferList(&(dev->txBuffers), desc->indexScratch[x])) != NULL ) {
          // Only return if owned by current desc
          if ( buff->userHas == desc ) {
             buff->userHas = NULL;
-
+   
             // Return entry to TX queue
             dmaQueuePush(&(dev->tq), buff);
          }
       } else {
-         dev_warn(dev->device, "Command: Invalid index posted: %i.\n", indexes[x]);
-         kfree(indexes);
-         kfree(buffList);
-         return -1;
+         dev_warn(dev->device, "Command: Invalid index posted: %i.\n", desc->indexScratch[x]);
+         mutex_unlock(&desc->mutex);
+         return -EINVAL;
       }
    }
 
    // Return receive buffers
-   dev->hwFunc->retRxBuffer(dev, buffList, bCnt);
+   dev->hwFunc->retRxBuffer(dev, desc->buffListScratch, bCnt);
 
-   kfree(buffList);
-   kfree(indexes);
+   // Clear these for subsequent operations, just in case.
+   memset(desc->buffListScratch, 0, sizeof(struct DmaBuffer*) * desc->buffListScratchCount);
+   memset(desc->indexScratch, 0, sizeof(uint32_t) * desc->indexScratchCount);
+
+   mutex_unlock(&desc->mutex);
    return 0;
-#endif
 }
 
 /**

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -603,7 +603,7 @@ int Dma_Release(struct inode *inode, struct file *filp) {
 
    // Clear the tx queue and free the descriptor
    dmaQueueFree(&(desc->q));
-   
+
    // Free scratch buffers
    kfree(desc->buffListScratch);
    kfree(desc->indexScratch);

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -29,6 +29,12 @@
 #include <linux/version.h>
 #include <linux/slab.h>
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#include <linux/minmax.h>
+#else
+#include <linux/kernel.h>
+#endif
+
 /**
  * struct DmaFunctions - Define interface routines for DMA operations
  * @owner:          Pointer to the module owner of this structure
@@ -488,6 +494,9 @@ int Dma_Open(struct inode *inode, struct file *filp) {
 
    if (!desc->readDataScratch || !desc->indexScratch || !desc->buffListScratch) {
       dev_err(dev->device, "Open: kzalloc for scratch area(s) failed\n");
+      kfree(desc->readDataScratch);
+      kfree(desc->indexScratch);
+      kfree(desc->buffListScratch);
       kfree(desc);
       return -ENOMEM;
    }
@@ -594,6 +603,11 @@ int Dma_Release(struct inode *inode, struct file *filp) {
 
    // Clear the tx queue and free the descriptor
    dmaQueueFree(&(desc->q));
+   
+   // Free scratch buffers
+   kfree(desc->buffListScratch);
+   kfree(desc->indexScratch);
+   kfree(desc->readDataScratch);
    kfree(desc);
    return 0;
 }
@@ -622,13 +636,10 @@ ssize_t Dma_Read(struct file *filp, __user char *buffer, size_t count, loff_t *f
    struct DmaDevice *dev = desc->dev;
    struct DmaReadData *rd = NULL;
 
-   mutex_lock(&desc->mutex);
-
    // Verify the size of the passed structure
    if ((count % sizeof(struct DmaReadData)) != 0) {
       dev_warn(dev->device, "Read: Called with incorrect size. Got=%li, Exp=%li\n",
                count, sizeof(struct DmaReadData));
-      mutex_unlock(&desc->mutex);
       return -1;
    }
 
@@ -639,10 +650,11 @@ ssize_t Dma_Read(struct file *filp, __user char *buffer, size_t count, loff_t *f
    // Check that we can read that many buffers
    if (rCnt > desc->readScratchCount || rCnt > desc->buffListScratchCount) {
       dev_warn(dev->device, "Read: attempted to read too many buffers. rCnt=%zu > max=%d\n",
-         rCnt, MIN(desc->readScratchCount, desc->buffListScratchCount));
-      mutex_unlock(&desc->mutex);
-      return -1;
+         rCnt, min(desc->readScratchCount, desc->buffListScratchCount));
+      return -EINVAL;
    }
+
+   mutex_lock(&desc->mutex);
 
    // Check that we can actually access the user buffers
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
@@ -850,6 +862,17 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
    desc = (struct DmaDesc *)filp->private_data;
    dev  = desc->dev;
 
+   // No work to do
+   if (cnt == 0)
+      return 0;
+
+   // Reject returns that are too large for the scratch buffer
+   if (cnt > desc->indexScratchCount) {
+      dev_warn(dev->device, "Ret_Indexes: Tried to return too many indexes (%d > %d)\n",
+         cnt, (int)desc->indexScratchCount);
+      return -EINVAL;
+   }
+
    // Ensure the buffer is readable
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
    if (!access_ok(arg, cnt * sizeof(uint32_t), VERIFY_READ)) {
@@ -859,13 +882,6 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
       dev_warn(dev->device, "Ret_Indexes: Invalid user buffer provided. buffer=%p, size=%ld\n",
          arg, cnt * sizeof(uint32_t));
       return -EFAULT;
-   }
-
-   // Reject returns that are too large for the scratch buffer
-   if (cnt > desc->indexScratchCount) {
-      dev_warn(dev->device, "Ret_Indexes: Tried to return too many indexes (%d > %d)\n",
-         cnt, (int)desc->indexScratchCount);
-      return -1;
    }
 
    mutex_lock(&desc->mutex);
@@ -898,6 +914,9 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
          }
       } else {
          dev_warn(dev->device, "Command: Invalid index posted: %i.\n", desc->indexScratch[x]);
+         // Clear these out for subsequent operations, just in case.
+         memset(desc->buffListScratch, 0, sizeof(struct DmaBuffer*) * desc->buffListScratchCount);
+         memset(desc->indexScratch, 0, sizeof(uint32_t) * desc->indexScratchCount);
          mutex_unlock(&desc->mutex);
          return -EINVAL;
       }

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -860,7 +860,7 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
          arg, cnt * sizeof(uint32_t));
       return -EFAULT;
    }
-   
+
    // Reject returns that are too large for the scratch buffer
    if (cnt > desc->indexScratchCount) {
       dev_warn(dev->device, "Ret_Indexes: Tried to return too many indexes (%d > %d)\n",
@@ -887,13 +887,12 @@ static ssize_t Dma_Ret_Indexes(struct file *filp, uint32_t cmd, __user void* arg
             buff->userHas = NULL;
             desc->buffListScratch[bCnt++] = buff;
          }
-   
       // Attempt to find in tx list
       } else if ( (buff = dmaGetBufferList(&(dev->txBuffers), desc->indexScratch[x])) != NULL ) {
          // Only return if owned by current desc
          if ( buff->userHas == desc ) {
             buff->userHas = NULL;
-   
+
             // Return entry to TX queue
             dmaQueuePush(&(dev->tq), buff);
          }

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -53,11 +53,6 @@ struct DmaDesc;
 typedef uint32_t __poll_t;
 #endif
 
-#undef MIN
-#define MIN(_x, _y) ((_x) < (_y) ? (_x) : (_y))
-#undef MAX
-#define MAX(_x, _y) ((_x) > (_y) ? (_x) : (_y))
-
 /**
  * struct DmaDevice - Represents a DMA-capable device.
  * @baseAddr: Base physical address of the device's memory-mapped I/O region.
@@ -198,10 +193,10 @@ struct DmaDesc {
    // Number of elements in the read scratch buffer. Corresponds to cfgRxCount
    uint32_t readScratchCount;
 
-   // Number of elements in the index scratch buffer. max(cfgTxCount, cfgRxCount)
+   // Number of elements in the index scratch buffer.
    uint32_t indexScratchCount;
 
-   // Number of elements in the buff list scratch buffer. max(cfgTxCount, cfgRxCount)
+   // Number of elements in the buff list scratch buffer.
    uint32_t buffListScratchCount;
 
    // Operation guard

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -53,6 +53,9 @@ struct DmaDesc;
 typedef uint32_t __poll_t;
 #endif
 
+#undef MIN
+#define MIN(_x, _y) ((_x) < (_y) ? (_x) : (_y))
+
 /**
  * struct DmaDevice - Represents a DMA-capable device.
  * @baseAddr: Base physical address of the device's memory-mapped I/O region.
@@ -162,6 +165,12 @@ struct DmaDevice {
    struct DmaQueue tq;
 };
 
+// 4096 indexes in the scratch buffer
+#define INDEX_SCRATCH_CNT 4096
+
+// 1024 DmaReadData in the scratch buffer
+#define READ_DATA_SCRATCH_CNT 1024
+
 /**
  * struct DmaDesc - DMA descriptor for a device.
  * @destMask: Destination mask for DMA transfers.
@@ -184,6 +193,13 @@ struct DmaDesc {
 
    // Pointer back to card structure
    struct DmaDevice * dev;
+
+   // Scratch data buffers for ioctl and read operations
+   uint32_t* indexScratch;
+   struct DmaReadData* readDataScratch;
+
+   // Operation guard
+   struct mutex mutex;
 };
 
 /**

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -55,6 +55,8 @@ typedef uint32_t __poll_t;
 
 #undef MIN
 #define MIN(_x, _y) ((_x) < (_y) ? (_x) : (_y))
+#undef MAX
+#define MAX(_x, _y) ((_x) > (_y) ? (_x) : (_y))
 
 /**
  * struct DmaDevice - Represents a DMA-capable device.
@@ -165,12 +167,6 @@ struct DmaDevice {
    struct DmaQueue tq;
 };
 
-// 4096 indexes in the scratch buffer
-#define INDEX_SCRATCH_CNT 4096
-
-// 1024 DmaReadData in the scratch buffer
-#define READ_DATA_SCRATCH_CNT 1024
-
 /**
  * struct DmaDesc - DMA descriptor for a device.
  * @destMask: Destination mask for DMA transfers.
@@ -197,6 +193,12 @@ struct DmaDesc {
    // Scratch data buffers for ioctl and read operations
    uint32_t* indexScratch;
    struct DmaReadData* readDataScratch;
+   struct DmaBuffer** buffListScratch;
+
+   // Number of elements in both of the scratch buffers
+   uint32_t readScratchCount;
+   uint32_t indexScratchCount;
+   uint32_t buffListScratchCount;
 
    // Operation guard
    struct mutex mutex;

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -197,10 +197,10 @@ struct DmaDesc {
 
    // Number of elements in the read scratch buffer. Corresponds to cfgRxCount
    uint32_t readScratchCount;
-   
+
    // Number of elements in the index scratch buffer. max(cfgTxCount, cfgRxCount)
    uint32_t indexScratchCount;
-   
+
    // Number of elements in the buff list scratch buffer. max(cfgTxCount, cfgRxCount)
    uint32_t buffListScratchCount;
 

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -195,9 +195,13 @@ struct DmaDesc {
    struct DmaReadData* readDataScratch;
    struct DmaBuffer** buffListScratch;
 
-   // Number of elements in both of the scratch buffers
+   // Number of elements in the read scratch buffer. Corresponds to cfgRxCount
    uint32_t readScratchCount;
+   
+   // Number of elements in the index scratch buffer. max(cfgTxCount, cfgRxCount)
    uint32_t indexScratchCount;
+   
+   // Number of elements in the buff list scratch buffer. max(cfgTxCount, cfgRxCount)
    uint32_t buffListScratchCount;
 
    // Operation guard

--- a/scripts/check-bar.sh
+++ b/scripts/check-bar.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
+N=0
+
 # Quickly prints out the BAR assignments for all SLAC cards on the system
 for d in $(lspci -d 1a4a: | grep -Eo '^\S+')
 do
     echo "$d: $(lspci -s "$d" -vvv | grep -Eo 'Memory at \w+')"
+    N=$((N + 1))
 done
+
+echo "Total cards: $N"


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

Pre-allocates scratch buffers so we don't have to keep calling `kmalloc` during `dmaReadIndex` and such.

Introduces the following limitations:
* Max number of indices that can be returned at once is cfgRxCount + cfgTxCount
* Max number of buffers that can be read or written at once is cfgRxCount + cfgTxCount

If those conditions are violated, the ioctl returns with error.

I am not sure if the DAQ is trying to read/write/return more than its allotted amount.