### PR TITLE
Fix GITV detection when build runs as a different user than the clone owner

### DIFF
--- a/Yocto/recipes-kernel/axistreamdma/files/Makefile
+++ b/Yocto/recipes-kernel/axistreamdma/files/Makefile
@@ -19,16 +19,22 @@ NAME := axi_stream_dma
 # Directory containing the Makefile
 HOME := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
+# Trust the worktree even when owned by a different user — required when
+# /etc/rc.local rebuilds drivers as root from a tree cloned by an
+# unprivileged user. System/global git config is suppressed so a hostile
+# core.fsmonitor / pager / credential helper there cannot ride along.
+GIT := GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null git -c safe.directory='*'
+
 # Automatically determine the git version (override via GITV=... from caller, e.g. recipe)
 ifndef GITV
-    GITT := $(shell cd $(HOME); git describe --tags 2>/dev/null)
+    GITT := $(shell cd $(HOME); $(GIT) describe --tags 2>/dev/null)
     ifeq ($(GITT),)
-        GITT := $(shell cd $(HOME); git rev-parse --short HEAD 2>/dev/null)
+        GITT := $(shell cd $(HOME); $(GIT) rev-parse --short HEAD 2>/dev/null)
     endif
     ifeq ($(GITT),)
         GITT := emulator
     endif
-    GITD := $(shell cd $(HOME); git status --short -uno 2>/dev/null | wc -l)
+    GITD := $(shell cd $(HOME); $(GIT) status --short -uno 2>/dev/null | wc -l)
     GITV := $(if $(filter $(GITD),0),$(GITT),$(GITT)-dirty)
 endif
 

--- a/data_dev/driver/Makefile
+++ b/data_dev/driver/Makefile
@@ -53,16 +53,22 @@ ifneq ($(NVIDIA_DRIVERS),)
 KBUILD_EXTRA_SYMBOLS := $(NVIDIA_DRIVERS)/Module.symvers
 endif
 
+# Trust the worktree even when owned by a different user — required when
+# /etc/rc.local rebuilds drivers as root from a tree cloned by an
+# unprivileged user. System/global git config is suppressed so a hostile
+# core.fsmonitor / pager / credential helper there cannot ride along.
+GIT := GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null git -c safe.directory='*'
+
 # Automatically determine the git version
 ifndef GITV
-    GITT := $(shell cd $(HOME); git describe --tags 2>/dev/null)
+    GITT := $(shell cd $(HOME); $(GIT) describe --tags 2>/dev/null)
     ifeq ($(GITT),)
-        GITT := $(shell cd $(HOME); git rev-parse --short HEAD 2>/dev/null)
+        GITT := $(shell cd $(HOME); $(GIT) rev-parse --short HEAD 2>/dev/null)
     endif
     ifeq ($(GITT),)
         GITT := emulator
     endif
-    GITD := $(shell cd $(HOME); git status --short -uno 2>/dev/null | wc -l)
+    GITD := $(shell cd $(HOME); $(GIT) status --short -uno 2>/dev/null | wc -l)
     GITV := $(if $(filter $(GITD),0),$(GITT),$(GITT)-dirty)
 endif
 

--- a/rce_hp_buffers/driver/Makefile
+++ b/rce_hp_buffers/driver/Makefile
@@ -21,10 +21,16 @@ OBJS := $(patsubst %.c,%.o,$(SRCS))
 GCC  := $(COMP)gcc
 TEST := $(shell which $(GCC) 2> /dev/null)
 
+# Trust the worktree even when owned by a different user — required when
+# /etc/rc.local rebuilds drivers as root from a tree cloned by an
+# unprivileged user. System/global git config is suppressed so a hostile
+# core.fsmonitor / pager / credential helper there cannot ride along.
+GIT := GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null git -c safe.directory='*'
+
 ifndef GITV
-	GITT := $(shell cd $(HOME); git describe --tags 2>/dev/null)
+	GITT := $(shell cd $(HOME); $(GIT) describe --tags 2>/dev/null)
 	ifeq ($(GITT),)
-		GITT := $(shell cd $(HOME); git rev-parse --short HEAD 2>/dev/null)
+		GITT := $(shell cd $(HOME); $(GIT) rev-parse --short HEAD 2>/dev/null)
 	endif
 	# Final fallback so -DGITV=\"$(GITV)\" always produces a well-formed
 	# string literal when building from a non-git source tree (release
@@ -34,7 +40,7 @@ ifndef GITV
 	ifeq ($(GITT),)
 		GITT := unknown
 	endif
-	GITD := $(shell cd $(HOME); git status --short -uno 2>/dev/null | wc -l)
+	GITD := $(shell cd $(HOME); $(GIT) status --short -uno 2>/dev/null | wc -l)
 	GITV := $(if $(filter $(GITD),0),$(GITT),$(GITT)-dirty)
 endif
 

