### PR TITLE
Add gpuEnableRx/Tx, avoid setting internal regs in rdmaTest

### DIFF
--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -502,6 +502,8 @@ int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
       case GPU_Set_Write_Enable:
       case GPU_Get_Gpu_Async_Ver:
       case GPU_Get_Max_Buffers:
+      case GPU_Enable_Rx:
+      case GPU_Enable_Tx:
 #ifdef DATA_GPU
          return dev->gpuEn ? Gpu_Command(dev, cmd, arg) : -ENOTSUPP;
 #else

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -145,6 +145,14 @@ int32_t Gpu_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
       case GPU_Get_Max_Buffers:
          return (int32_t)data->maxBuffers;
 
+      // Enable TX operations
+      case GPU_Enable_Tx:
+         return Gpu_EnableTx(dev, arg);
+
+      // Enable RX operations
+      case GPU_Enable_Rx:
+         return Gpu_EnableRx(dev, arg);
+
       default:
          dev_warn(dev->device, "Command: Invalid command=%u\n", cmd);
          return -1;
@@ -314,7 +322,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
          x |= 0x00000100;  // Set write-enable bit
          x |= (data->writeBuffers.count-1);  // Set the 0-based write buffer count
       } else {
-         x |= 1 << 15;  // Set write-enable bit
+         x &= ~(1 << 15);  // Clear write-enable bit; User space must call gpuEnableTx to set this.
          x |= (data->writeBuffers.count-1) & 0x7FFF;  // Set the 0-based write buffer count
       }
    }
@@ -324,7 +332,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
          x |= 0x01000000;  // Set read-enable bit
          x |= (data->readBuffers.count-1) << 16;  // Set the 0-based read buffer count
       } else {
-         x |= 1 << 31;  // Set read-enable bit
+         x &= ~(1 << 31);  // Clear read-enable bit; User space must call gpuEnableRx to set this.
          x |= (data->readBuffers.count-1) << 16;  // Set the 0-based read buffer count
       }
    }
@@ -635,4 +643,42 @@ void Gpu_Show(struct seq_file *s, struct DmaDevice *dev) {
       seq_printf(s, "  Read Address : 0x%llX\n", ((u64)rah << 32) | ral);
       seq_printf(s, "     Read Size : 0x%X\n", rs);
    }
+}
+
+/**
+ * @brief Toggles the write enable bit
+ * @param dev The device
+ * @param enable Enable or disable. Treated as a boolean.
+ */
+int32_t Gpu_EnableTx(struct DmaDevice *dev, uint64_t enable) {
+   struct GpuData* data = (struct GpuData*)dev->utilData;
+
+   const struct GpuAsyncRegister* theReg = NULL;
+   if (data->version < 4) {
+      theReg = &GpuAsyncReg_WriteEnableV1;
+   } else {
+      theReg = &GpuAsyncReg_WriteEnableV4;
+   }
+
+   writeGpuAsyncReg(data->base, theReg, !!enable);
+   return 0;
+}
+
+/**
+ * @brief Toggles the read enable bit
+ * @param dev The device
+ * @param enable Enable or disable. Treated as a boolean.
+ */
+int32_t Gpu_EnableRx(struct DmaDevice *dev, uint64_t enable) {
+   struct GpuData* data = (struct GpuData*)dev->utilData;
+
+   const struct GpuAsyncRegister* theReg = NULL;
+   if (data->version < 4) {
+      theReg = &GpuAsyncReg_ReadEnableV1;
+   } else {
+      theReg = &GpuAsyncReg_ReadEnableV4;
+   }
+
+   writeGpuAsyncReg(data->base, theReg, !!enable);
+   return 0;
 }

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -114,5 +114,7 @@ void Gpu_FreeNvidia(void * data);
 int32_t Gpu_SetWriteEn(struct DmaDevice *dev, uint64_t arg);
 void Gpu_Show(struct seq_file *s, struct DmaDevice *dev);
 int32_t Gpu_GetVersion(struct DmaDevice *dev);
+int32_t Gpu_EnableTx(struct DmaDevice *dev, uint64_t enable);
+int32_t Gpu_EnableRx(struct DmaDevice *dev, uint64_t enable);
 
 #endif  // __GPU_ASYNC_2_H__

