### PR TITLE
NVIDIA P2P Cleanup Refactor + Support for GpuAsyncCore V5

### DIFF
--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -357,7 +357,7 @@ static void Gpu_ClearBufferRegs(struct DmaDevice* dev) {
 
    // Disable reads and writes before freeing underlying buffers.
    writel(0, data->base + 0x008);
-   
+
    // GpuAsyncV4 has no "DMA complete" indicator, so we need to delay for a bit while pending transactions complete.
    // This is far from scientific; I'm just choosing a value (50ms) that *should* prevent crashes...
    if (data->version < 5) {

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -24,10 +24,11 @@
 #include <linux/seq_file.h>
 #include <linux/signal.h>
 #include <linux/slab.h>
+#include <linux/delay.h>
 #include <nv-p2p.h>
 
 /* Update this when you add support for a new GpuAsyncCore version! */
-#define DATAGPU_MAX_VERSION 4
+#define DATAGPU_MAX_VERSION 5
 
 /**
  * Gpu_Init - Initialize GPU with given offset
@@ -46,19 +47,19 @@ int32_t Gpu_Init(struct DmaDevice *dev, uint32_t offset) {
    uint8_t version = readGpuAsyncReg(gpuBase, &GpuAsyncReg_Version);
    dev->gpuEn = !!version;
 
-   /* GPU not enabled, avoid allocating GPU data */
+   // GPU not enabled, avoid allocating GPU data */
    if (!dev->gpuEn)
       return 0;
 
-   /* warn on unsupported version */
+   // warn on unsupported version
    if (version > DATAGPU_MAX_VERSION) {
       dev_err(dev->device, "Gpu_Init: Unsupported GpuAsyncCore version: %d. Max supported is version %d\n",
             version, DATAGPU_MAX_VERSION);
       dev->gpuEn = 0;
-      return 0;  /* allow fallback to CPU DMA */
+      return 0;  // allow fallback to CPU DMA
    }
 
-   /* Read the firmware buffer count before allocating any GPU state */
+   // Read the firmware buffer count before allocating any GPU state
    if (version < 4) {
       maxBuffers = readGpuAsyncReg(gpuBase, &GpuAsyncReg_MaxBuffersV1);
    } else {
@@ -76,7 +77,7 @@ int32_t Gpu_Init(struct DmaDevice *dev, uint32_t offset) {
       return 0;  /* allow fallback to CPU DMA */
    }
 
-   /* Allocate memory for GPU utility data */
+   // Allocate memory for GPU utility data
    gpuData = (struct GpuData *)kzalloc(sizeof(struct GpuData), GFP_KERNEL);
    if (!gpuData) {
       dev_err(dev->device, "Gpu_Init: Failed to allocate GpuData space of size %ld bytes\n",
@@ -84,10 +85,10 @@ int32_t Gpu_Init(struct DmaDevice *dev, uint32_t offset) {
       return -ENOMEM;  /* allocation failure aborts probe */
    }
 
-   /* Associate GPU utility data with the device */
+   // Associate GPU utility data with the device
    dev->utilData = gpuData;
 
-   /* Initialize GPU base address and buffer counts */
+   // Initialize GPU base address and buffer counts
    gpuData->base = dev->base + offset;
    gpuData->writeBuffers.count = 0;
    gpuData->readBuffers.count = 0;
@@ -211,6 +212,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
    buffer->size = dat.size;
    buffer->pageTable = 0;
    buffer->dmaMapping = 0;
+   buffer->dev = dev;
 
    // Align virtual start address as required by NVIDIA kernel driver
    virt_start = buffer->address & GPU_BOUND_MASK;
@@ -226,7 +228,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
          buffer->address, buffer->size, virt_start, pin_size, buffer->write);
 
    // Map GPU memory through NVIDIA P2P API
-   ret = nvidia_p2p_get_pages(0, 0, virt_start, pin_size, &(buffer->pageTable), Gpu_FreeNvidia, dev);
+   ret = nvidia_p2p_get_pages(0, 0, virt_start, pin_size, &(buffer->pageTable), Gpu_FreeNvidia, buffer);
 
    if (ret == 0) {
       dev_warn(dev->device, "Gpu_AddNvidia: mapped memory with address=0x%llx, size=%i, page count=%i, write=%i\n", buffer->address, buffer->size, buffer->pageTable->entries, buffer->write);
@@ -327,8 +329,105 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
       }
    }
 
+   data->disabled = 0;
    writel(x, data->base+0x008);
    return 0;
+}
+
+/**
+ * Gpu_ClearBufferRegs - Clear register state on the FPGA
+ * Safe to call multiple times.
+ *
+ * @dev: The underlying DMA device to free the buffers on
+ */
+static void Gpu_ClearBufferRegs(struct DmaDevice* dev) {
+   uint32_t x;
+   u64 offset;
+   ktime_t waitStart;
+
+   struct GpuData *data;
+   struct GpuBuffer *buffer;
+
+   // Retrieve the GPU specific data from the DMA device
+   data = (struct GpuData *)dev->utilData;
+
+   // Skip this code if this has already been disabled.
+   if (data->disabled)
+      return;
+
+   // Disable reads and writes before freeing underlying buffers.
+   writel(0, data->base + 0x008);
+   
+   // GpuAsyncV4 has no "DMA complete" indicator, so we need to delay for a bit while pending transactions complete.
+   // This is far from scientific; I'm just choosing a value (50ms) that *should* prevent crashes...
+   if (data->version < 5) {
+      if (!data->disabled)
+         fsleep(50000);
+      data->disabled = 1;
+   } else {
+      // V5+: Spin on write/read enable readback. This will get cleared once the FPGA has completed all RDMA transactions to the GPU.
+      waitStart = ktime_get();
+      while (readl(data->base + 0x44) != 0) {
+         cpu_relax();
+
+         // Avoid hanging the system if there's a stalled transfer
+         if (ktime_to_ms(ktime_sub(ktime_get(), waitStart)) > 1000) {
+            dev_warn(dev->device, "Gpu_ClearBufferRegs: Possible stalled DMA; already waited for 1s\n");
+            break;
+         }
+      }
+      data->disabled = 1;
+   }
+
+   // Clear out remote write size register
+   if (data->version >= 4) {
+      writeGpuAsyncReg(data->base, &GpuAsyncReg_RemoteWriteMaxSizeV4, 0);
+   }
+
+   // Clear out the write buffer registers
+   for (x = 0; x < data->writeBuffers.count; x++) {
+      buffer = &(data->writeBuffers.list[x]);
+
+      // Compute version specific offsets
+      if (data->version < 4) {
+         offset = GPU_ASYNC_REG_WRITE_BASE_V1 + x * 16;
+      } else {
+         offset = GPU_ASYNC_REG_WRITE_BASE_V4 + x * 8;
+      }
+
+      // Clear address register; firmware may initiate an rdma transaction even when dropEn=1, which
+      // typically leads to a hang in the GPU software under some circumstances. This is usually a problem
+      // when 2 or more FPGAs end up with the same physical addresses in these registers (e.g. if you're running
+      // an application against multiple different FPGAs and one GPU)
+      writel(0, data->base + offset);
+      writel(0, data->base + offset + 0x4);
+
+      dev_warn(dev->device, "Gpu_ClearBufferRegs: unmapped write memory with address=0x%llx\n", buffer->address);
+   }
+
+   // Clear out the read buffer registers
+   for (x = 0; x < data->readBuffers.count; x++) {
+      buffer = &(data->readBuffers.list[x]);
+
+      // Compute version specific offsets
+      if (data->version < 4) {
+         offset = GPU_ASYNC_REG_READ_BASE_V1 + data->readBuffers.count * 16;
+      } else {
+         offset = GPU_ASYNC_REG_READ_BASE_V4 + data->readBuffers.count * 8;
+      }
+
+      // See comment in the previous for loop for why this is done.
+      writel(0, data->base + offset);
+      writel(0, data->base + offset + 0x4);
+
+      dev_warn(dev->device, "Gpu_ClearBufferRegs: unmapped read memory with address=0x%llx\n", buffer->address);
+   }
+
+   // Reset the buffer counts
+   data->writeBuffers.count = 0;
+   data->readBuffers.count = 0;
+
+   return;
 }
 
 /**
@@ -346,8 +445,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
  */
 int32_t Gpu_RemNvidia(struct DmaDevice *dev, uint64_t arg) {
    uint32_t x;
-   u64 virt_start;
-   u64 offset;
+   int ret;
 
    struct GpuData *data;
    struct GpuBuffer *buffer;
@@ -355,80 +453,54 @@ int32_t Gpu_RemNvidia(struct DmaDevice *dev, uint64_t arg) {
    // Retrieve the GPU specific data from the DMA device
    data = (struct GpuData *)dev->utilData;
 
-   // Disable reads and writes before freeing underlying buffers.
-   writel(0, data->base + 0x008);
+   dev_info(dev->device, "Gpu_RemNvidia: Called\n");
 
-   // Unmap and release pages for all write buffers
+   // Clear out FPGA state, disable DMAs
+   Gpu_ClearBufferRegs(dev);
+
+   // Unmap write pages
    for (x = 0; x < data->writeBuffers.count; x++) {
       buffer = &(data->writeBuffers.list[x]);
-      virt_start = buffer->address & GPU_BOUND_MASK;
 
-      nvidia_p2p_dma_unmap_pages(dev->pcidev, buffer->pageTable, buffer->dmaMapping);
-      nvidia_p2p_free_page_table(buffer->pageTable);
-
-      // Compute version specific offsets
-      if (data->version < 4) {
-         offset = GPU_ASYNC_REG_WRITE_BASE_V1 + x * 16;
-      } else {
-         offset = GPU_ASYNC_REG_WRITE_BASE_V4 + x * 8;
+      ret = nvidia_p2p_dma_unmap_pages(dev->pcidev, buffer->pageTable, buffer->dmaMapping);
+      if (ret != 0) {
+         dev_warn(dev->device, "Gpu_RemNvidia: nvidia_p2p_dma_unmap_pages returned %d\n", ret);
       }
-
-      // Clear address register; firmware may initiate an rdma transaction even when dropEn=1, which
-      // typically leads to a hang in the GPU software under some circumstances. This is usually a problem
-      // when 2 or more FPGAs end up with the same physical addresses in these registers (e.g. if you're running
-      // an application against multiple different FPGAs and one GPU)
-      writel(0, data->base + offset);
-      writel(0, data->base + offset + 0x4);
-
-      dev_warn(dev->device, "Gpu_RemNvidia: unmapped write memory with address=0x%llx\n", buffer->address);
    }
 
-   // Unmap and release pages for all read buffers
+   // Unmap read pages
    for (x = 0; x < data->readBuffers.count; x++) {
       buffer = &(data->readBuffers.list[x]);
-      virt_start = buffer->address & GPU_BOUND_MASK;
 
-      nvidia_p2p_dma_unmap_pages(dev->pcidev, buffer->pageTable, buffer->dmaMapping);
-      nvidia_p2p_free_page_table(buffer->pageTable);
-
-      // Compute version specific offsets
-      if (data->version < 4) {
-         offset = GPU_ASYNC_REG_READ_BASE_V1 + data->readBuffers.count * 16;
-      } else {
-         offset = GPU_ASYNC_REG_READ_BASE_V4 + data->readBuffers.count * 8;
+      ret = nvidia_p2p_dma_unmap_pages(dev->pcidev, buffer->pageTable, buffer->dmaMapping);
+      if (ret != 0) {
+         dev_warn(dev->device, "Gpu_RemNvidia: nvidia_p2p_dma_unmap_pages returned %d\n", ret);
       }
-
-      // See comment in the previous for loop for why this is done.
-      writel(0, data->base + offset);
-      writel(0, data->base + offset + 0x4);
-
-      dev_warn(dev->device, "Gpu_RemNvidia: unmapped read memory with address=0x%llx\n", buffer->address);
    }
-
-   // Clear out remote write size register
-   if (data->version >= 4) {
-      writeGpuAsyncReg(data->base, &GpuAsyncReg_RemoteWriteMaxSizeV4, 0);
-   }
-
-   // Reset the buffer counts
-   data->writeBuffers.count = 0;
-   data->readBuffers.count = 0;
 
    return 0;
 }
 
 /**
- * Gpu_FreeNvidia - Release NVIDIA GPU resources
+ * Gpu_FreeNvidia - Release NVIDIA GPU resources.
  * @data: Pointer to the device-specific data
  *
- * This function is a callback for freeing NVIDIA GPU resources associated
- * with a DMA device. It logs a warning message and removes NVIDIA GPU
- * resources.
+ * This is called for each buffer by the unpin callback, and frees the page table.
+ * Pages are unmapped by explicit calls to Gpu_RemNvidia, or automatically when the
+ * device fd is closed/removed.
  */
 void Gpu_FreeNvidia(void *data) {
-   struct DmaDevice *dev = (struct DmaDevice *)data;
-   dev_warn(dev->device, "Gpu_FreeNvidia: Called\n");
-   Gpu_RemNvidia(dev, 0);
+   int r;
+   struct GpuBuffer *buffer = data;
+
+   // Disable DMAs, clear out registers on the FPGA side.
+   Gpu_ClearBufferRegs(buffer->dev);
+
+   // Free the underlying page table
+   if ((r = nvidia_p2p_free_page_table(buffer->pageTable)) != 0) {
+      dev_warn(buffer->dev->device, "Gpu_FreeNvidia: nvidia_p2p_free_page_table returned %d!\n", r);
+   }
+   buffer->pageTable = NULL;
 }
 
 /**

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -56,6 +56,7 @@
  * @size: Size of the buffer in bytes
  * @pageTable: Pointer to the NVIDIA-specific page table
  * @dmaMapping: Pointer to the DMA mapping structure for this buffer
+ * @dev: Pointer to the DMA device; needed by unpin callback.
  *
  * This structure defines a single buffer's properties, including its
  * memory address, size, and associated NVIDIA page table and DMA mapping.
@@ -66,6 +67,7 @@ struct GpuBuffer {
    uint64_t address;
    nvidia_p2p_page_table_t *pageTable;
    struct nvidia_p2p_dma_mapping *dmaMapping;
+   struct DmaDevice* dev;
 };
 
 /**
@@ -84,6 +86,9 @@ struct GpuBuffers {
 /**
  * struct GpuData - High-level structure representing GPU-related data
  * @base: Base pointer to the GPU data in memory
+ * @disabled: Bool indicating we cleared FPGA state (a hack for V4)
+ * @bufferDataCount: Index of next free entry in bufferData
+ * @bufferData: Slab of memory for per-buffer private data. Total size is MaxReadBuffs + MaxWriteBuffs
  * @writeBuffers: GpuBuffers structure for write operations
  * @readBuffers: GpuBuffers structure for read operations
  *
@@ -95,6 +100,7 @@ struct GpuData {
    uint32_t offset;
    int32_t version;
    uint32_t maxBuffers;
+   uint32_t disabled;
    struct GpuBuffers writeBuffers;
    struct GpuBuffers readBuffers;
 };

--- a/data_dev/app/src/dmaGpuIoctlTest.cpp
+++ b/data_dev/app/src/dmaGpuIoctlTest.cpp
@@ -11,7 +11,12 @@
  *       - datadev_emulator.ko loaded
  *       - nvidia_p2p_stub.ko loaded (provides nvidia_p2p_* symbols)
  *       - datadev.ko built with NVIDIA_DRIVERS=$(pwd)/emulator/gpu_stub, loaded
- *       - /dev/datadev_0 present and gpuEn == 1 (Version register == 4)
+ *       - /dev/datadev_0 present and gpuEn == 1 (Version register == 5)
+ *
+ *    GPU buffers are reserved through /dev/nvidia_p2p_stub_mem (not a plain
+ *    userspace buffer) so the driver's nvidia_p2p_get_pages takes the stub
+ *    addr-table reuse path; the entry then has an FD owner and is released
+ *    when we close the stub fd, instead of leaking to rmmod time.
  *
  *    Exit code: 0 if all checks pass, 1 otherwise.
  * ----------------------------------------------------------------------------
@@ -27,6 +32,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -40,6 +47,7 @@
 
 #include <AxisDriver.h>
 #include <GpuAsync.h>
+#include "emu_gpu_addr_table.h"   /* STUB_RESERVE_BUF uapi (via -I gpu_stub/src) */
 
 /* ----------------------------------------------------------------------------
  * Argp CLI (matches Phase 3 dmaIoctlTest pattern)
@@ -86,6 +94,70 @@ static void report(const char *name, bool ok, const char *detail) {
 }
 
 /* ----------------------------------------------------------------------------
+ * Stub buffer helpers
+ *
+ * The datadev driver's nvidia_p2p_get_pages only takes the addr-table "reuse"
+ * path -- giving the entry a stub-FD owner that is released on close -- when
+ * the registered VA lies inside a /dev/nvidia_p2p_stub_mem mmap. A plain
+ * posix_memalign buffer takes the fallback path, whose entry has no owner and
+ * leaks (tripping WARN_ON in emu_gpu_addr_table_exit at rmmod). Reserve +
+ * mmap a stub buffer, 64KB-aligned (so the driver-computed virt_offset is 0
+ * and the emulator addr_lookup resolves), matching rdmaTestEmu/dmaGpuToggleTest.
+ * --------------------------------------------------------------------------*/
+
+static void *stubAllocBuf(int stub_fd, size_t size, uint32_t *out_buf_id) {
+   struct stub_reserve_req req;
+   memset(&req, 0, sizeof(req));
+   req.size = static_cast<uint32_t>(size);
+
+   if (ioctl(stub_fd, STUB_RESERVE_BUF, &req) < 0) {
+      fprintf(stderr, "stubAllocBuf: STUB_RESERVE_BUF failed size=%zu: %s\n",
+              size, strerror(errno));
+      return nullptr;
+   }
+
+   long page_size = sysconf(_SC_PAGESIZE);
+   if (page_size <= 0) page_size = 4096;
+   off_t offset = static_cast<off_t>(req.buf_id) * page_size;
+
+   const size_t kAlign = 64 * 1024;
+   void *rsv = mmap(nullptr, size + kAlign, PROT_NONE,
+                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+   if (rsv == MAP_FAILED) {
+      fprintf(stderr, "stubAllocBuf: mmap reservation size=%zu failed: %s\n",
+              size + kAlign, strerror(errno));
+      return nullptr;
+   }
+
+   uintptr_t rsv_u   = reinterpret_cast<uintptr_t>(rsv);
+   uintptr_t aligned = (rsv_u + kAlign - 1) & ~static_cast<uintptr_t>(kAlign - 1);
+   size_t    head    = aligned - rsv_u;
+   size_t    tail    = kAlign - head;
+
+   if (head > 0) munmap(rsv, head);
+   if (tail > 0) munmap(reinterpret_cast<void *>(aligned + size), tail);
+
+   void *va = mmap(reinterpret_cast<void *>(aligned), size,
+                   PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                   stub_fd, offset);
+   if (va == MAP_FAILED) {
+      fprintf(stderr, "stubAllocBuf: mmap(buf_id=%u size=%zu) failed: %s\n",
+              req.buf_id, size, strerror(errno));
+      munmap(reinterpret_cast<void *>(aligned), size);
+      return nullptr;
+   }
+
+   *out_buf_id = req.buf_id;
+   return va;
+}
+
+static void stubFreeBuf(void *va, size_t size) {
+   if (va && va != MAP_FAILED) munmap(va, size);
+   /* No ioctl; the stub drops the FD-holder refcount on close(stub_fd),
+    * which is also where the driver's free_callback is fired. */
+}
+
+/* ----------------------------------------------------------------------------
  * main
  * --------------------------------------------------------------------------*/
 
@@ -103,6 +175,13 @@ int main(int argc, char **argv) {
 
    printf("=== dmaGpuIoctlTest: %s ===\n", args.path);
 
+   int stub_fd = open("/dev/nvidia_p2p_stub_mem", O_RDWR);
+   if (stub_fd < 0) {
+      fprintf(stderr, "open(/dev/nvidia_p2p_stub_mem) failed: %s\n", strerror(errno));
+      close(fd);
+      return 1;
+   }
+
    /* 1) GPU_Is_Gpu_Async_Supp -> true */
    bool supp = gpuIsGpuAsyncSupported(fd);
    {
@@ -111,12 +190,12 @@ int main(int argc, char **argv) {
       report("GPU_Is_Gpu_Async_Supp", supp, buf);
    }
 
-   /* 2) GPU_Get_Gpu_Async_Ver -> 4 */
+   /* 2) GPU_Get_Gpu_Async_Ver -> 5 */
    uint32_t ver = gpuGetGpuAsyncVersion(fd);
    {
       char buf[64];
-      snprintf(buf, sizeof(buf), "(got %u, expected 4)", ver);
-      report("GPU_Get_Gpu_Async_Ver", ver == 4, buf);
+      snprintf(buf, sizeof(buf), "(got %u, expected 5)", ver);
+      report("GPU_Get_Gpu_Async_Ver", ver == 5, buf);
    }
 
    /* 3) GPU_Get_Max_Buffers -> 4 */
@@ -127,17 +206,20 @@ int main(int argc, char **argv) {
       report("GPU_Get_Max_Buffers", maxb == 4, buf);
    }
 
-   /* 4) GPU_Add_Nvidia_Memory (write=1) with a 64KB-aligned userspace buf */
-   void *buf = nullptr;
-   int rc_align = posix_memalign(&buf, 65536, 65536);
-   if (rc_align != 0 || buf == nullptr) {
-      fprintf(stderr, "posix_memalign failed: %s\n", strerror(rc_align));
+   /* 4) GPU_Add_Nvidia_Memory (write=1) with a stub-reserved 64KB buffer.
+    *    A separate reservation per Add keeps one nvidia_p2p_get_pages (one
+    *    driver-holder) per stub addr-table entry, so each is cleanly freed
+    *    when the stub fd is closed. */
+   uint32_t wbufId = 0;
+   void *wbuf = stubAllocBuf(stub_fd, 65536, &wbufId);
+   if (wbuf == nullptr) {
+      close(stub_fd);
       close(fd);
       return 1;
    }
-   memset(buf, 0, 65536);
+   memset(wbuf, 0, 65536);
 
-   ssize_t rc = gpuAddNvidiaMemory(fd, 1, reinterpret_cast<uint64_t>(buf), 65536);
+   ssize_t rc = gpuAddNvidiaMemory(fd, 1, reinterpret_cast<uint64_t>(wbuf), 65536);
    {
       char detail[64];
       snprintf(detail, sizeof(detail), "(rc=%zd, expected 0)", rc);
@@ -168,8 +250,18 @@ int main(int argc, char **argv) {
       report("GPU_Rem_Nvidia_Memory", rc == 0, detail);
    }
 
-   /* 8) GPU_Add_Nvidia_Memory (write=0 -> read buffer path) */
-   rc = gpuAddNvidiaMemory(fd, 0, reinterpret_cast<uint64_t>(buf), 65536);
+   /* 8) GPU_Add_Nvidia_Memory (write=0 -> read buffer path), fresh stub buffer */
+   uint32_t rbufId = 0;
+   void *rbuf = stubAllocBuf(stub_fd, 65536, &rbufId);
+   if (rbuf == nullptr) {
+      stubFreeBuf(wbuf, 65536);
+      close(stub_fd);
+      close(fd);
+      return 1;
+   }
+   memset(rbuf, 0, 65536);
+
+   rc = gpuAddNvidiaMemory(fd, 0, reinterpret_cast<uint64_t>(rbuf), 65536);
    {
       char detail[64];
       snprintf(detail, sizeof(detail), "(rc=%zd, expected 0)", rc);
@@ -184,7 +276,11 @@ int main(int argc, char **argv) {
       report("GPU_Rem_Nvidia_Memory(after read)", rc == 0, detail);
    }
 
-   free(buf);
+   stubFreeBuf(wbuf, 65536);
+   stubFreeBuf(rbuf, 65536);
+   /* Closing the stub fd releases the reservations and fires the driver's
+    * free_callback for each mapped buffer -> no addr-table leak at rmmod. */
+   close(stub_fd);
    close(fd);
 
    printf("=== Summary: %d passed, %d failed ===\n", gPassed, gErrors);

--- a/data_dev/app/src/rdmaTestEmu.cpp
+++ b/data_dev/app/src/rdmaTestEmu.cpp
@@ -22,7 +22,7 @@
  *       - nvidia_p2p_stub.ko loaded (provides nvidia_p2p_* + addr table)
  *       - datadev.ko built with NVIDIA_DRIVERS=$(pwd)/emulator/gpu_stub,
  *         loaded against the emulator
- *       - /dev/datadev_0 present, BAR0 GpuAsync version == 4
+ *       - /dev/datadev_0 present, BAR0 GpuAsync version >= 4 (v5 emulated)
  *       - /dev/nvidia_p2p_stub_mem present
  *
  *    Exit code: 0 on full success; 1 on any failure (ioctl/mmap error,
@@ -698,12 +698,13 @@ int main(int argc, char **argv) {
       return 1;
    }
 
-   /* V4-only gate (project_gpu_v4_only.md). gpuGetGpuAsyncVersion's return
-    * type is uint32_t for ABI reasons (see include/GpuAsync.h), so a -1
-    * ioctl error becomes 0xFFFFFFFFu. A naive `(uint32_t)ver < 4` check
-    * would be vacuously false and let the test proceed against a driver
-    * that never reported a version. Cast to int32_t and reject negatives
-    * explicitly before the version comparison. */
+   /* Minimum-version gate (V4 register layout or newer; the emulator now
+    * reports V5). gpuGetGpuAsyncVersion's return type is uint32_t for ABI
+    * reasons (see include/GpuAsync.h), so a -1 ioctl error becomes
+    * 0xFFFFFFFFu. A naive `(uint32_t)ver < 4` check would be vacuously false
+    * and let the test proceed against a driver that never reported a
+    * version. Cast to int32_t and reject negatives explicitly before the
+    * version comparison. */
    int32_t ver = static_cast<int32_t>(gpuGetGpuAsyncVersion(fd));
    if (ver < 0) {
       fprintf(stderr,
@@ -714,7 +715,7 @@ int main(int argc, char **argv) {
    }
    if (static_cast<uint32_t>(ver) < kRequiredGpuAsyncVersion) {
       fprintf(stderr,
-         "rdmaTestEmu: unsupported GPU Async version %d (V4 required)\n", ver);
+         "rdmaTestEmu: unsupported GPU Async version %d (v4+ required)\n", ver);
       ::close(fd);
       return 1;
    }

--- a/emulator/driver/src/bar0_regs.c
+++ b/emulator/driver/src/bar0_regs.c
@@ -214,10 +214,10 @@ void emu_bar0_init_regs(struct emu_bar0 *bar, u32 max_buffers)
     * PrbsData::processData reports "Bad size. exp=262148, got=65536". */
    iowrite32((u32)EMU_GPU_DATA_BYTES_C << 16, base + EMU_GPU_ASYNC_OFF + 0x4);
 
-   /* Version (0x0030, bits 7:0): 4 => V4 register layout */
+   /* Version (0x0030, bits 7:0): 5 => V5 register layout (V4 + 0x44 readback) */
    iowrite32(EMU_GPU_VERSION_INIT, base + EMU_GPU_ASYNC_OFF + 0x0030);
 
-   pr_info("emu: BAR0 GPU Async V4 initialized (version=4, maxBuffers=%u)\n",
+   pr_info("emu: BAR0 GPU Async V5 initialized (version=5, maxBuffers=%u)\n",
            max_buffers & 0x7FF);
 
    /* Verify init writes are readable back through UC mapping. The

--- a/emulator/driver/src/bar0_regs.h
+++ b/emulator/driver/src/bar0_regs.h
@@ -153,7 +153,7 @@
 #define EMU_REG_DATAGPU_EN_INIT   0x00000001
 
 /* ----------------------------------------------------------------
- * GPU Async Core V4 initial register values (offsets relative to
+ * GPU Async Core V5 initial register values (offsets relative to
  * EMU_GPU_ASYNC_OFF = 0x00028000)
  *
  * Only two registers must be non-zero at init.  The remaining 32KB
@@ -162,15 +162,18 @@
  * the driver's Gpu_AddNvidia / Gpu_RemNvidia / Gpu_SetWriteEn paths
  * write into and read from that region as ordinary memory.
  *
- * Only the V4 layout is emulated — V1/V2/V3 are not supported going forward.
+ * The V5 layout matches V4 (axi-pcie-core v6.8.1, AxiPcieGpuAsyncControl.vhd)
+ * plus the new write/read "active" readback at 0x44 (see gpu_engine.c).
+ * V1/V2/V3 are not supported going forward.
  * ---------------------------------------------------------------- */
 
 /*
  * Version register (offset 0x0030, bits 7:0):
- *   Must be 4 so Gpu_Init takes the V4 path and sets dev->gpuEn = 1.
- *   gpu_async.c:45 reads this via readGpuAsyncReg(..., &GpuAsyncReg_Version).
+ *   Must be 5 so Gpu_Init takes the V5 teardown path (spin on the 0x44
+ *   write/read active readback) and sets dev->gpuEn = 1. gpu_async.c:47
+ *   reads this via readGpuAsyncReg(..., &GpuAsyncReg_Version).
  */
-#define EMU_GPU_VERSION_INIT      0x00000004
+#define EMU_GPU_VERSION_INIT      0x00000005
 
 /*
  * MaxBuffersV4 register (offset 0x0000, bits 10:0):

--- a/emulator/driver/src/gpu_engine.c
+++ b/emulator/driver/src/gpu_engine.c
@@ -156,6 +156,23 @@ static u64 emu_gpu_read_buf_addr(struct emu_gpu_engine *eng,
    return ((u64)hi << 32) | lo;
 }
 
+/* V5 write/read "active" readback (register 0x44). Mirror the FW's
+ * r.writeActive/r.readActive (AxiPcieGpuAsyncControl.vhd: v.writeActive :=
+ * r.writeEnable in RX IDLE_S; v.readActive := r.readEnable in TX IDLE_S).
+ * The emulator processes a frame atomically per tick and has no multi-tick
+ * in-flight state, so sampling the CTRL enable bits once per poll iteration
+ * is the faithful equivalent. When the driver disables the engines (writel 0
+ * to CTRL) during teardown, the next tick clears 0x44, releasing the driver's
+ * V5 drain spin (gpu_async.c:370). */
+static void emu_gpu_update_active(struct emu_gpu_engine *eng)
+{
+   u32 ctrl = ioread32(eng->reg_base + EMU_GPU_REG_CTRL);
+   u32 active = ((ctrl & BIT(15)) ? 0x1u : 0x0u) |   /* writeEnable -> writeActive */
+                ((ctrl & BIT(31)) ? 0x2u : 0x0u);    /* readEnable  -> readActive  */
+
+   iowrite32(active, eng->reg_base + EMU_GPU_REG_ACTIVE);
+}
+
 /* ----------------------------------------------------------------
  * Engine lifecycle
  * ---------------------------------------------------------------- */
@@ -439,6 +456,7 @@ static int emu_gpu_poll_thread_fn(void *data)
            EMU_GPU_MOD, emu_gpu_poll_interval_us);
    while (!kthread_should_stop()) {
       emu_gpu_service_cnt_rst(eng);
+      emu_gpu_update_active(eng);
       emu_gpu_rx_tick(eng);
       emu_gpu_tx_tick(eng);
       /* Read the param every tick so late-binding sysfs writes take

--- a/emulator/driver/src/gpu_engine.h
+++ b/emulator/driver/src/gpu_engine.h
@@ -38,7 +38,7 @@
 #include <linux/spinlock.h>
 #include "bar0_regs.h"
 
-/* V4 register offsets inside the GPU Async window (EMU_GPU_ASYNC_OFF +
+/* V4/V5 register offsets inside the GPU Async window (EMU_GPU_ASYNC_OFF +
  * these offsets, all from AxiPcieGpuAsyncControl.vhd). */
 #define EMU_GPU_REG_MAX_BUFFERS   0x0000  /* [10:0]                     */
 #define EMU_GPU_REG_CTRL          0x0008  /* writeCount [14:0],         */
@@ -50,6 +50,12 @@
 #define EMU_GPU_REG_CNT_RST       0x0020  /* write any non-zero => clear */
                                           /* rx/tx frame counts          */
 #define EMU_GPU_REG_VERSION       0x0030
+/* Write/read "active" readback (V5, axi-pcie-core v6.8.1). Mirrors the FW's
+ * r.writeActive/r.readActive: bit0 = writeActive, bit1 = readActive. The
+ * driver's V5 teardown (gpu_async.c:370) disables the engines then spins on
+ * this until it reads 0, guaranteeing no in-flight RDMA before it frees
+ * buffers. The poll thread keeps it in sync with the CTRL enable bits. */
+#define EMU_GPU_REG_ACTIVE        0x0044  /* bit0 writeActive, bit1 readActive */
 #define EMU_GPU_REG_RW_MAX_SIZE   0x0060
 
 #define EMU_GPU_FREELIST_BASE     0x2000  /* writeFreeList[i] @ +i*4    */

--- a/emulator/gpu_stub/src/emu_gpu_addr_table.c
+++ b/emulator/gpu_stub/src/emu_gpu_addr_table.c
@@ -266,6 +266,43 @@ void emu_gpu_addr_table_release(struct emu_gpu_addr_entry *entry)
 }
 
 /* ----------------------------------------------------------------------- */
+/* Internal helper: stub_fire_free_cb_once                                   */
+/* ----------------------------------------------------------------------- */
+
+/* Emulate the NVIDIA free_callback (revocation) exactly once per entry.
+ * The datadev driver registers this callback via nvidia_p2p_get_pages and
+ * frees its page table ONLY from here (Gpu_FreeNvidia ->
+ * nvidia_p2p_free_page_table); Gpu_RemNvidia and the datadev fd-release path
+ * never free it. The real-hardware trigger is the app freeing its GPU
+ * allocation, whose stub analog is the /dev/nvidia_p2p_stub_mem mapping going
+ * away (munmap or process exit) — fired from stub_vm_close. stub_release
+ * fires it too, as a fallback for a stub fd closed while a mapping is still
+ * live or a buffer reserved but never mapped. The one-shot claim is done
+ * under addr_ht_lock so the vm_close and fd-release paths cannot both invoke
+ * the callback. The callback runs OUTSIDE the lock: it re-enters
+ * emu_gpu_addr_table_release (via free_page_table) and may sleep. */
+static void stub_fire_free_cb_once(struct emu_gpu_addr_entry *entry)
+{
+   void (*free_cb)(void *) = NULL;
+   void *free_cb_data = NULL;
+   unsigned long flags;
+
+   if (!entry)
+      return;
+
+   spin_lock_irqsave(&addr_ht_lock, flags);
+   if (entry->free_cb && !entry->free_cb_fired) {
+      entry->free_cb_fired = true;
+      free_cb              = entry->free_cb;
+      free_cb_data         = entry->free_cb_data;
+   }
+   spin_unlock_irqrestore(&addr_ht_lock, flags);
+
+   if (free_cb)
+      free_cb(free_cb_data);
+}
+
+/* ----------------------------------------------------------------------- */
 /* Internal API: emu_gpu_addr_table_find_by_idx                              */
 /* ----------------------------------------------------------------------- */
 
@@ -370,34 +407,21 @@ static int stub_release(struct inode *inode, struct file *file)
 
    list_for_each_entry_safe(hold, tmp, &to_free, node) {
       struct emu_gpu_addr_entry *entry = hold->entry;
-      void (*free_cb)(void *) = NULL;
-      void *free_cb_data = NULL;
 
       list_del(&hold->node);
 
-      /* Emulate NVIDIA revocation: if the datadev driver mapped this
-       * buffer (registered a free_callback via nvidia_p2p_get_pages),
-       * the app-side owner going away (this FD closing) is the analog of
-       * the app freeing its GPU allocation. Invoke the callback so the
-       * driver's Gpu_FreeNvidia runs nvidia_p2p_free_page_table, which
-       * drops the driver-holder refcount (2 -> 1); the release below then
-       * drops the FD-holder (1 -> 0) and the entry is freed. Fire at most
-       * once. Snapshot the fields, then invoke OUTSIDE any lock: the
-       * callback re-enters emu_gpu_addr_table_release (via
-       * free_page_table) and may block (synchronize_rcu on the final put
-       * happens in the release below, not the driver-holder decrement). */
-      if (entry->free_cb && !entry->free_cb_fired) {
-         entry->free_cb_fired = true;
-         free_cb              = entry->free_cb;
-         free_cb_data         = entry->free_cb_data;
-      }
-      if (free_cb)
-         free_cb(free_cb_data);
+      /* Fallback revocation. Normally stub_vm_close already fired the
+       * driver's free_callback when the mapping went away (dropping the
+       * driver-holder), but a stub fd closed while its mapping is still
+       * live — or a buffer reserved but never mapped — reaches the
+       * driver-holder drop only from here. The one-shot claim inside
+       * makes this a no-op if vm_close already ran. */
+      stub_fire_free_cb_once(entry);
 
       /* Drop the FD-owned refcount. For app-only reservations (no driver
-       * mapping, free_cb == NULL) this is the sole holder -> __free_pages
-       * + drain-cb. For driver-mapped buffers the callback above already
-       * dropped the driver-holder, so this drops the last reference. */
+       * mapping, free_cb == NULL) and unmapped reservations this is the
+       * sole/last holder -> __free_pages + drain-cb; otherwise the
+       * mapping-holder released in stub_vm_close takes the entry to zero. */
       emu_gpu_addr_table_release(entry);
       kfree(hold);
    }
@@ -473,6 +497,45 @@ static long stub_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 }
 
 /* ----------------------------------------------------------------------- */
+/* Miscdevice vm_operations: per-mapping lifecycle                           */
+/* ----------------------------------------------------------------------- */
+
+/* A stub mmap models a GPU buffer visible to userspace. Its teardown
+ * (munmap or process exit) is the stub analog of the app freeing its GPU
+ * allocation, which on real hardware fires the NVIDIA free_callback. Firing
+ * it here — rather than only at stub-fd close — runs the datadev driver's
+ * Gpu_FreeNvidia while its per-buffer page-table pointer is still valid,
+ * BEFORE a sweep/toggle test reuses the same driver buffer slot for the next
+ * size. Firing only at fd close let old-size entries leak (their free_cb ran
+ * against a reused slot), tripping WARN_ON in emu_gpu_addr_table_exit.
+ * vm_private_data pins the addr-table entry (reference taken in stub_mmap) so
+ * the entry outlives the mapping regardless of stub-fd vs mm teardown order. */
+static void stub_vm_open(struct vm_area_struct *vma)
+{
+   /* VMA split/fork: the new VMA needs its own reference so its eventual
+    * stub_vm_close has something to release. */
+   emu_gpu_addr_table_get(vma->vm_private_data);
+}
+
+static void stub_vm_close(struct vm_area_struct *vma)
+{
+   struct emu_gpu_addr_entry *entry = vma->vm_private_data;
+
+   if (!entry)
+      return;
+
+   /* Revoke (fire the driver free_callback) once, then drop the mapping's
+    * reference. */
+   stub_fire_free_cb_once(entry);
+   emu_gpu_addr_table_release(entry);
+}
+
+static const struct vm_operations_struct stub_vm_ops = {
+   .open  = stub_vm_open,
+   .close = stub_vm_close,
+};
+
+/* ----------------------------------------------------------------------- */
 /* Miscdevice fops: stub_mmap                                                */
 /* ----------------------------------------------------------------------- */
 
@@ -484,7 +547,7 @@ static int stub_mmap(struct file *file, struct vm_area_struct *vma)
    int ret;
 
    (void)file;
-   entry = emu_gpu_addr_table_find_by_idx(buf_id);
+   entry = emu_gpu_addr_table_find_by_idx(buf_id);   /* refcount: +1 mapping-holder */
    if (!entry) {
       pr_err("nvidia_p2p_stub: mmap buf_id=%u not found\n", buf_id);
       return -EINVAL;
@@ -499,18 +562,22 @@ static int stub_mmap(struct file *file, struct vm_area_struct *vma)
    /* Pitfall D: vm_flags_set BEFORE the range mapping call. */
    vm_flags_set(vma, VM_IO | VM_PFNMAP | VM_DONTDUMP);
 
-   /* find_by_idx bumped the refcount; release it now that we are done
-    * accessing entry->backing_pages.  remap_pfn_range pins the pages
-    * via the VMA pte, so the underlying memory stays mapped. */
    ret = remap_pfn_range(vma, vma->vm_start,
                          page_to_pfn(entry->backing_pages),
                          size, vma->vm_page_prot);
-   emu_gpu_addr_table_release(entry);
    if (ret) {
       pr_err("nvidia_p2p_stub: remap_pfn_range buf_id=%u failed (%d)\n",
              buf_id, ret);
+      emu_gpu_addr_table_release(entry);
       return ret;
    }
+
+   /* Retain the find_by_idx reference as the mapping-holder; stub_vm_close
+    * releases it (and fires the driver revocation callback) when the mapping
+    * goes away. remap_pfn_range pins the pages via the VMA pte, so the
+    * underlying memory stays mapped for the life of the VMA. */
+   vma->vm_private_data = entry;
+   vma->vm_ops          = &stub_vm_ops;
    return 0;
 }
 

--- a/emulator/gpu_stub/src/emu_gpu_addr_table.c
+++ b/emulator/gpu_stub/src/emu_gpu_addr_table.c
@@ -369,11 +369,36 @@ static int stub_release(struct inode *inode, struct file *file)
    mutex_unlock(&fs->lock);
 
    list_for_each_entry_safe(hold, tmp, &to_free, node) {
+      struct emu_gpu_addr_entry *entry = hold->entry;
+      void (*free_cb)(void *) = NULL;
+      void *free_cb_data = NULL;
+
       list_del(&hold->node);
-      /* Drop the sole refcount for this FD-owned entry (single-holder
-       * lineage: alloc_and_register sets refcount=1; FD closure drops
-       * it to 0 -> __free_pages + drain-cb). */
-      emu_gpu_addr_table_release(hold->entry);
+
+      /* Emulate NVIDIA revocation: if the datadev driver mapped this
+       * buffer (registered a free_callback via nvidia_p2p_get_pages),
+       * the app-side owner going away (this FD closing) is the analog of
+       * the app freeing its GPU allocation. Invoke the callback so the
+       * driver's Gpu_FreeNvidia runs nvidia_p2p_free_page_table, which
+       * drops the driver-holder refcount (2 -> 1); the release below then
+       * drops the FD-holder (1 -> 0) and the entry is freed. Fire at most
+       * once. Snapshot the fields, then invoke OUTSIDE any lock: the
+       * callback re-enters emu_gpu_addr_table_release (via
+       * free_page_table) and may block (synchronize_rcu on the final put
+       * happens in the release below, not the driver-holder decrement). */
+      if (entry->free_cb && !entry->free_cb_fired) {
+         entry->free_cb_fired = true;
+         free_cb              = entry->free_cb;
+         free_cb_data         = entry->free_cb_data;
+      }
+      if (free_cb)
+         free_cb(free_cb_data);
+
+      /* Drop the FD-owned refcount. For app-only reservations (no driver
+       * mapping, free_cb == NULL) this is the sole holder -> __free_pages
+       * + drain-cb. For driver-mapped buffers the callback above already
+       * dropped the driver-holder, so this drops the last reference. */
+      emu_gpu_addr_table_release(entry);
       kfree(hold);
    }
 

--- a/emulator/gpu_stub/src/emu_gpu_addr_table.h
+++ b/emulator/gpu_stub/src/emu_gpu_addr_table.h
@@ -65,7 +65,7 @@ struct emu_gpu_addr_entry {
     unsigned int      order;           /* alloc_pages order                  */
     size_t            size;            /* bytes: (size_t)PAGE_SIZE << order  */
     u32               idx;             /* buf_id: miscdevice mmap offset     */
-    refcount_t        refcount;        /* 1 driver-holder + 0..1 FD-holder   */
+    refcount_t        refcount;        /* FD-holder + mapping-holder + driver-holder */
     struct hlist_node node;            /* embedded in addr_ht                */
 
     /* NVIDIA free_callback registered by the datadev driver via

--- a/emulator/gpu_stub/src/emu_gpu_addr_table.h
+++ b/emulator/gpu_stub/src/emu_gpu_addr_table.h
@@ -67,6 +67,17 @@ struct emu_gpu_addr_entry {
     u32               idx;             /* buf_id: miscdevice mmap offset     */
     refcount_t        refcount;        /* 1 driver-holder + 0..1 FD-holder   */
     struct hlist_node node;            /* embedded in addr_ht                */
+
+    /* NVIDIA free_callback registered by the datadev driver via
+     * nvidia_p2p_get_pages(). Real NVIDIA fires this when the GPU
+     * allocation is freed/revoked; the stub's analog is the app-side
+     * owner (the STUB_RESERVE_BUF FD) going away. Invoked once from
+     * stub_release so the driver's Gpu_FreeNvidia -> nvidia_p2p_free_
+     * page_table drops its holder reference and the table can drain.
+     * NULL for app-only reservations the driver never mapped. */
+    void            (*free_cb)(void *);
+    void             *free_cb_data;
+    bool              free_cb_fired;   /* idempotency guard (fire at most once) */
 };
 
 /* --- EXPORT_SYMBOL_GPL surface ---

--- a/emulator/gpu_stub/src/nvidia_p2p_stub.c
+++ b/emulator/gpu_stub/src/nvidia_p2p_stub.c
@@ -44,8 +44,6 @@ int nvidia_p2p_get_pages(uint64_t p2p_token, uint32_t va_space,
 
    (void)p2p_token;
    (void)va_space;
-   (void)free_callback;
-   (void)data;
 
    if (!page_table)
       return -EINVAL;
@@ -110,6 +108,15 @@ int nvidia_p2p_get_pages(uint64_t p2p_token, uint32_t va_space,
     * discipline is identical regardless of which path allocated. */
    pt->gpu_uuid = (uint8_t *)entry;
    pt->flags    = 0;
+
+   /* Record the driver's free_callback so stub_release can emulate the
+    * NVIDIA revocation that fires when the app frees its GPU allocation.
+    * Without this, the datadev driver's async free path (Gpu_FreeNvidia)
+    * never runs under the stub and addr-table entries leak, tripping the
+    * WARN_ON in emu_gpu_addr_table_exit at rmmod. */
+   entry->free_cb       = free_callback;
+   entry->free_cb_data  = data;
+   entry->free_cb_fired = false;
 
    *page_table = pt;
    return 0;

--- a/scripts/ci/load-modules-gpu.sh
+++ b/scripts/ci/load-modules-gpu.sh
@@ -20,8 +20,8 @@
 # insmod, the script refuses to proceed if kernel headers for the running
 # kernel are not available inside this container, and injects a unique
 # baseline marker into the kernel ring buffer so check-dmesg.sh can extract
-# a post-load delta. The functional assertions for GPU Async V4 registers
-# and GpuAsyncCore version 4 remain — they are functional checks, not
+# a post-load delta. The functional assertions for GPU Async V5 registers
+# and GpuAsyncCore version 5 remain — they are functional checks, not
 # readiness probes.
 #
 # Exit codes: 0=success, 1=timeout/failure/refused
@@ -172,18 +172,18 @@ timeout $TIMEOUT_SEC bash -c "until [ \"\$(cat /sys/module/datadev_emulator/init
 }
 echo "datadev_emulator is live"
 
-# Functional assertion — GPU Async V4 BAR0 init must have happened
+# Functional assertion — GPU Async V5 BAR0 init must have happened
 # during emulator init. This is NOT a readiness probe (initstate already
 # guaranteed that) — it is a correctness check that the emulator built the
 # expected register layout. Scan only the post-marker delta so a prior run's
 # log line in a reused container/VM can't satisfy this probe.
 if ! $SUDO dmesg | awk -v m="$CI_DMESG_MARKER" 'f{print} index($0,m){f=1}' | \
-        grep -q "BAR0 GPU Async V4 initialized"; then
-   echo_fail "GPU Async V4 init log line not found in this run's dmesg delta"
+        grep -q "BAR0 GPU Async V5 initialized"; then
+   echo_fail "GPU Async V5 init log line not found in this run's dmesg delta"
    $SUDO dmesg | tail -50
    exit 1
 fi
-echo "GPU Async V4 registers initialized"
+echo "GPU Async V5 registers initialized"
 
 # --- 3) datadev (GPU build) ------------------------------------------------
 timeout --kill-after=5s "${INSMOD_TIMEOUT_SEC}s" $SUDO insmod data_dev/driver/datadev.ko cfgDebug=$CFG_DEBUG cfgTxCount=$CFG_TX_COUNT cfgRxCount=$CFG_RX_COUNT cfgSize=$CFG_SIZE cfgMode=$CFG_MODE || {
@@ -235,16 +235,16 @@ timeout $TIMEOUT_SEC bash -c 'until [ -e /proc/datadev_0 ]; do sleep 0.5; done' 
 echo "/proc/datadev_0 exists"
 
 # Functional assertion — GPU path was actually exercised (Gpu_Init ran
-# the V4 code path against the V4 registers emulated by datadev_emulator).
+# the V5 code path against the V5 registers emulated by datadev_emulator).
 # Delta-scan so a prior run's confirmation line in a reused VM cannot
 # satisfy this probe.
 if ! $SUDO dmesg | awk -v m="$CI_DMESG_MARKER" 'f{print} index($0,m){f=1}' | \
-        grep -q "Configured for GpuAsyncCore version 4"; then
-   echo_fail "Gpu_Init V4 confirmation not found in this run's dmesg delta"
+        grep -q "Configured for GpuAsyncCore version 5"; then
+   echo_fail "Gpu_Init V5 confirmation not found in this run's dmesg delta"
    $SUDO dmesg | tail -100
    exit 1
 fi
-echo "Gpu_Init reported GpuAsyncCore version 4"
+echo "Gpu_Init reported GpuAsyncCore version 5"
 
 $SUDO cat /proc/datadev_0 > /dev/null 2>&1
 sleep 2

--- a/tests/test_gpu_proc.sh
+++ b/tests/test_gpu_proc.sh
@@ -4,7 +4,7 @@
 # -----------------------------------------------------------------------------
 # Description:
 #    GPU /proc interface verification. Asserts /proc/datadev_0 shows the
-#    GPU-enabled driver state with GpuAsyncCore version 4.
+#    GPU-enabled driver state with GpuAsyncCore version 5.
 # -----------------------------------------------------------------------------
 # This file is part of the aes_stream_drivers package. It is subject to the
 # license terms in the LICENSE.txt file found in the top-level directory of
@@ -19,7 +19,7 @@
 #
 # Expected strings (flexible whitespace grep):
 #   - "GPUAsync Support : Enabled"    (from dma_common.c Dma_ShowInfo)
-#   - "GpuAsyncCore Version : 4"      (from gpu_async.c Gpu_Show)
+#   - "GpuAsyncCore Version : 5"      (from gpu_async.c Gpu_Show)
 #   - "Max Buffers : 4"               (from gpu_async.c Gpu_Show)
 #
 # Environment:
@@ -54,7 +54,7 @@ check_line() {
 }
 
 check_line "GPUAsync Support Enabled"  '^[[:space:]]*GPUAsync[[:space:]]*Support[[:space:]]*:[[:space:]]*Enabled'
-check_line "GpuAsyncCore Version 4"     '^[[:space:]]*GpuAsyncCore[[:space:]]*Version[[:space:]]*:[[:space:]]*4'
+check_line "GpuAsyncCore Version 5"     '^[[:space:]]*GpuAsyncCore[[:space:]]*Version[[:space:]]*:[[:space:]]*5'
 check_line "Max Buffers 4"              '^[[:space:]]*Max[[:space:]]*Buffers[[:space:]]*:[[:space:]]*4'
 
 if [ "$ERRS" -eq 0 ]; then

--- a/tests/vm_inside_gpu.sh
+++ b/tests/vm_inside_gpu.sh
@@ -28,7 +28,7 @@
 #   2. Load datadev_emulator.ko (built on the host)
 #   3. Load datadev.ko (GPU build: built with NVIDIA_DRIVERS=$HOST/emulator/gpu_stub)
 #   4. Wait for /dev/datadev_0 and /proc/datadev_0
-#   5. Confirm "Configured for GpuAsyncCore version 4" in dmesg
+#   5. Confirm "Configured for GpuAsyncCore version 5" in dmesg
 #   6. Run tests/run_tests.sh with GPU_ENABLED=1 (Phase 3 + Phase 4 cases)
 #   7. Unload in reverse load order:
 #      datadev -> datadev_emulator -> nvidia_p2p_stub
@@ -103,12 +103,12 @@ echo "  emulator loaded"
 # Scan only the post-marker delta so a prior run's log line in a reused
 # VM can't satisfy this probe. Same awk+index() idiom as check-dmesg.sh.
 if ! dmesg | awk -v m="$CI_DMESG_MARKER" 'f{print} index($0,m){f=1}' | \
-        grep -q "BAR0 GPU Async V4 initialized"; then
-   echo "FAIL: GPU Async V4 init log line not found in this run's dmesg delta"
+        grep -q "BAR0 GPU Async V5 initialized"; then
+   echo "FAIL: GPU Async V5 init log line not found in this run's dmesg delta"
    dmesg | tail -50
    exit 1
 fi
-echo "  GPU Async V4 registers initialized"
+echo "  GPU Async V5 registers initialized"
 
 echo "=== VM-GPU: Loading datadev (GPU build) ==="
 insmod "$HOST/data_dev/driver/datadev.ko" cfgDebug=1 || {
@@ -136,12 +136,12 @@ echo "  /proc/datadev_0 exists"
 # Delta-scan so a prior run's confirmation line in a reused VM cannot
 # satisfy this probe.
 if ! dmesg | awk -v m="$CI_DMESG_MARKER" 'f{print} index($0,m){f=1}' | \
-        grep -q "Configured for GpuAsyncCore version 4"; then
-   echo "FAIL: Gpu_Init V4 confirmation not found in this run's dmesg delta"
+        grep -q "Configured for GpuAsyncCore version 5"; then
+   echo "FAIL: Gpu_Init V5 confirmation not found in this run's dmesg delta"
    dmesg | tail -100
    record_rc 1
 else
-   echo "  Gpu_Init reported GpuAsyncCore version 4"
+   echo "  Gpu_Init reported GpuAsyncCore version 5"
 fi
 
 chmod 666 /dev/datadev_0


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

* Adds support for GpuAsnycCore V5
* Fixes issues where we are freeing buffers that are in use by the GPU
  * For V5: We spin on the readActive/writeActive register after disabling readEnable/writeEnable. When it goes low, we can proceed with the unmapping
  * For v4 and earlier: Wait for an arbitrary time (50ms) before continuing. Should prevent most crashes. 
* Refactors buffer unmapping/freeing to be more consistent with intended API usage