--- a/rce_memmap/driver/Makefile
+++ b/rce_memmap/driver/Makefile
@@ -24,10 +24,16 @@ OBJS := $(patsubst %.c,%.o,$(SRCS))
 GCC  := $(COMP)gcc
 TEST := $(shell which $(GCC) 2> /dev/null)
 
+# Trust the worktree even when owned by a different user — required when
+# /etc/rc.local rebuilds drivers as root from a tree cloned by an
+# unprivileged user. System/global git config is suppressed so a hostile
+# core.fsmonitor / pager / credential helper there cannot ride along.
+GIT := GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null git -c safe.directory='*'
+
 ifndef GITV
-	GITT := $(shell cd $(HOME); git describe --tags 2>/dev/null)
+	GITT := $(shell cd $(HOME); $(GIT) describe --tags 2>/dev/null)
 	ifeq ($(GITT),)
-		GITT := $(shell cd $(HOME); git rev-parse --short HEAD 2>/dev/null)
+		GITT := $(shell cd $(HOME); $(GIT) rev-parse --short HEAD 2>/dev/null)
 	endif
 	# Final fallback so -DGITV=\"$(GITV)\" always produces a well-formed
 	# string literal when building from a non-git source tree (release
@@ -37,7 +43,7 @@ ifndef GITV
 	ifeq ($(GITT),)
 		GITT := unknown
 	endif
-	GITD := $(shell cd $(HOME); git status --short -uno 2>/dev/null | wc -l)
+	GITD := $(shell cd $(HOME); $(GIT) status --short -uno 2>/dev/null | wc -l)
 	GITV := $(if $(filter $(GITD),0),$(GITT),$(GITT)-dirty)
 endif
 

--- a/rce_stream/driver/Makefile
+++ b/rce_stream/driver/Makefile
@@ -24,10 +24,16 @@ OBJS := $(patsubst %.c,%.o,$(SRCS))
 GCC  := $(COMP)gcc
 TEST := $(shell which $(GCC) 2> /dev/null)
 
+# Trust the worktree even when owned by a different user — required when
+# /etc/rc.local rebuilds drivers as root from a tree cloned by an
+# unprivileged user. System/global git config is suppressed so a hostile
+# core.fsmonitor / pager / credential helper there cannot ride along.
+GIT := GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null git -c safe.directory='*'
+
 ifndef GITV
-	GITT := $(shell cd $(HOME); git describe --tags 2>/dev/null)
+	GITT := $(shell cd $(HOME); $(GIT) describe --tags 2>/dev/null)
 	ifeq ($(GITT),)
-		GITT := $(shell cd $(HOME); git rev-parse --short HEAD 2>/dev/null)
+		GITT := $(shell cd $(HOME); $(GIT) rev-parse --short HEAD 2>/dev/null)
 	endif
 	# Final fallback so -DGITV=\"$(GITV)\" always produces a well-formed
 	# string literal when building from a non-git source tree (release
@@ -37,7 +43,7 @@ ifndef GITV
 	ifeq ($(GITT),)
 		GITT := unknown
 	endif
-	GITD := $(shell cd $(HOME); git status --short -uno 2>/dev/null | wc -l)
+	GITD := $(shell cd $(HOME); $(GIT) status --short -uno 2>/dev/null | wc -l)
 	GITV := $(if $(filter $(GITD),0),$(GITT),$(GITT)-dirty)
 endif
 

--- a/run_local_ci.sh
+++ b/run_local_ci.sh
@@ -99,6 +99,10 @@ fi
 
 # --- Build modules and tests (no sudo required) ---
 echo "=== Building kernel modules and test binaries ==="
+# Force GITV=emulator for local CI builds to match scripts/ci/build-cpu.sh
+# behavior in GitHub Actions: deterministic version, identifiable as a CI
+# artifact regardless of branch/tag/dirty state.
+export GITV=emulator
 # Build gpu_stub FIRST. emulator/driver's emu_init() eagerly calls
 # emu_gpu_register_drain_cb() (exported by nvidia_p2p_stub.ko), so
 # kbuild needs the stub's Module.symvers to resolve cross-module refs
@@ -110,7 +114,7 @@ make -C "$SCRIPT_DIR/emulator/gpu_stub"
 make -C "$SCRIPT_DIR/emulator/driver" clean
 make -C "$SCRIPT_DIR/emulator/driver"
 make -C "$SCRIPT_DIR/data_dev/driver" clean
-make -C "$SCRIPT_DIR/data_dev/driver"
+make -C "$SCRIPT_DIR/data_dev/driver" GITV="$GITV"
 make -C "$SCRIPT_DIR/data_dev/app" clean
 make -C "$SCRIPT_DIR/data_dev/app"
 

--- a/scripts/ci/build-cpu.sh
+++ b/scripts/ci/build-cpu.sh
@@ -43,16 +43,11 @@ export KVER="$CI_KVER"
 
 echo_step "Building against kernel ${KVER}"
 
