### PR TITLE
Fix kernel version guards for 3.10 through 7.0 support

### DIFF
--- a/Yocto/recipes-kernel/aximemorymap/files/aximemorymap.c
+++ b/Yocto/recipes-kernel/aximemorymap/files/aximemorymap.c
@@ -111,10 +111,10 @@ struct file_operations MapFunctions = {
  * Note: The permissions set by this callback can be overridden by udev rules on
  * systems where udev is responsible for device node creation and management.
  */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-char *Map_DevNode(struct device *dev, umode_t *mode) {
-#else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
 char *Map_DevNode(const struct device *dev, umode_t *mode) {
+#else
+char *Map_DevNode(struct device *dev, umode_t *mode) {
 #endif
    if (mode != NULL) *mode = 0666;  // Set default permissions to read and write for user, group, and others
    return NULL;  // Return NULL as no specific device node name alteration is required
@@ -160,10 +160,10 @@ int Map_Init(void) {
 
    // Step 4: Create a device class
    pr_info("%s: Init: Creating device class\n", MOD_NAME);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-   gCl = class_create(THIS_MODULE, dev.devName);
-#else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
    gCl = class_create(dev.devName);
+#else
+   gCl = class_create(THIS_MODULE, dev.devName);
 #endif
    if (IS_ERR(gCl)) {
       pr_err("%s: Init: Failed to create device class\n", MOD_NAME);

--- a/Yocto/recipes-kernel/aximemorymap/files/aximemorymap.h
+++ b/Yocto/recipes-kernel/aximemorymap/files/aximemorymap.h
@@ -70,11 +70,15 @@ struct MapDevice {
    struct MemMap *maps;
 };
 
+#ifndef RHEL_RELEASE_VERSION
+#define RHEL_RELEASE_VERSION(...) 0
+#endif
+
 // Function prototypes for device operations.
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-char *Map_DevNode(struct device *dev, umode_t *mode);
-#else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
 char *Map_DevNode(const struct device *dev, umode_t *mode);
+#else
+char *Map_DevNode(struct device *dev, umode_t *mode);
 #endif
 int Map_Init(void);
 void Map_Exit(void);

--- a/Yocto/recipes-kernel/axistreamdma/files/axistreamdma.c
+++ b/Yocto/recipes-kernel/axistreamdma/files/axistreamdma.c
@@ -285,7 +285,7 @@ int Rce_Probe(struct platform_device *pdev) {
    if ((dev->cfgMode & BUFF_ARM_ACP) || (dev->cfgMode & AXIS2_RING_ACP)) {
       // Set DMA operations to coherent if supported
       set_dma_ops(&pdev->dev, &arm_coherent_dma_ops);
-      pr_info("%s: Probe: Set COHERENT DMA =%i\n", dev->device, dev->cfgMode);
+      pr_info("%s: Probe: Set COHERENT DMA =%i\n", MOD_NAME, dev->cfgMode);
    }
 #endif
 #endif

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -146,7 +146,11 @@ struct class *gCl;
  *
  * Returns NULL always.
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
+char *Dma_DevNode(const struct device *dev, umode_t *mode) {
+#else
 char *Dma_DevNode(struct device *dev, umode_t *mode) {
+#endif
    if (mode != NULL) {
       *mode = 0666;
    }
@@ -260,7 +264,7 @@ int Dma_Init(struct DmaDevice *dev) {
          goto cleanup_cdev_add;
       }
 
-      gCl->devnode = (void *)Dma_DevNode;
+      gCl->devnode = Dma_DevNode;
    }
 
    // Attempt to create the device

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -189,7 +189,7 @@ int Dma_MapReg(struct DmaDevice *dev) {
    if (dev->base == NULL) {
       dev_info(dev->device, "Init: Mapping Register space 0x%llx with size 0x%x.\n", (uint64_t)dev->baseAddr, dev->baseSize);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 25)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
       dev->base = ioremap(dev->baseAddr, dev->baseSize);
 #else
       dev->base = ioremap_nocache(dev->baseAddr, dev->baseSize);

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -29,10 +29,6 @@
 #include <linux/version.h>
 #include <linux/slab.h>
 
-#ifndef RHEL_RELEASE_VERSION
-#define RHEL_RELEASE_VERSION(...) 0
-#endif
-
 /**
  * struct DmaFunctions - Define interface routines for DMA operations
  * @owner:          Pointer to the module owner of this structure

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -223,7 +223,11 @@ extern struct class * gCl;
 extern struct file_operations DmaFunctions;
 
 // Function prototypes
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
+char *Dma_DevNode(const struct device *dev, umode_t *mode);
+#else
 char *Dma_DevNode(struct device *dev, umode_t *mode);
+#endif
 int Dma_MapReg(struct DmaDevice *dev);
 int Dma_Init(struct DmaDevice *dev);
 void Dma_Clean(struct DmaDevice *dev);

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -31,6 +31,10 @@
 #include <DmaDriver.h>
 #include <dma_buffer.h>
 
+#ifndef RHEL_RELEASE_VERSION
+#define RHEL_RELEASE_VERSION(...) 0
+#endif
+
 #ifdef __GNUC__
 #define MAYBE_UNUSED __attribute__((unused))
 #else


### PR DESCRIPTION
## Summary

- Add `const struct device *` version guard on `Dma_DevNode` callback for kernels >= 6.4 / RHEL 9.4+ (matches existing pattern in aximemorymap)
- Fix `ioremap_nocache` guard threshold from 2.6.25 to 5.6.0 (when it was actually removed)
- Add RHEL 9.4 guards to aximemorymap `class_create` and `Map_DevNode` for consistency with `common/driver`
- Fix `pr_info` format bug in axistreamdma passing `struct device *` to `%s` specifier

## Test plan

- [x] CI build matrix passes across all containers (Ubuntu 22.04/24.04, Rocky 9, Debian experimental, CentOS 7)
- [x] cpplint passes on all modified files
- [x] Sparse analysis clean on Debian experimental
- [x] Verify `Dma_DevNode` compiles without warnings on kernel 6.4+ (no more `(void *)` cast masking type mismatch)