### PR TITLE
tests(gpu): clear stale BAR0 state at startup to prevent retry-WARN

### DIFF
--- a/data_dev/app/src/dmaGpuToggleTest.cpp
+++ b/data_dev/app/src/dmaGpuToggleTest.cpp
@@ -413,6 +413,30 @@ int main(int argc, char **argv) {
 
    printf("=== dmaGpuToggleTest: %s ===\n", args.path);
 
+   /* Defensive cleanup of stale BAR0 per-buffer state from a prior
+    * test instance. test_gpu_dma_loopback.sh's run_with_retry harness
+    * re-invokes this binary on a 10s tx-ack timeout flake, but the
+    * prior instance's gpuRemNvidiaMemory only clears ctrl and
+    * RW_MAX_SIZE — remoteReadSize[] and freeList[] survive. On the
+    * next gpuAddNvidiaMemory(write=0) below, ctrl re-enables RE=1
+    * with rcnt=0; the kernel TX tick immediately reads the stale
+    * remoteReadSize[0]=65520, looks up the freshly-mapped (zero-
+    * filled) TX buffer, and emu_prbs_process_data fires
+    * WARN_ON_ONCE at prbs.c:123 because the new buffer's
+    * data32[1]=0 yields event_length=4 != stale reqsz=65520. Force
+    * a clean slate here. ctrl was already cleared to WE=0/RE=0 by
+    * the prior session's Gpu_RemNvidia, so no engine activity can
+    * race these writes. */
+   regs.setWriteEnable(0);
+   regs.setReadEnable(0);
+   {
+      const uint32_t maxBuffersHw = regs.maxBuffers();
+      for (uint32_t i = 0; i < maxBuffersHw; ++i) {
+         regs.setRemoteReadSize(i, 0);
+         regs.writeReg(regs.freeListOffset(i), 0);
+      }
+   }
+
    /* Allocate rx/tx buffer arrays. */
    uint8_t  *rxBuffs[kBufCnt] = {nullptr};
    uint8_t  *txBuffs[kBufCnt] = {nullptr};

--- a/data_dev/app/src/rdmaTestEmu.cpp
+++ b/data_dev/app/src/rdmaTestEmu.cpp
@@ -768,6 +768,30 @@ int main(int argc, char **argv) {
 
    GpuAsyncCoreRegs regs(bar0);
 
+   /* Defensive cleanup of stale BAR0 per-buffer state from a prior
+    * test instance. test_gpu_dma_loopback.sh's run_with_retry harness
+    * re-invokes this binary on a 10s tx-ack timeout flake, but the
+    * prior instance's gpuRemNvidiaMemory only clears ctrl and
+    * RW_MAX_SIZE — remoteReadSize[] and freeList[] survive. On the
+    * next gpuAddNvidiaMemory(write=0) below, ctrl re-enables RE=1
+    * with rcnt=0; the kernel TX tick immediately reads the stale
+    * remoteReadSize[0]=non-zero, looks up the freshly-mapped (zero-
+    * filled) TX buffer, and emu_prbs_process_data fires
+    * WARN_ON_ONCE at prbs.c:123 because the new buffer's
+    * data32[1]=0 yields event_length=4 != stale reqsz. Force a
+    * clean slate here. ctrl was already cleared to WE=0/RE=0 by the
+    * prior session's Gpu_RemNvidia, so no engine activity can race
+    * these writes. */
+   regs.setWriteEnable(0);
+   regs.setReadEnable(0);
+   {
+      const uint32_t maxBuffersHw = regs.maxBuffers();
+      for (uint32_t i = 0; i < maxBuffersHw; ++i) {
+         regs.setRemoteReadSize(i, 0);
+         regs.writeReg(regs.freeListOffset(i), 0);
+      }
+   }
+
    /* Allocate parallel arrays for rx/tx buffers + their stub buf_ids. */
    uint8_t *rxBuffs[kMaxBufCnt] = {0};
    uint8_t *txBuffs[kMaxBufCnt] = {0};


### PR DESCRIPTION
## Summary

- Defensively zero `remoteReadSize[i]` and `freeList[i]` for all `maxBuffers` slots at the start of `dmaGpuToggleTest` and `rdmaTestEmu`, before any `gpuAddNvidiaMemory` call has a chance to re-enable the engine
- Fixes the GPU-cell CI WARN at `src/prbs.c:123` triggered when `run_with_retry` re-invokes a test binary after a 10 s tx-ack scheduler flake

## Root cause

`run_with_retry` in `test_gpu_dma_loopback.sh` re-runs `dmaGpuToggleTest`/`rdmaTestEmu` if attempt 1 trips the 10 s tx-ack deadline. Attempt 1's atexit handler calls `gpuRemNvidiaMemory`, which clears `ctrl` and `RW_MAX_SIZE` only — `remoteReadSize[]` and `freeList[]` survive. On attempt 2's first `gpuAddNvidiaMemory(write=0)`, `Gpu_AddNvidia` re-enables `RE=1` with `rcnt=0`; the kernel TX tick reads the stale `remoteReadSize[0]=65520` against the freshly-mmapped (zero-filled) TX buffer and `emu_prbs_process_data` fires `WARN_ON_ONCE` at `prbs.c:123` because the new buffer's `data32[1]=0` yields `event_length=4 != reqsz=65520`. The retry attempt itself passes, but the WARN persists in dmesg and `check-dmesg.sh` fails the build (e.g. [GHA run 25139103893](https://github.com/slaclab/aes-stream-drivers/actions/runs/25139103893/job/73685598306), ubuntu:24.04 GPU cell).

`gpu_async.c` is intentionally not touched — CI's preamble gate 2 locks it against `origin/main`.

## Test plan

- [x] `cpplint` clean on both files
- [x] No trailing whitespace / no tabs (CI lint rule)
- [x] **Reproducer (unfixed)**: seeding `remoteReadSize[0..3]=65520` via direct BAR0 write and running `dmaGpuToggleTest` reproduces the exact CI WARN: `WARNING: CPU: 3 PID: 45244 at src/prbs.c:123 emu_prbs_process_data+0xd7/0x1b0`
- [x] **Reproducer (fixed)**: same seeded state → toggle test passes (`3 passed, 0 failed`), no `prbs.c` WARN in dmesg
- [x] Full GPU CI cell pass on KVM (ubuntu:24.04, kernel 6.17.0-1011-azure), all subtests green, dmesg clean