-# Compute git version once here where we're in the repo root.
-# The Makefile's own git logic fails under kbuild (runs from kernel build
-# dir, outside the repo).  Passing GITV= on the command line skips the
-# Makefile's ifndef GITV block entirely.
-GITV=$(git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo "emulator")
-# Silence stderr and fall back to 0 when $(pwd) isn't a git worktree (e.g.
-# release tarball / exported source). Under `set -e` a failing git status
-# would otherwise abort the whole build even though GITV already resolved.
-GITD=$(git status --short -uno 2>/dev/null | wc -l || echo 0)
-if [ "$GITD" -ne 0 ]; then GITV="${GITV}-dirty"; fi
+# Force GITV=emulator for CI test builds so the artifact is identifiable
+# as a CI build regardless of branch/tag/dirty state and the build is
+# deterministic across CI runs. Tagged release artifacts (Phase 5 DKMS)
+# bypass this and let the Makefile compute the real version.
+GITV=emulator
 export GITV
 echo_step "Git version: ${GITV}"
 

--- a/scripts/ci/build-gpu.sh
+++ b/scripts/ci/build-gpu.sh
@@ -43,16 +43,11 @@ export KVER="$CI_KVER"
 
 echo_step "Building against kernel ${KVER}"
 
-# Compute git version once here where we're in the repo root.
-# The Makefile's own git logic fails under kbuild (runs from kernel build
-# dir, outside the repo).  Passing GITV= on the command line skips the
-# Makefile's ifndef GITV block entirely.
-GITV=$(git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo "emulator")
-# Silence stderr and fall back to 0 when $(pwd) isn't a git worktree (e.g.
-# release tarball / exported source). Under `set -e` a failing git status
-# would otherwise abort the whole build even though GITV already resolved.
-GITD=$(git status --short -uno 2>/dev/null | wc -l || echo 0)
-if [ "$GITD" -ne 0 ]; then GITV="${GITV}-dirty"; fi
+# Force GITV=emulator for CI test builds so the artifact is identifiable
+# as a CI build regardless of branch/tag/dirty state and the build is
+# deterministic across CI runs. Tagged release artifacts (Phase 5 DKMS)
+# bypass this and let the Makefile compute the real version.
+GITV=emulator
 export GITV
 echo_step "Git version: ${GITV}"
 


### PR DESCRIPTION
## Summary

Fix `/proc/datadev_0` reporting `DMA Driver's Git Version : emulator` when `/etc/rc.local` rebuilds drivers as root against a worktree cloned by an unprivileged user.

Root cause: modern git (>= 2.35.2, post-CVE-2022-24765) refuses worktrees whose owner doesn't match the running uid (`fatal: detected dubious ownership in repository at ...`). The driver Makefiles redirect git stderr to `/dev/null`, so the failure was silent and `GITT` fell through to the literal fallback (`emulator` / `unknown`), poisoning the embedded version.

## Changes

**Driver Makefiles** (`data_dev`, `rce_hp_buffers`, `rce_memmap`, `rce_stream`, Yocto `axistreamdma` recipe):

- Wrap every `git` invocation in the `ifndef GITV` block with `-c safe.directory='*'` (git's documented bypass for trusted automated builds).
- Prefix with `GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null` so a hostile per-user `core.fsmonitor` / pager / credential helper can't ride along into the read-only version queries.
- Fallback paths (`emulator` / `unknown` for tarball / non-git source) are unchanged.

**CI test builds** (`scripts/ci/build-cpu.sh`, `scripts/ci/build-gpu.sh`, `run_local_ci.sh`):

- Replace per-build `git describe` resolution with a literal `GITV=emulator` override.
- Test artifacts are now deterministic across runs and identifiable as CI builds regardless of branch / tag / dirty state.
- Phase 5 DKMS (release packaging via `make -C data_dev/driver dkms` on tagged releases) intentionally untouched — those artifacts still embed the real git-derived version through the Makefile.

## Test plan

- [x] Owner-case regression: `make -C data_dev/driver -p | grep '^GITV'` resolves to the real `git describe` output (e.g. `7.2.2-2-ge9eaf12-dirty`).
- [x] Tarball regression: `make -p` against a copy with no `.git` resolves cleanly to `GITV := emulator` (no spurious `-dirty`).
- [x] Lint: no trailing whitespace or tab characters introduced in `*.sh`; `bash -n` passes for all three CI scripts.
- [x] On the affected host (e.g. `rdsrv406`), build & load as root from the user-owned `/u1/aes-stream-drivers` clone, then `cat /proc/datadev_0 | grep "Git Version"` and confirm the real version replaces `emulator`.
- [x] Full GitHub Actions CI matrix (Phases 1–4) green.
- [x] Local QEMU CI (`./run_local_ci.sh`) green.