### PR TITLE
axistreamdma: report real Git Version in /proc/axi_stream_dma_0

### DIFF
--- a/Yocto/recipes-kernel/axistreamdma/axistreamdma.bb
+++ b/Yocto/recipes-kernel/axistreamdma/axistreamdma.bb
@@ -7,6 +7,29 @@ inherit module
 
 INHIBIT_PACKAGE_STRIP = "1"
 
+# Resolve the aes-stream-drivers Git version at recipe parse time so the
+# axi_stream_dma kernel module reports the real upstream tag in
+# /proc/axi_stream_dma_0 — matching the host data_dev driver semantic.
+# This must run at parse time (not do_configure) because by the time
+# do_configure runs, sources have been copied to WORKDIR and ${THISDIR}
+# is no longer a path inside a git checkout from the build's perspective.
+python __anonymous() {
+    import subprocess
+    repo = d.expand("${THISDIR}/../../..")
+    def _git(args):
+        try:
+            return subprocess.check_output(
+                ["git", "-C", repo] + args,
+                stderr=subprocess.DEVNULL,
+            ).decode().strip()
+        except Exception:
+            return ""
+    tag = _git(["describe", "--tags"]) or _git(["rev-parse", "--short", "HEAD"]) or "emulator"
+    if _git(["status", "--short", "-uno"]):
+        tag += "-dirty"
+    d.setVar("GITV", tag)
+}
+
 SRC_URI = "file://Makefile \
            file://axistreamdma.h \
            file://axistreamdma.c \
@@ -35,6 +58,7 @@ do_compile() {
            DMA_TX_BUFF_COUNT=${DMA_TX_BUFF_COUNT} \
            DMA_RX_BUFF_COUNT=${DMA_RX_BUFF_COUNT} \
            DMA_BUFF_SIZE=${DMA_BUFF_SIZE} \
+           GITV="${GITV}" \
            ${MAKE_TARGETS}
 }
 

--- a/Yocto/recipes-kernel/axistreamdma/files/Makefile
+++ b/Yocto/recipes-kernel/axistreamdma/files/Makefile
@@ -19,8 +19,18 @@ NAME := axi_stream_dma
 # Directory containing the Makefile
 HOME := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-# Version or identifier for this build
-GITV := yocto
+# Automatically determine the git version (override via GITV=... from caller, e.g. recipe)
+ifndef GITV
+    GITT := $(shell cd $(HOME); git describe --tags 2>/dev/null)
+    ifeq ($(GITT),)
+        GITT := $(shell cd $(HOME); git rev-parse --short HEAD 2>/dev/null)
+    endif
+    ifeq ($(GITT),)
+        GITT := emulator
+    endif
+    GITD := $(shell cd $(HOME); git status --short -uno 2>/dev/null | wc -l)
+    GITV := $(if $(filter $(GITD),0),$(GITT),$(GITT)-dirty)
+endif
 
 # Source files discovery within the same directory as the Makefile
 SRCS := $(wildcard $(HOME)/*.c)


### PR DESCRIPTION
## Summary

Make the Yocto-built `axi_stream_dma` kernel module report its real Git Version
in `/proc/axi_stream_dma_0` — matching the format already produced by the host
`data_dev` driver (tag, tag-dirty, short-SHA, short-SHA-dirty, or `emulator`).

Before this change, `cat /proc/axi_stream_dma_0` on a Yocto-baked image showed:
`DMA Driver's Git Version : yocto` (the literal placeholder string hardcoded in
the Yocto Makefile).

After this change, it shows the real upstream version, e.g.:
`DMA Driver's Git Version : 7.2.1-2-gf55ab44`.

## Commits

1. **`axistreamdma: honor GITV override and use git-describe fallback`**
   Replaces the hardcoded `GITV := yocto` line in
   `Yocto/recipes-kernel/axistreamdma/files/Makefile` with the same
   `ifndef GITV` / `git describe` / `rev-parse --short HEAD` / `emulator`
   fallback chain used by `data_dev/driver/Makefile:57-67`. Verbatim copy of the
   reference block — behavior matches the host build byte-for-byte.

2. **`axistreamdma: resolve GITV at recipe parse time and pass to oe_runmake`**
   Adds a `python __anonymous` hook in `axistreamdma.bb` that resolves the
   `aes-stream-drivers` repo version (`describe` → `rev-parse --short HEAD` →
   `emulator`, with `-dirty` suffix when the working tree is modified) against
   `\${THISDIR}/../../..` at recipe-parse time, then passes `GITV=\"\${GITV}\"`
   to `oe_runmake` in `do_compile`. Parse-time resolution is required because
   by the time `do_configure` runs, sources have been copied to WORKDIR and the
   `.git` directory of the aes-stream-drivers checkout is no longer reachable
   from the build's working directory.

## Why parse-time, not configure-time

Yocto's `file://` SRC_URI strips git metadata when copying sources to WORKDIR,
so any in-Makefile `git describe` would always fall back to \`emulator\`. The
recipe must inject the version from a context where the aes-stream-drivers
checkout is still reachable — and \`\${THISDIR}\` only points at the repo
during recipe parse (it points at WORKDIR after \`do_unpack\`). The Makefile
honors the injected GITV via the new \`ifndef GITV\` guard, so when GITV is
passed through, no \`git\` is invoked inside the Yocto build at all.

## Scope

- Only \`axistreamdma.bb\` and \`axistreamdma/files/Makefile\` change.
- Sibling recipes (\`aximemorymap\`, \`axidmasamples\`) and the host
  \`data_dev\` driver are intentionally untouched.
- No new dependencies; uses Python stdlib (\`subprocess\`) inside the recipe
  hook, which is always available in the BitBake parser context.

## Test plan

- [x] Host: \`make HOME=\$(pwd) GITV=test-override -p -n clean\` shows
      \`GITV = test-override\` (override path).
- [x] Host: \`make HOME=\$(pwd) -p -n clean\` shows
      \`GITV := <git-describe output>\` (fallback path).
- [x] \`bitbake -e axistreamdma | grep ^GITV=\` shows the parse-time
      resolved version.
- [x] Yocto-baked image booted on RFSoC 4x2:
      \`cat /proc/axi_stream_dma_0\` reports
      \`DMA Driver's Git Version : 7.2.1-2-gf55ab44\` (real \`git describe\`
      output, formatted identically to the host \`data_dev\` driver's
      \`/proc/datadev_0\` output).