### PR TITLE
Fix BUFF_STREAM (cfgMode=2) data corruption on kernels >= 5.15

### DIFF
--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -127,10 +127,9 @@ size_t dmaAllocBuffers(struct DmaDevice *dev, struct DmaBufferList *list,
             dev_err(list->dev->device, "dmaAllocBuffers(BUFF_STREAM): kmalloc Memory allocation failed\n");
          }
 #else
-         buff->buffAddr = dma_alloc_pages(list->dev->device, list->dev->cfgSize, &buff->buffHandle, direction, GFP_KERNEL);
-         // Check for mapping error
+         buff->buffAddr = dma_alloc_noncoherent(list->dev->device, list->dev->cfgSize, &buff->buffHandle, direction, GFP_KERNEL);
          if (buff->buffAddr == NULL) {
-            dev_err(dev->device, "dmaAllocBuffers(BUFF_STREAM): dma_alloc_pages failed\n");
+            dev_err(dev->device, "dmaAllocBuffers(BUFF_STREAM): dma_alloc_noncoherent failed\n");
          }
 #endif
 
@@ -204,15 +203,26 @@ void dmaFreeBuffersList(struct DmaBufferList *list) {
                               list->indexed[sl][sli]->buffHandle);
          }
 
-         // Unmap streaming buffer
+         // Unmap and free streaming buffer
          if (list->dev->cfgMode & BUFF_STREAM) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
             dma_unmap_single(list->dev->device,
                              list->indexed[sl][sli]->buffHandle,
                              list->dev->cfgSize, list->direction);
+#else
+            dma_free_noncoherent(list->dev->device, list->dev->cfgSize,
+                                 list->indexed[sl][sli]->buffAddr,
+                                 list->indexed[sl][sli]->buffHandle,
+                                 list->direction);
+#endif
          }
 
-         // Free buffer for streaming type or ARM ACP
+         // Free buffer for streaming type (pre-5.15 only) or ARM ACP
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
          if ((list->dev->cfgMode & BUFF_STREAM) || (list->dev->cfgMode & BUFF_ARM_ACP)) {
+#else
+         if (list->dev->cfgMode & BUFF_ARM_ACP) {
+#endif
             kfree(list->indexed[sl][sli]->buffAddr);
          }
       }


### PR DESCRIPTION
## Summary

- `dma_alloc_pages()` returns `struct page*`, not a kernel virtual address. The BUFF_STREAM allocation path stored this page pointer directly into `buff->buffAddr` (`void*`), causing `copy_to_user()` and `mmap` to operate on wrong memory — the `vmemmap` page metadata region instead of the actual DMA buffer contents.
- Switched to `dma_alloc_noncoherent()` / `dma_free_noncoherent()` which correctly return a kernel virtual address via `page_address()`.
- Only affects kernels >= 5.15 where the `dma_alloc_pages` code path is compiled. Kernels < 5.15 use `kmalloc` + `dma_map_single` and are unaffected.

## Test plan

- [x] Kernel module builds cleanly on kernel 6.8 (x86_64)
- [x] Load with `cfgMode=0x2`: `insmod datadev.ko cfgSize=0x200000 cfgRxCount=256 cfgTxCount=16 cfgMode=0x2`
- [x] PRBS test passes with zero bit errors (XilinxVariumC1100PrbsTester firmware)
- [x] Verified `cfgMode=0x1` still works correctly (regression check)

Resolves ESROGUE-731