### PR TITLE
common/driver/gpu_async: Guard Gpu_Command against NULL utilData

### DIFF
--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -98,6 +98,15 @@ void Gpu_Init(struct DmaDevice *dev, uint32_t offset) {
 int32_t Gpu_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
    struct GpuData* data = dev->utilData;
 
+   /* Guard against an uninitialized GPU context. Gpu_Init() can leave the
+    * device marked GPU-enabled while utilData stays NULL (e.g. the GpuData
+    * allocation failed), so reject commands here instead of dereferencing a
+    * NULL pointer in the handlers below. */
+   if (data == NULL) {
+      dev_err(dev->device, "Gpu_Command: GPU not initialized (utilData is NULL), cmd=%u\n", cmd);
+      return -1;
+   }
+
    switch (cmd) {
       // Add NVIDIA Memory
       case GPU_Add_Nvidia_Memory:


### PR DESCRIPTION
### Description
Add a NULL check at the top of `Gpu_Command()` so GPU ioctl commands return an error instead of dereferencing a NULL `utilData` pointer when GPU initialization failed to allocate its context.

### Details
`Gpu_Init()` marks a device GPU-enabled before allocating `GpuData`, so a `kzalloc` failure leaves `gpuEn=1` with `utilData=NULL`. The ioctl dispatcher gates GPU commands on `gpuEn` alone, so `Gpu_Command()` and its handlers could then dereference NULL and panic the kernel. The guard covers all GPU sub-commands at the single dispatch point. Validated with `cpplint` and the GPU build (`scripts/ci/build-gpu.sh`).