--- a/data_dev/app/src/dmaGpuToggleTest.cpp
+++ b/data_dev/app/src/dmaGpuToggleTest.cpp
@@ -5,12 +5,12 @@
  * Description:
  *    Mid-stream state-transition test for the GPU-async data path emulator.
  *    Three subtests:
- *      1. toggle_disable: setWriteEnable(0)+setReadEnable(0) mid-run;
+ *      1. toggle_disable: gpuEnableTx(0)+gpuEnableRx(0) mid-run;
  *         100ms quiesce + countReset + 100ms settle; assert
  *         rxFrameCnt==0 && txFrameCnt==0 (race-immune zero baseline).
- *      2. toggle_resume:  setWriteEnable(1)+setReadEnable(1); run 4 frames
+ *      2. toggle_resume:  gpuEnableTx(1)+gpuEnableRx(1); run 4 frames
  *         (one full round-robin at bufCnt=4); assert PRBS clean on first frame.
- *      3. maxbuffers_4to2: while traffic flowing, writeCount(1)+readCount(1)
+ *      3. maxbuffers_4to2: while traffic flowing, setWriteCount(2)+setReadCount(2)
  *         (reduces 4->2 active buffers); run 100 more frames; assert no
  *         dmesg WARN/KASAN and no PRBS mismatch.
  *
