### PR TITLE
common/driver/gpu_async: reject firmware buffer counts above MAX_GPU_BUFFERS

### DIFF
--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -335,7 +335,11 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
 
 #ifdef DATA_GPU
    // GPU Init
-   Gpu_Init(dev, GPU_ASYNC_CORE_OFFSET);
+   probeReturn = Gpu_Init(dev, GPU_ASYNC_CORE_OFFSET);
+   if (probeReturn < 0) {
+      dev_err(dev->device, "Init: Gpu_Init returned error %i.\n", probeReturn);
+      goto err_unmap;
+   }
 #endif
 
    // Manage device reset cycle

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -38,30 +38,50 @@
  * it, and associates it with the given DmaDevice. It sets up
  * the base address for GPU operations and initializes buffer counts.
  */
-void Gpu_Init(struct DmaDevice *dev, uint32_t offset) {
+int Gpu_Init(struct DmaDevice *dev, uint32_t offset) {
    struct GpuData *gpuData;
 
+   uint32_t maxBuffers = 0;
    uint8_t* gpuBase = dev->base + offset;
    uint8_t version = readGpuAsyncReg(gpuBase, &GpuAsyncReg_Version);
    dev->gpuEn = !!version;
+
+   /* GPU not enabled, avoid allocating GPU data */
+   if (!dev->gpuEn)
+      return 0;
 
    /* warn on unsupported version */
    if (version > DATAGPU_MAX_VERSION) {
       dev_err(dev->device, "Gpu_Init: Unsupported GpuAsyncCore version: %d. Max supported is version %d\n",
             version, DATAGPU_MAX_VERSION);
       dev->gpuEn = 0;
+      return 0;  /* allow fallback to CPU DMA */
    }
 
-   /* GPU not enabled, avoid allocating GPU data */
-   if (!dev->gpuEn)
-      return;
+   /* Read the firmware buffer count before allocating any GPU state */
+   if (version < 4) {
+      maxBuffers = readGpuAsyncReg(gpuBase, &GpuAsyncReg_MaxBuffersV1);
+   } else {
+      maxBuffers = readGpuAsyncReg(gpuBase, &GpuAsyncReg_MaxBuffersV4);
+   }
+
+   /* The writeBuffers/readBuffers list[] arrays are statically sized to
+    * MAX_GPU_BUFFERS. If firmware reports more than we can hold, Gpu_AddNvidia
+    * would index past the array and corrupt kernel memory. Refuse to enable
+    * GPU in that case; the device still works via the CPU DMA path. */
+   if (maxBuffers > MAX_GPU_BUFFERS) {
+      dev_err(dev->device, "Gpu_Init: Firmware reports unsupported buffer count: %u > %d\n",
+         maxBuffers, MAX_GPU_BUFFERS);
+      dev->gpuEn = 0;
+      return 0;  /* allow fallback to CPU DMA */
+   }
 
    /* Allocate memory for GPU utility data */
    gpuData = (struct GpuData *)kzalloc(sizeof(struct GpuData), GFP_KERNEL);
    if (!gpuData) {
       dev_err(dev->device, "Gpu_Init: Failed to allocate GpuData space of size %ld bytes\n",
          (ulong)(sizeof(struct GpuData)));
-      return;  // Handle memory allocation failure if necessary
+      return -ENOMEM;  /* allocation failure aborts probe */
    }
 
    /* Associate GPU utility data with the device */
@@ -73,14 +93,10 @@ void Gpu_Init(struct DmaDevice *dev, uint32_t offset) {
    gpuData->readBuffers.count = 0;
    gpuData->offset = offset;
    gpuData->version = version;
-
-   if (version < 4) {
-      gpuData->maxBuffers = readGpuAsyncReg(gpuData->base, &GpuAsyncReg_MaxBuffersV1);
-   } else {
-      gpuData->maxBuffers = readGpuAsyncReg(gpuData->base, &GpuAsyncReg_MaxBuffersV4);
-   }
+   gpuData->maxBuffers = maxBuffers;
 
    dev_info(dev->device, "Gpu_Init: Configured for GpuAsyncCore version %d\n", version);
+   return 0;
 }
 
 /**

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -100,7 +100,7 @@ struct GpuData {
 };
 
 // Function prototypes
-void Gpu_Init(struct DmaDevice *dev, uint32_t offset);
+int Gpu_Init(struct DmaDevice *dev, uint32_t offset);
 int32_t Gpu_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg);
 int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg);
 int32_t Gpu_RemNvidia(struct DmaDevice *dev, uint64_t arg);


### PR DESCRIPTION
### Description
Validate the firmware-reported GPU buffer count against `MAX_GPU_BUFFERS` during `Gpu_Init`, preventing a kernel buffer overflow when firmware advertises more buffers than the driver's statically-sized `writeBuffers`/`readBuffers` arrays can hold. If the firmware count is out of range (or the GpuAsyncCore version is unsupported), the device falls back to CPU DMA instead of enabling GPU.

### Details
`struct GpuBuffers.list[]` is fixed at `MAX_GPU_BUFFERS` (1024) entries, but `Gpu_AddNvidia()` bounds-checks the running buffer count against the firmware `maxBuffers` register. A firmware/register mismatch reporting `maxBuffers > MAX_GPU_BUFFERS` would let the count index past the array end and corrupt adjacent kernel memory.

Changes:
- `Gpu_Init()` reads `maxBuffers` before allocating GPU state and rejects `maxBuffers > MAX_GPU_BUFFERS` (logs and disables GPU, returning 0 to allow CPU-DMA fallback).
- `Gpu_Init()` return type changed `void` → `int`: `-ENOMEM` aborts probe on `kzalloc` failure, `0` otherwise.
- `DataDev_Probe()` checks the return value and routes a negative result through the existing `err_unmap` cleanup.

Verification: GPU CI build path (`scripts/ci/build-gpu.sh`) compiles cleanly with `-DDATA_GPU=1`; `cpplint` (repo `CPPLINT.cfg`) and the tab check pass on all three changed files.