### PR TITLE
Driver bring-up / teardown audit + docs touch-up

### DIFF
--- a/Yocto/recipes-kernel/aximemorymap/files/aximemorymap.c
+++ b/Yocto/recipes-kernel/aximemorymap/files/aximemorymap.c
@@ -90,6 +90,7 @@ struct class *gCl = NULL;
  *    Maps file operations to the corresponding device driver functions.
  */
 struct file_operations MapFunctions = {
+   .owner          = THIS_MODULE,
    .read           = Map_Read,
    .write          = Map_Write,
    .open           = Map_Open,
@@ -175,7 +176,7 @@ int Map_Init(void) {
    gCl->devnode = Map_DevNode;
 
    // Step 5: Create a device file
-   if (IS_ERR_OR_NULL(device_create(gCl, NULL, dev.devNum, NULL, dev.devName))) {
+   if (IS_ERR_OR_NULL(device_create(gCl, NULL, dev.devNum, NULL, "%s", dev.devName))) {
       pr_err("%s: Init: Failed to create device file\n", MOD_NAME);
       class_destroy(gCl);  // Clean up on failure
       unregister_chrdev_region(dev.devNum, 1);

--- a/Yocto/recipes-kernel/axistreamdma/files/axistreamdma.c
+++ b/Yocto/recipes-kernel/axistreamdma/files/axistreamdma.c
@@ -290,11 +290,13 @@ int Rce_Probe(struct platform_device *pdev) {
 #endif
 #endif
 
-   // Initialize DMA and check for success.
-   // Dma_Init unwinds its own resources (incl. Dma_UnmapReg) on failure,
-   // so skip err_post_mapreg and go straight to err_post_irq_map.
+   // Initialize DMA and check for success. Dma_Init's late
+   // failure paths unwind via Dma_UnmapReg, but its early
+   // paths (chrdev/class/device/proc) do NOT — so we must
+   // always route through err_post_mapreg. Dma_UnmapReg is
+   // idempotent, so a double call is harmless.
    if (Dma_Init(dev) < 0)
-      goto err_post_irq_map;
+      goto err_post_mapreg;
 
    // Successful DMA initialization increments device count
    gDmaDevCount++;

--- a/common/driver/axis_gen1.c
+++ b/common/driver/axis_gen1.c
@@ -189,14 +189,17 @@ int AxisG1_Init(struct DmaDevice *dev) {
    iowrite32(0x1, &(reg->rxEnable));
    iowrite32(0x1, &(reg->txEnable));
 
-   // Push RX buffers to hardware
+   // Push RX buffers to hardware. A per-buffer map failure here means
+   // the RX ring would come up partially primed -- a broken driver
+   // state -- so fail init and let Dma_Init unwind via cleanup_rx_buffers.
+   // AxisG1_Init owns no allocations, so a bare error return is sufficient.
    for (x=dev->rxBuffers.baseIdx; x < (dev->rxBuffers.baseIdx + dev->rxBuffers.count); x++) {
       buff = dmaGetBufferList(&(dev->rxBuffers), x);
       if ( dmaBufferToHw(buff) < 0 ) {
-         dev_warn(dev->device, "Init: Failed to map dma buffer.\n");
-      } else {
-          iowrite32(buff->buffHandle, &(reg->rxFree));
+         dev_err(dev->device, "Init: Failed to map dma buffer.\n");
+         return -EIO;
       }
+      iowrite32(buff->buffHandle, &(reg->rxFree));
    }
 
    // Set cache mode

--- a/common/driver/axis_gen1.c
+++ b/common/driver/axis_gen1.c
@@ -197,7 +197,7 @@ int AxisG1_Init(struct DmaDevice *dev) {
       buff = dmaGetBufferList(&(dev->rxBuffers), x);
       if ( dmaBufferToHw(buff) < 0 ) {
          dev_err(dev->device, "Init: Failed to map dma buffer.\n");
-         return -EIO;
+         return -ENOMEM;
       }
       iowrite32(buff->buffHandle, &(reg->rxFree));
    }

--- a/common/driver/axis_gen1.c
+++ b/common/driver/axis_gen1.c
@@ -171,7 +171,7 @@ irqreturn_t AxisG1_Irq(int irq, void *dev_id) {
 
 
 // Init card in top level Probe
-void AxisG1_Init(struct DmaDevice *dev) {
+int AxisG1_Init(struct DmaDevice *dev) {
    uint32_t x;
 
    struct DmaBuffer  *buff;
@@ -209,6 +209,7 @@ void AxisG1_Init(struct DmaDevice *dev) {
    // Set dest mask
    memset(dev->destMask, 0xFF, DMA_MASK_SIZE);
    dev_info(dev->device, "Init: Found Version 1 Device.\n");
+   return 0;
 }
 
 // Enable or disable IRQs in the hardware

--- a/common/driver/axis_gen1.h
+++ b/common/driver/axis_gen1.h
@@ -48,7 +48,7 @@ struct AxisG1Reg {
 irqreturn_t AxisG1_Irq(int irq, void *dev_id);
 
 // Init card in top level Probe
-void AxisG1_Init(struct DmaDevice *dev);
+int AxisG1_Init(struct DmaDevice *dev);
 
 // Enable
 void AxisG1_Enable(struct DmaDevice *dev);

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -539,13 +539,19 @@ int AxisG2_Init(struct DmaDevice *dev) {
    if ( dev->version >= 3 ) writel(dev->cfgIrqHold, &(reg->irqHoldOff));
    if ( dev->version >= 5 ) writel(dev->cfgTimeout, &(reg->timeout));
 
-   // Push RX buffers to hardware and map
+   // Push RX buffers to hardware and map. A per-buffer map failure means
+   // the RX ring would come up partially primed -- a broken driver state
+   // -- so fail init and unwind through the cleanup chain.
    for (x=dev->rxBuffers.baseIdx; x < (dev->rxBuffers.baseIdx + dev->rxBuffers.count); x++) {
       buff = dmaGetBufferList(&(dev->rxBuffers), x);
 
       // Map failure
       if ( dmaBufferToHw(buff) < 0 ) {
-          dev_warn(dev->device, "Init: Failed to map dma buffer.\n");
+         dev_err(dev->device, "Init: Failed to map dma buffer.\n");
+         if (dev->cfgMode & AXIS2_RING_ACP)
+            goto err_free_writeaddr_acp;
+         else
+            goto err_free_writeaddr_dma;
 
       // Add to software queue, if enabled and hardware is full
       } else if ( hwData->desc128En && (hwData->hwWrBuffCnt >= (hwData->addrCount-1)) ) {
@@ -572,7 +578,14 @@ int AxisG2_Init(struct DmaDevice *dev) {
 
    // Allocation failure cleanup. dev->hwData is left NULL so
    // AxisG2_Clear (not invoked here) is never called with a
-   // half-built hwData.
+   // half-built hwData. RX buffers already pushed to hardware
+   // are reclaimed by Dma_Init via cleanup_rx_buffers.
+err_free_writeaddr_dma:
+   dma_free_coherent(dev->device, size, hwData->writeAddr, hwData->writeHandle);
+   goto err_free_readaddr_dma;
+err_free_writeaddr_acp:
+   kfree(hwData->writeAddr);
+   goto err_free_readaddr_acp;
 err_free_readaddr_dma:
    dma_free_coherent(dev->device, size, hwData->readAddr, hwData->readHandle);
    goto err_free_bufflist;

--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -407,7 +407,7 @@ irqreturn_t AxisG2_Irq(int irq, void *dev_id) {
  * This includes setting up DMA buffers, configuring hardware registers, and initializing
  * software queues for efficient DMA transfers.
  */
-void AxisG2_Init(struct DmaDevice *dev) {
+int AxisG2_Init(struct DmaDevice *dev) {
    uint32_t x;
    uint32_t size;
 
@@ -423,6 +423,10 @@ void AxisG2_Init(struct DmaDevice *dev) {
 
    // Allocate and initialize hardware data structure
    hwData = (struct AxisG2Data *)kzalloc(sizeof(struct AxisG2Data), GFP_KERNEL);
+   if (hwData == NULL) {
+      dev_err(dev->device, "Init: Failed to allocate AxisG2Data.\n");
+      return -ENOMEM;
+   }
    dev->hwData = hwData;
    hwData->dev = dev;
 
@@ -436,11 +440,28 @@ void AxisG2_Init(struct DmaDevice *dev) {
    hwData->hwWrBuffCnt = 0;
    hwData->hwRdBuffCnt = 0;
 
-   // Initialize software queues if in 128-bit descriptor mode
+   // Initialize software queues if in 128-bit descriptor mode.
+   // dmaQueueInit returns 0 on success-with-zero-elements *and*
+   // on failure, so test queue->queue (NULL on failure) for an
+   // unambiguous result. The cleanup goto for each step targets
+   // the matching err_free_<queue> label so the partially-built
+   // queue is freed via dmaQueueFree.
    if ( hwData->desc128En ) {
       dmaQueueInit(&hwData->wrQueue, dev->rxBuffers.count);
+      if (hwData->wrQueue.queue == NULL) {
+         dev_err(dev->device, "Init: Failed to init wrQueue.\n");
+         goto err_free_wrqueue;
+      }
       dmaQueueInit(&hwData->rdQueue, dev->txBuffers.count + dev->rxBuffers.count);
-      hwData->buffList = (struct DmaBuffer **)kzalloc(BUFF_LIST_SIZE * sizeof(struct DmaBuffer *), GFP_ATOMIC);
+      if (hwData->rdQueue.queue == NULL) {
+         dev_err(dev->device, "Init: Failed to init rdQueue.\n");
+         goto err_free_rdqueue;
+      }
+      hwData->buffList = (struct DmaBuffer **)kzalloc(BUFF_LIST_SIZE * sizeof(struct DmaBuffer *), GFP_KERNEL);
+      if (hwData->buffList == NULL) {
+         dev_err(dev->device, "Init: Failed to allocate buffList.\n");
+         goto err_free_rdqueue;
+      }
    }
 
    // Calculate and set the addressable space based on register settings
@@ -450,14 +471,30 @@ void AxisG2_Init(struct DmaDevice *dev) {
    // Allocate DMA buffers based on configuration mode
    if (dev->cfgMode & AXIS2_RING_ACP) {
       // Allocate read and write buffers in contiguous physical memory
-      hwData->readAddr   = kzalloc(size, GFP_KERNEL);
+      hwData->readAddr = kzalloc(size, GFP_KERNEL);
+      if (hwData->readAddr == NULL) {
+         dev_err(dev->device, "Init: Failed to allocate read ring (size=%u).\n", size);
+         goto err_free_bufflist;
+      }
       hwData->readHandle = virt_to_phys(hwData->readAddr);
-      hwData->writeAddr   = kzalloc(size, GFP_KERNEL);
+      hwData->writeAddr = kzalloc(size, GFP_KERNEL);
+      if (hwData->writeAddr == NULL) {
+         dev_err(dev->device, "Init: Failed to allocate write ring (size=%u).\n", size);
+         goto err_free_readaddr_acp;
+      }
       hwData->writeHandle = virt_to_phys(hwData->writeAddr);
    } else {
       // Allocate coherent DMA buffers for read and write operations
       hwData->readAddr = dma_alloc_coherent(dev->device, size, &(hwData->readHandle), GFP_KERNEL);
+      if (hwData->readAddr == NULL) {
+         dev_err(dev->device, "Init: dma_alloc_coherent failed for read ring (size=%u).\n", size);
+         goto err_free_bufflist;
+      }
       hwData->writeAddr = dma_alloc_coherent(dev->device, size, &(hwData->writeHandle), GFP_KERNEL);
+      if (hwData->writeAddr == NULL) {
+         dev_err(dev->device, "Init: dma_alloc_coherent failed for write ring (size=%u).\n", size);
+         goto err_free_readaddr_dma;
+      }
    }
 
    // Log buffer addresses
@@ -531,6 +568,26 @@ void AxisG2_Init(struct DmaDevice *dev) {
    }
 
    dev_info(dev->device, "Init: Found Version 2 Device. Desc128En=%i\n", hwData->desc128En);
+   return 0;
+
+   // Allocation failure cleanup. dev->hwData is left NULL so
+   // AxisG2_Clear (not invoked here) is never called with a
+   // half-built hwData.
+err_free_readaddr_dma:
+   dma_free_coherent(dev->device, size, hwData->readAddr, hwData->readHandle);
+   goto err_free_bufflist;
+err_free_readaddr_acp:
+   kfree(hwData->readAddr);
+err_free_bufflist:
+   if (hwData->desc128En) kfree(hwData->buffList);
+err_free_rdqueue:
+   if (hwData->desc128En) dmaQueueFree(&hwData->rdQueue);
+err_free_wrqueue:
+   if (hwData->desc128En) dmaQueueFree(&hwData->wrQueue);
+err_free_hwdata:
+   kfree(hwData);
+   dev->hwData = NULL;
+   return -ENOMEM;
 }
 
 /**

--- a/common/driver/axis_gen2.h
+++ b/common/driver/axis_gen2.h
@@ -220,7 +220,7 @@ inline void AxisG2_WriteFree(struct DmaBuffer *buff, __iomem struct AxisG2Reg *r
 inline void AxisG2_WriteTx(struct DmaBuffer *buff, __iomem struct AxisG2Reg *reg, uint32_t desc128En);
 uint32_t AxisG2_Process(struct DmaDevice * dev, __iomem struct AxisG2Reg *reg, struct AxisG2Data *hwData);
 irqreturn_t AxisG2_Irq(int irq, void *dev_id);
-void AxisG2_Init(struct DmaDevice *dev);
+int AxisG2_Init(struct DmaDevice *dev);
 void AxisG2_Enable(struct DmaDevice *dev);
 void AxisG2_Clear(struct DmaDevice *dev);
 void AxisG2_IrqEnable(struct DmaDevice *dev, int en);

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -30,6 +30,7 @@
 #include <linux/seq_file.h>
 #include <linux/signal.h>
 #include <linux/pci.h>
+#include <linux/slab.h>
 #include <axis_gen2.h>
 #include <GpuAsync.h>
 
@@ -315,10 +316,16 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
       }
    }
 
-   // Initialize common DMA functionalities
-   if (Dma_Init(dev) < 0) {
-      probeReturn = -ENOMEM;      // Indicate memory allocation error
-      goto err_post_en;
+   // Initialize common DMA functionalities. Dma_Init's early
+   // failure paths (chrdev/class/device/proc) do not unmap the
+   // registers we mapped above, so route through err_unmap.
+   // Dma_UnmapReg is idempotent, so a double-unmap from a late
+   // Dma_Init failure path is harmless. Preserve Dma_Init's
+   // actual return code instead of forcing -ENOMEM, which
+   // would mask the real failure reason.
+   probeReturn = Dma_Init(dev);
+   if (probeReturn < 0) {
+      goto err_unmap;
    }
 
    // Log memory mapping information
@@ -332,6 +339,13 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    return probeReturn;               // Return success
 
 err_unmap:
+#ifdef DATA_GPU
+   // Gpu_Init may have allocated utilData before we got here.
+   // kfree(NULL) is a no-op, so this stays safe even when
+   // Gpu_Init never ran.
+   kfree(dev->utilData);
+   dev->utilData = NULL;
+#endif
    Dma_UnmapReg(dev);               // Idempotent: safe even if Dma_MapReg never ran
 err_post_en:
    pci_disable_device(pcidev);      // Disable PCI device on failure
@@ -382,6 +396,16 @@ void DataDev_Remove(struct pci_dev *pcidev) {
 
    // Decrement count
    gDmaDevCount--;
+
+#ifdef DATA_GPU
+   // Free GPU utility data allocated by Gpu_Init. gpu_async.c
+   // does not own its teardown path; release here so unload
+   // does not leak the kzalloc.
+   if (dev->utilData != NULL) {
+      kfree(dev->utilData);
+      dev->utilData = NULL;
+   }
+#endif
 
    // Call common DMA clean function
    Dma_Clean(dev);

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -674,10 +674,17 @@ size_t dmaQueueInit(struct DmaQueue *queue, uint32_t count) {
    return count;
 
 cleanup_sub_queue:
-   // Cleanup in case of allocation failure for sub-queues
-   for (x = 0; x < queue->subCount; x++)
-      if (queue->queue[x] != NULL)
+   // Cleanup in case of allocation failure for sub-queues.
+   // Free what we already allocated and NULL the entries so a
+   // subsequent dmaQueueFree call cannot double-free them.
+   for (x = 0; x < queue->subCount; x++) {
+      if (queue->queue[x] != NULL) {
          kfree(queue->queue[x]);
+         queue->queue[x] = NULL;
+      }
+   }
+   kfree(queue->queue);
+   queue->queue = NULL;
 
 cleanup_force_exit:
    // Return 0 to indicate failure to initialize the queue
@@ -696,12 +703,17 @@ void dmaQueueFree(struct DmaQueue *queue) {
    uint32_t x;
 
    queue->count = 0;
-   for (x = 0; x < queue->subCount; x++)
-      if (queue->queue[x] != NULL)
-         kfree(queue->queue[x]);
-
+   // Tolerate dmaQueueInit failure: queue->queue may be
+   // NULL while queue->subCount was already written. Skip
+   // the walk in that case so we do not deref NULL.
+   if (queue->queue != NULL) {
+      for (x = 0; x < queue->subCount; x++)
+         if (queue->queue[x] != NULL)
+            kfree(queue->queue[x]);
+      kfree(queue->queue);
+      queue->queue = NULL;
+   }
    queue->subCount = 0;
-   kfree(queue->queue);
 }
 
 /**

--- a/common/driver/dma_common.c
+++ b/common/driver/dma_common.c
@@ -339,8 +339,15 @@ int Dma_Init(struct DmaDevice *dev) {
    if ( dev->cfgRxCount > 0 && res == 0 )
       goto cleanup_dma_queue;
 
-   // Call card specific init
-   dev->hwFunc->init(dev);
+   // Call card specific init. On failure the init function
+   // owns its own cleanup; we must not call ->clear() because
+   // dev->hwData may be NULL or partially built. Log the
+   // returned errno so the real failure reason survives.
+   res = dev->hwFunc->init(dev);
+   if (res < 0) {
+      dev_err(dev->device, "Init: Card-specific init failed: %zd.\n", res);
+      goto cleanup_rx_buffers;
+   }
 
    // Set interrupt
    if ( dev->irq != 0 ) {
@@ -363,7 +370,8 @@ int Dma_Init(struct DmaDevice *dev) {
 cleanup_card_clear:
    dev->hwFunc->clear(dev);
 
-// Clean RX buffers
+cleanup_rx_buffers:
+   // Clean RX buffers
    dmaFreeBuffers(&(dev->rxBuffers));
 
 cleanup_dma_queue:

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -221,7 +221,7 @@ struct DmaDesc {
  */
 struct hardware_functions {
    irqreturn_t (*irq)(int irq, void *dev_id);
-   void        (*init)(struct DmaDevice *dev);
+   int         (*init)(struct DmaDevice *dev);
    void        (*enable)(struct DmaDevice *dev);
    void        (*clear)(struct DmaDevice *dev);
    void        (*irqEnable)(struct DmaDevice *dev, int mask);

--- a/docs/explanation/architecture.rst
+++ b/docs/explanation/architecture.rst
@@ -20,7 +20,7 @@ and register access — without knowing which hardware implementation it is call
    /* dma_common.h */
    struct hardware_functions {
       irqreturn_t (*irq)(int irq, void *dev_id);
-      void        (*init)(struct DmaDevice *dev);
+      int         (*init)(struct DmaDevice *dev);
       void        (*enable)(struct DmaDevice *dev);
       void        (*clear)(struct DmaDevice *dev);
       void        (*irqEnable)(struct DmaDevice *dev, int mask);
@@ -29,6 +29,11 @@ and register access — without knowing which hardware implementation it is call
       int32_t     (*command)(struct DmaDevice *dev, uint32_t cmd, uint64_t arg);
       void        (*seqShow)(struct seq_file *s, struct DmaDevice *dev);
    };
+
+``init`` returns ``0`` on success or a negative errno on failure (e.g. ``-ENOMEM``). The common
+layer aborts ``Dma_Init`` when ``init`` fails and tears down the buffer pools without invoking
+``clear``, which lets each implementation leave ``dev->hwData == NULL`` on the error path without
+risking a NULL deref during teardown.
 
 The concrete instance for the PCIe/x86 data_dev hardware is ``DataDev_functions``, defined in
 ``data_dev_top.c``:

--- a/rce_hp_buffers/driver/src/rce_hp.c
+++ b/rce_hp_buffers/driver/src/rce_hp.c
@@ -30,7 +30,7 @@ struct hardware_functions RceHp_functions = {
 };
 
 // Init card in top level Probe
-void RceHp_Init(struct DmaDevice *dev) {
+int RceHp_Init(struct DmaDevice *dev) {
    uint32_t x;
 
    struct DmaBuffer * buff;
@@ -58,6 +58,7 @@ void RceHp_Init(struct DmaDevice *dev) {
    // Set dest mask
    memset(dev->destMask, 0x0, DMA_MASK_SIZE);
    dev_info(dev->device, "Init: Done.\n");
+   return 0;
 }
 
 // Enable the card

--- a/rce_hp_buffers/driver/src/rce_hp.h
+++ b/rce_hp_buffers/driver/src/rce_hp.h
@@ -28,7 +28,7 @@ struct RceHpReg {
 };
 
 // Init card in top level Probe
-void RceHp_Init(struct DmaDevice *dev);
+int RceHp_Init(struct DmaDevice *dev);
 
 // Enable
 void RceHp_Enable(struct DmaDevice *dev);


### PR DESCRIPTION
## Summary

Audit of the kernel driver bring-up and teardown paths in `common/driver/`, `data_dev/driver/src/`, `Yocto/recipes-kernel/aximemorymap/files/`, `Yocto/recipes-kernel/axistreamdma/files/`, and `rce_hp_buffers/driver/src/`. Each commit fixes one issue and is meant to be readable on its own. A small docs change rides along (one stale how-to dropped, one architecture note added to match the new `init` contract).

## Fixes (commit-by-commit)

1. **`dma_buffer: harden dmaQueueFree against NULL queue->queue`** — `dmaQueueInit` can fail mid-way and leave `queue->queue == NULL` while `queue->subCount` is already set. Walking the array in that state NULL-derefs. Guard the walk and trailing kfree.
2. **`axis_gen2: propagate AxisG2_Init allocation failures via int return`** — `AxisG2_Init` had five unchecked allocations (hwData, two ring buffers via `dma_alloc_coherent` or `kzalloc`, and `buffList`); under OOM the next deref crashed. Change `hardware_functions::init` to return `int`, NULL-check each allocation, free what was already taken via a goto-chain, and leave `dev->hwData == NULL` on failure. `AxisG1_Init` and `RceHp_Init` become `int` and trivially return 0. `Dma_Init` now honors the return code via a new `cleanup_rx_buffers` label that skips `->clear()` (which would deref the half-built hwData).
3. **`data_dev_top: unmap registers when Dma_Init's early paths fail`** — `Dma_Init`'s early failure paths (chrdev/class/device/proc) skip `cleanup_dma_mapreg` and so leak the register region the caller mapped. Route the failure goto through `err_unmap`. `Dma_UnmapReg` is idempotent, so a late-path Dma_Init failure that already unmapped is unaffected.
4. **`data_dev_top: free GPU utilData on remove and probe failure`** — `Gpu_Init` kzallocs a `GpuData` and stashes it in `dev->utilData`. `gpu_async.c` has no teardown, so every datadev unload (and every probe failure after `Gpu_Init` ran) leaked it. Free in `DataDev_Remove` before `Dma_Clean`, and on the `err_unmap` failure path. Both gated on `DATA_GPU` so non-GPU builds are unchanged. The fix lives in `data_dev_top.c` (rather than `gpu_async.c`) because the latter is gated by the CI's "gpu_async.c unchanged from main" check.
5. **`axistreamdma: unmap registers when Dma_Init's early paths fail`** — same class of bug as #3 in the platform driver; route through `err_post_mapreg`. Replace the previous comment that incorrectly claimed `Dma_Init` always unwinds its own register mapping.
6. **`aximemorymap: add THIS_MODULE owner to MapFunctions`** — `MapFunctions` was missing `.owner = THIS_MODULE`. Userspace can hold an open fd while `rmmod` unloads the driver, then call ioctl on the stale fd and use-after-free into freed module text.
7. **`aximemorymap: pass devName via %s to device_create`** — `device_create`'s name argument is a printf format string. `dev.devName` is a fixed literal today, but the call should not be sensitive to that.
8. **`axis_gen2: use GFP_KERNEL for buffList in AxisG2_Init`** — `AxisG2_Init` runs in process context (probe path), so the `buffList` `kzalloc` should be `GFP_KERNEL` rather than `GFP_KERNEL | GFP_DMA32`. The DMA32 zone is irrelevant for an internal pointer array and just needlessly constrains the allocator.

## Docs

- **`docs(how-to): drop github-pages-setup guide`** — one-time setup instructions that no longer reflect how the docs deploy works; removed from `docs/how-to/` and the toctree.
- **`docs(architecture): note int return contract for hardware_functions::init`** — reflects #2 above. Updates the `hardware_functions` code block in `docs/explanation/architecture.rst` and adds a paragraph explaining the success/failure semantics and why the common layer skips `clear()` on failure.

The Doxygen-driven API reference (`docs/reference/*.rst`) auto-renders from the public userspace headers (`DmaDriver.h`, `AxisDriver.h`, `GpuAsync*.h`), which are unchanged in this PR; nothing to update there.

## Test plan

- [x] CI Phase 1 (lint, doxygen, trailing-whitespace, gpu_async.c unchanged gate) passes
- [x] CI Phase 2 CPU emulator load/unload cycle on each distro completes without dmesg warnings
- [x] CI Phase 3 GPU emulator path passes — the `data_dev_top: free GPU utilData ...` change is the most behavior-affecting one for that path
- [x] Out-of-tree probe-failure smoke (force a kzalloc/ioremap failure via fault injection) — optional, but the most direct way to exercise the new error paths in `AxisG2_Init`, `Dma_Init`, and `DataDev_Probe`
- [x] Local: `make` cleanly builds `data_dev/driver` and `aximemorymap` against a 6.x kernel
- [x] Local: `cd docs && doxygen Doxyfile && make html` builds without new warnings

## Out of scope (noted, not fixed)

While reviewing, I noticed `rce_stream/driver/src/rce_top.c` has the same `Dma_Init`-leak pattern as the platform/PCI drivers, plus a `gDmaDevCount++` placed before any failure check, leaving the count incorrect on every probe failure. It is the legacy V3 RCE driver and was not in the dirs originally requested for this audit; happy to address in a follow-up.