@@ -327,24 +327,24 @@ static int runOneFrame(GpuAsyncCoreRegs &regs, int bufCnt, int curBuff,
  * RemoteWriteMaxSize, bring engine back up.
  * -------------------------------------------------------------------------*/
 
-static void armBuffers(GpuAsyncCoreRegs &regs, int bufCnt,
+static void armBuffers(GpuAsyncCoreRegs &regs, int fd, int bufCnt,
                        uint8_t **rxBuffs, uint8_t **txBuffs,
                        uint32_t bufSize) {
    const uint32_t dmaHeaderSize = regs.dmaDataBytes();
 
-   /* Quiesce-and-reset: the sequential setWriteEnable(0) +
-    * setReadEnable(0) pair is NOT atomic vs the 1ms emu_gpu_poll kthread,
+   /* Quiesce-and-reset: the sequential gpuEnableTx(0) +
+    * gpuEnableRx(0) pair is NOT atomic vs the 1ms emu_gpu_poll kthread,
     * so wait 100ms for any in-flight tick to drain, call countReset() to
     * establish a zero baseline for both counters, then wait another 100ms
     * to confirm no further motion before re-arming. */
-   regs.setWriteEnable(0);
-   regs.setReadEnable(0);
+   gpuEnableTx(fd, 0);
+   gpuEnableRx(fd, 0);
    ::usleep(100000);          /* let kthread drain any pending tick */
    regs.countReset();         /* establish zero baseline */
    ::usleep(100000);          /* confirm no further counter motion */
 
-   regs.setWriteCount(bufCnt - 1);
-   regs.setReadCount(bufCnt - 1);
+   /* Buffer count is established by gpuAddNvidiaMemory during registration;
+    * no explicit setWriteCount/setReadCount needed here. */
 
    for (int i = 0; i < bufCnt; ++i) {
       regs.writeReg(regs.freeListOffset(i), 1);
@@ -354,8 +354,8 @@ static void armBuffers(GpuAsyncCoreRegs &regs, int bufCnt,
 
    regs.setRemoteWriteMaxSize(0, bufSize - dmaHeaderSize);
 
-   regs.setWriteEnable(1);
-   regs.setReadEnable(1);
+   gpuEnableTx(fd, 1);
+   gpuEnableRx(fd, 1);
 }
 
 /* ---------------------------------------------------------------------------
@@ -427,8 +427,8 @@ int main(int argc, char **argv) {
     * a clean slate here. ctrl was already cleared to WE=0/RE=0 by
     * the prior session's Gpu_RemNvidia, so no engine activity can
     * race these writes. */
-   regs.setWriteEnable(0);
-   regs.setReadEnable(0);
+   gpuEnableTx(fd, 0);
+   gpuEnableRx(fd, 0);
    {
       const uint32_t maxBuffersHw = regs.maxBuffers();
       for (uint32_t i = 0; i < maxBuffersHw; ++i) {
@@ -474,7 +474,7 @@ int main(int argc, char **argv) {
 
    /* Reset counters and bring the engine up. */
    regs.countReset();
-   armBuffers(regs, kBufCnt, rxBuffs, txBuffs, kBufSize);
+   armBuffers(regs, fd, kBufCnt, rxBuffs, txBuffs, kBufSize);
 
    /*
     * Single shared PrbsData instance across all subtests.
@@ -505,7 +505,7 @@ int main(int argc, char **argv) {
 
       /* ---- Subtest 1: toggle_disable (quiesce-and-reset) ----
        *
-       * The sequential setWriteEnable(0) + setReadEnable(0) pair is NOT atomic
+       * The sequential gpuEnableTx(0) + gpuEnableRx(0) pair is NOT atomic
        * vs the 1ms emu_gpu_poll kthread: in the us-scale window between the
        * two BAR0 writes the kthread can fire and process up to kBufCnt pending
        * ticks on the direction whose enable has not yet been cleared. Prior
@@ -518,8 +518,8 @@ int main(int argc, char **argv) {
        * is race-immune because CntRst happens after the kthread has already
        * drained any pending in-flight ticks, and any further tick after
        * CntRst would require re-enabling — which this subtest does not do. */
-      regs.setWriteEnable(0);
-      regs.setReadEnable(0);
+      gpuEnableTx(fd, 0);
+      gpuEnableRx(fd, 0);
       ::usleep(100000);               /* drain pending kthread tick */
       regs.countReset();              /* zero baseline for both counters */
       ::usleep(100000);               /* verify no motion post-reset */
@@ -536,8 +536,8 @@ int main(int argc, char **argv) {
       /* Re-enable engine; arm doorbells so round-robin starts from buffer 0.
        * Observable contract: VHDL-faithful nextWriteIdx resets to
        * 0 on disable, so the engine resumes from buffer 0 post-enable. */
-      regs.setWriteEnable(1);
-      regs.setReadEnable(1);
+      gpuEnableTx(fd, 1);
+      gpuEnableRx(fd, 1);
 
       /* Re-arm all doorbells for the resumed run (freelist + rx doorbell clear). */
       for (int i = 0; i < kBufCnt; ++i) {
@@ -608,10 +608,10 @@ int main(int argc, char **argv) {
 
       /* Mid-flight buffer count reduction: 4->2 via BAR0 writes.
        * Kernel reads writeCount once per tick and clamps nextWriteIdx via
-       * idx % (wcnt + 1) (gpu_engine.c:218).
-       * N = activeBufs - 1, so setWriteCount(1) = 2 active buffers. */
-      regs.setWriteCount(1);
-      regs.setReadCount(1);
+       * idx % (wcnt + 1) (gpu_engine.c:218). setWriteCount/setReadCount take
+       * a 1-based active-buffer count, so 2 = two active buffers. */
+      regs.setWriteCount(2);
+      regs.setReadCount(2);
       int reducedBufCnt = 2;
 
       /* Run kPostReduceFrames frames with bufCnt=2 (curBuff wraps 0,1,0,1,...).

--- a/data_dev/app/src/rdmaTest.cu
+++ b/data_dev/app/src/rdmaTest.cu
@@ -209,11 +209,10 @@ static int initSession(TestSession& s, const char* dev, int gpuIdx,
     s.coreRegs = new GpuAsyncCoreRegs(s.regs.ptr);
 
     /* Disable engines first; idempotent recovery from a prior crashed run. */
-    s.coreRegs->setWriteEnable(0);
-    s.coreRegs->setReadEnable(0);
+    gpuEnableTx(fd, 0);
+    gpuEnableRx(fd, 0);
 
     s.dmaHeaderSize = s.coreRegs->dmaDataBytes();
-    s.coreRegs->setRemoteWriteMaxSize(0, bufSize);
 
     /* Allocate rx (and optionally tx) buffers sized bufSize + dmaHeaderSize for
      * descriptor headroom; only bufSize is registered with the FPGA. */
@@ -249,9 +248,6 @@ static int initSession(TestSession& s, const char* dev, int gpuIdx,
         return -1;
     }
 
-    s.coreRegs->setWriteCount(bufCnt - 1);
-    s.coreRegs->setReadCount(bufCnt - 1);
-
     /* Arm the FPGA free list and pre-clear doorbells via the GPU stream so the
      * writes traverse the same PCIe path as runtime traffic. The host enable
      * below must wait for these to land. */
@@ -276,9 +272,9 @@ static int initSession(TestSession& s, const char* dev, int gpuIdx,
         return -1;
     }
 
-    s.coreRegs->setWriteEnable(1);
+    gpuEnableTx(fd, 1);
     if (loopback)
-        s.coreRegs->setReadEnable(1);
+        gpuEnableRx(fd, 1);
 
     return 0;
 }

--- a/data_dev/app/src/rdmaTestEmu.cpp
+++ b/data_dev/app/src/rdmaTestEmu.cpp
@@ -318,13 +318,13 @@ static uint32_t emu_wait_value32_with_deadline(
  *
  * Faithful port of rdmaTest.cu's runSimpleLoop with the three
  * substitutions for the CPU emulator. Required sequencing:
- * setWriteEnable(0)/setReadEnable(0), arm free-list + clear doorbells
+ * gpuEnableTx(0)/gpuEnableRx(0), arm free-list + clear doorbells
  * per buffer, setRemoteWriteMaxSize, then enables go LAST. The
  * rxBuffs[i]+4 pre-clear in the arming block plus the per-frame clear
  * after the memcpy prevents a stale doorbell from acking the next frame.
  * -------------------------------------------------------------------------*/
 
-static void runSimpleLoop(GpuAsyncCoreRegs &regs, int bufCnt,
+static void runSimpleLoop(GpuAsyncCoreRegs &regs, int fd, int bufCnt,
                           uint8_t **rxBuffs, uint8_t **txBuffs,
                           int frameCount, uint32_t bufSize) {
    const uint32_t dmaHeaderSize = regs.dmaDataBytes();
@@ -358,14 +358,14 @@ static void runSimpleLoop(GpuAsyncCoreRegs &regs, int bufCnt,
     * this run's counters from any prior iteration (sweep mode calls
     * runSimpleLoop multiple times; without reset, later iterations
     * inherit earlier frame counts). */
-   regs.setWriteEnable(0);
-   regs.setReadEnable(0);
+   gpuEnableTx(fd, 0);
+   gpuEnableRx(fd, 0);
    ::usleep(100000);       /* drain pending kthread tick */
    regs.countReset();      /* isolate this run's counters */
    ::usleep(100000);       /* confirm no motion post-reset */
 
-   regs.setWriteCount(bufCnt - 1);
-   regs.setReadCount(bufCnt - 1);
+   /* Buffer count is established by gpuAddNvidiaMemory during registration;
+    * no explicit setWriteCount/setReadCount needed here. */
 
    for (int i = 0; i < bufCnt; ++i) {
       /* Arm FPGA's free-list slot for buffer i. */
@@ -390,8 +390,8 @@ static void runSimpleLoop(GpuAsyncCoreRegs &regs, int bufCnt,
    regs.setRemoteWriteMaxSize(0, bufSize - dmaHeaderSize);
 
    /* Now bring both directions back online. */
-   regs.setWriteEnable(1);
-   regs.setReadEnable(1);
+   gpuEnableTx(fd, 1);
+   gpuEnableRx(fd, 1);
 
    int curBuff = 0;
    for (int n = 0; n < frameCount; ++n) {
@@ -548,7 +548,7 @@ static void reallocBuffersAtSize(
 
    /* 1. Pause the poll thread BEFORE touching any registration.
     *
-    * The sequential setWriteEnable(0) + setReadEnable(0) pair is NOT atomic
+    * The sequential gpuEnableTx(0) + gpuEnableRx(0) pair is NOT atomic
     * vs the 1ms emu_gpu_poll kthread. Between the two BAR0 writes the
     * kthread can fire and process up to kBufCnt pending ticks on whichever
     * direction still has its enable bit set. Without the quiesce-and-reset
@@ -558,8 +558,8 @@ static void reallocBuffersAtSize(
     * Fix: after the disable-pair, wait 100ms for the kthread to drain,
     * countReset() to zero the BAR0 counters for a fresh baseline, then
     * wait 100ms more before re-enabling. */
-   regs.setWriteEnable(0);
-   regs.setReadEnable(0);
+   gpuEnableTx(fd, 0);
+   gpuEnableRx(fd, 0);
    ::usleep(100000);       /* drain pending kthread tick */
    regs.countReset();      /* zero baseline — eliminates race-window leak */
    ::usleep(100000);       /* confirm no motion post-reset */
@@ -622,13 +622,11 @@ static void reallocBuffersAtSize(
       }
    }
 
-   /* 6. Update header + counts for the new size. setWriteCount /
-    *    setReadCount are redundant with runSimpleLoop's setup but kept
-    *    here for parity with the pre-loop block. RemoteWriteMaxSize
-    *    holds payload size, buffer = payload + dmaDataBytes(). */
+   /* 6. Update header for the new size. The buffer count is re-established
+    *    by the gpuAddNvidiaMemory calls above, so no explicit count write is
+    *    needed. RemoteWriteMaxSize holds payload size, buffer = payload +
+    *    dmaDataBytes(). */
    regs.setRemoteWriteMaxSize(0, newSize - regs.dmaDataBytes());
-   regs.setWriteCount(bufCnt - 1);
-   regs.setReadCount(bufCnt - 1);
 
    /* runSimpleLoop re-arms free-list + doorbells and flips the enables
     * back on; no separate resume needed here. */
@@ -667,7 +665,7 @@ static void runSweep(GpuAsyncCoreRegs &regs, int fd, int stub_fd,
       /* Run the full loop at this size. Internal failures (PRBS
        * mismatch, timeout, counter mismatch, hdr.size bound) call
        * std::exit(1) directly - no return-code plumbing needed. */
-      runSimpleLoop(regs, bufCnt, rxBuffs, txBuffs, frameCount, newSize);
+      runSimpleLoop(regs, fd, bufCnt, rxBuffs, txBuffs, frameCount, newSize);
 
       if (s_verbose > 0) {
          fprintf(stdout, "rdmaTestEmu: sweep size=%u PASSED\n", newSize);
@@ -783,8 +781,8 @@ int main(int argc, char **argv) {
     * clean slate here. ctrl was already cleared to WE=0/RE=0 by the
     * prior session's Gpu_RemNvidia, so no engine activity can race
     * these writes. */
-   regs.setWriteEnable(0);
-   regs.setReadEnable(0);
+   gpuEnableTx(fd, 0);
+   gpuEnableRx(fd, 0);
    {
       const uint32_t maxBuffersHw = regs.maxBuffers();
       for (uint32_t i = 0; i < maxBuffersHw; ++i) {
@@ -845,7 +843,7 @@ int main(int argc, char **argv) {
                args.count, args.size);
       liveSize = kSweepSizes[kSweepSizeCount - 1];
    } else {
-      runSimpleLoop(regs, bufCnt, rxBuffs, txBuffs, args.count, args.size);
+      runSimpleLoop(regs, fd, bufCnt, rxBuffs, txBuffs, args.count, args.size);
    }
 
    /* Teardown: drop driver-side registrations, then unmap user VAs,

--- a/include/GpuAsync.h
+++ b/include/GpuAsync.h
@@ -34,6 +34,8 @@
 #define GPU_Is_Gpu_Async_Supp 0x8005   // Check if GPU Async is supported by firmware
 #define GPU_Get_Gpu_Async_Ver 0x8006   // Get the GpuAsyncCore version
 #define GPU_Get_Max_Buffers   0x8007   // Get the max number of DMA buffers
+#define GPU_Enable_Tx         0x8008   // Enable tx buffers (FPGA -> GPU)
+#define GPU_Enable_Rx         0x8009   // Enable rx buffers (GPU -> FPGA)
 
 /**
  * @brief Represents NVIDIA GPU memory data.
@@ -54,6 +56,10 @@ struct GpuNvidiaData {
  *
  * This function adds a specified memory region to the NVIDIA GPU, allowing
  * for the region to be accessed as specified by the write flag.
+ *
+ * For GpuAsyncCore V4 and later, this function will clear the "write enable"
+ * and "read enable" bits. Userspace must call gpuEnableRx/gpuEnableTx as needed
+ * after adding memory with this function.
  *
  * @param fd       File descriptor for the device.
  * @param write    Write access flag (1 for write access, 0 for read-only).
@@ -160,6 +166,30 @@ static inline ssize_t gpuGetGpuAsyncVersion(int32_t fd) {
  */
 static inline ssize_t gpuGetMaxBuffers(int32_t fd) {
    return ioctl(fd, GPU_Get_Max_Buffers);
+}
+
+/**
+ * @brief Enables TX buffers, flowing from FPGA -> GPU
+ *
+ * @param fd File descriptor for the device.
+ * @param enable Disable tx if 0, enable tx if != 0
+ *
+ * @return On success, returns 0. On failure, returns -1 the sets errno.
+ */
+static inline int32_t gpuEnableTx(int32_t fd, uint32_t enable) {
+   return ioctl(fd, GPU_Enable_Tx, enable);
+}
+
+/**
+ * @brief Enable RX buffers, flowing from GPU -> FPGA
+ *
+ * @param fd File descriptor for the device.
+ * @param enable Disable rx if 0, enable rx if != 0
+ *
+ * @return On success, returns 0. On failure, returns -1 and sets errno.
+ */
+static inline int32_t gpuEnableRx(int32_t fd, uint32_t enable) {
+   return ioctl(fd, GPU_Enable_Rx, enable);
 }
 
 #endif  // !DMA_IN_KERNEL

--- a/include/GpuAsyncUser.h
+++ b/include/GpuAsyncUser.h
@@ -104,11 +104,13 @@ public:
 
    /**
     * @brief Sets the number of write buffers.
+    * @param val Number of write buffers.
     * @note gpuAddNvidiaMemory sets this for you.
     * @note This is an INTERNAL register, you should not use this unless you know what you're doing!
     */
    inline void setWriteCount(uint32_t val) {
-      writeRegV1V4(GpuAsyncReg_WriteCountV1, GpuAsyncReg_WriteCountV4, val-1);
+      // Count is zero inclusive, but we've made it cleaner for callers of this function.
+      writeRegV1V4(GpuAsyncReg_WriteCountV1, GpuAsyncReg_WriteCountV4, val ? val-1 : 0);
    }
 
    inline uint32_t writeEnable() const {
@@ -129,11 +131,13 @@ public:
 
    /**
     * @brief Sets the number of read buffers.
+    * @param val Number of read buffers.
     * @note gpuAddNvidiaMemory sets this for you.
     * @note This is an INTERNAL register, you should not use this unless you know what you're doing!
     */
    inline void setReadCount(uint32_t val) {
-      writeRegV1V4(GpuAsyncReg_ReadCountV1, GpuAsyncReg_ReadCountV4, val-1);
+      // Count is zero inclusive, but we've made it cleaner for callers of this function.
+      writeRegV1V4(GpuAsyncReg_ReadCountV1, GpuAsyncReg_ReadCountV4, val ? val-1 : 0);
    }
 
    inline uint32_t readEnable() const {

--- a/include/GpuAsyncUser.h
+++ b/include/GpuAsyncUser.h
@@ -99,7 +99,8 @@ public:
    }
 
    inline uint32_t writeCount() const {
-      return readRegV1V4(GpuAsyncReg_WriteCountV1, GpuAsyncReg_WriteCountV4);
+      // Write count is zero-inclusive
+      return readRegV1V4(GpuAsyncReg_WriteCountV1, GpuAsyncReg_WriteCountV4) + 1;
    }
 
    /**
@@ -126,7 +127,8 @@ public:
    }
 
    inline uint32_t readCount() const {
-      return readRegV1V4(GpuAsyncReg_ReadCountV1, GpuAsyncReg_ReadCountV4);
+      // Read count is a zero-inclusive count
+      return readRegV1V4(GpuAsyncReg_ReadCountV1, GpuAsyncReg_ReadCountV4) + 1;
    }
 
    /**

--- a/include/GpuAsyncUser.h
+++ b/include/GpuAsyncUser.h
@@ -102,14 +102,23 @@ public:
       return readRegV1V4(GpuAsyncReg_WriteCountV1, GpuAsyncReg_WriteCountV4);
    }
 
+   /**
+    * @brief Sets the number of write buffers.
+    * @note gpuAddNvidiaMemory sets this for you.
+    * @note This is an INTERNAL register, you should not use this unless you know what you're doing!
+    */
    inline void setWriteCount(uint32_t val) {
-      writeRegV1V4(GpuAsyncReg_WriteCountV1, GpuAsyncReg_WriteCountV4, val);
+      writeRegV1V4(GpuAsyncReg_WriteCountV1, GpuAsyncReg_WriteCountV4, val-1);
    }
 
    inline uint32_t writeEnable() const {
       return readRegV1V4(GpuAsyncReg_WriteEnableV1, GpuAsyncReg_WriteEnableV4);
    }
 
+   /**
+    * @brief Sets the write (Tx) enable bit, enabling data flow from FPGA -> GPU.
+    * @note Use gpuEnableTx to set this register.
+    */
    inline void setWriteEnable(uint32_t val) {
       writeRegV1V4(GpuAsyncReg_WriteEnableV1, GpuAsyncReg_WriteEnableV4, val);
    }
@@ -118,14 +127,23 @@ public:
       return readRegV1V4(GpuAsyncReg_ReadCountV1, GpuAsyncReg_ReadCountV4);
    }
 
+   /**
+    * @brief Sets the number of read buffers.
+    * @note gpuAddNvidiaMemory sets this for you.
+    * @note This is an INTERNAL register, you should not use this unless you know what you're doing!
+    */
    inline void setReadCount(uint32_t val) {
-      writeRegV1V4(GpuAsyncReg_ReadCountV1, GpuAsyncReg_ReadCountV4, val);
+      writeRegV1V4(GpuAsyncReg_ReadCountV1, GpuAsyncReg_ReadCountV4, val-1);
    }
 
    inline uint32_t readEnable() const {
       return readRegV1V4(GpuAsyncReg_ReadEnableV1, GpuAsyncReg_ReadEnableV4);
    }
 
+   /**
+    * @brief Sets the write (Rx) enable bit, enabling data flow from GPU -> FPGA.
+    * @note Use gpuEnableRx to set this register.
+    */
    inline void setReadEnable(uint32_t val) {
       writeRegV1V4(GpuAsyncReg_ReadEnableV1, GpuAsyncReg_ReadEnableV4, val);
    }
@@ -284,6 +302,7 @@ public:
     * @param buffer The buffer to set the remote size for. Ignored in version >= 4
     * @param size The size
     * @note buffer is ignored when version() >= 4, since in V4 all buffers share the same register
+    * @note This is an INTERNAL register, you should not use this unless you know what you're doing!
     */
    inline void setRemoteWriteMaxSize(uint32_t buffer, uint32_t size) {
       switch (versionSwitch()) {
@@ -303,6 +322,7 @@ public:
     * @brief Sets the remote write address for the specified buffer. Used for FPGA -> GPU transfers
     * @param buffer The buffer index. Must be < 16 for V1, and < 1024 for V4
     * @param addr 64-bit address in GPU device memory
+    * @note This is an INTERNAL register, you should not use this unless you know what you're doing!
     */
    inline void setRemoteWriteAddress(uint32_t buffer, uint64_t addr) {
       uint32_t l = uint32_t(addr & 0xFFFFFFFF);
@@ -327,6 +347,7 @@ public:
     * @brief Sets the remote read address for the specified buffer. Used for GPU -> FPGA transfers
     * @param buffer The buffer index. Must be < 16 for V1, and < 1024 for V4
     * @param addr 64-bit address in GPU device memory
+    * @note This is an INTERNAL register, you should not use this unless you know what you're doing!
     */
    inline void setRemoteReadAddress(uint32_t buffer, uint64_t addr) {
       uint32_t l = uint32_t(addr & 0xFFFFFFFF);


### PR DESCRIPTION
### Description
- These are internal registers and should not be set by userspace in most cases.