### PR TITLE
rdmaTest: Move clearing of the handshake space further down

### DIFF
--- a/data_dev/app/src/rdmaTest.cu
+++ b/data_dev/app/src/rdmaTest.cu
@@ -388,14 +388,7 @@ static void runSimpleLoop(TestSession& s) {
             }
         }
 
-        /* Clear handshake space on the GPU side ("GPU's doorbell"). */
-        assertOk(cuStreamWriteValue32(s.stream,
-            (CUdeviceptr)s.rxBuffers[curBuff] + 4, 0, 0));
-
-        /* Return the buffer index back to the FPGA side ("FPGA's free list"). */
-        assertOk(cuStreamWriteValue32(s.stream,
-            s.regs.dptr + s.coreRegs->freeListOffset(curBuff), 1, 0));
-
+        // Dump header data when requested
         if (s_verbose > 1) {
             printf("hdr{size=%u, firstUser=%u, lastUser=%u, cont=%u, overflow=%u, result=%u}\n",
                 hdr.size, hdr.firstUser, hdr.lastUser, hdr.cont, hdr.overflow, hdr.result);
@@ -444,6 +437,14 @@ static void runSimpleLoop(TestSession& s) {
                 s_dumpToFile = 1;
             }
         }
+
+        /* Clear handshake space on the GPU side ("GPU's doorbell"). */
+        assertOk(cuStreamWriteValue32(s.stream,
+            (CUdeviceptr)s.rxBuffers[curBuff] + 4, 0, 0));
+
+        /* Return the buffer index back to the FPGA side ("FPGA's free list"). */
+        assertOk(cuStreamWriteValue32(s.stream,
+            s.regs.dptr + s.coreRegs->freeListOffset(curBuff), 1, 0));
 
         totalEvents++;
         totalRecv += (uint64_t)hdr.size;


### PR DESCRIPTION
Clear the handshake space after the possible data copying to avoid printing an incorrect value for the DMA size word.

<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
To avoid printing an incorrect value for the DMA size word when `s_dumpBytes` is true (`-x` option), the clearing of the handshake space should be performed later in the code.
