### PR TITLE
common/driver: Check for DataGpuEn (0x428) before initting GpuAsyncCore

### DIFF
--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -334,11 +334,14 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    dev->rwSize = (2*USER_SIZE) - PHY_OFF;  // Read/Write region size
 
 #ifdef DATA_GPU
-   // GPU Init
-   probeReturn = Gpu_Init(dev, GPU_ASYNC_CORE_OFFSET);
-   if (probeReturn < 0) {
-      dev_err(dev->device, "Init: Gpu_Init returned error %i.\n", probeReturn);
-      goto err_unmap;
+   // Skip GPU init if the module is not enabled
+   if (readl(dev->base + AVER_OFF + 0x428) == 1) {
+      // GPU Init
+      probeReturn = Gpu_Init(dev, GPU_ASYNC_CORE_OFFSET);
+      if (probeReturn < 0) {
+         dev_err(dev->device, "Init: Gpu_Init returned error %i.\n", probeReturn);
+         goto err_unmap;
+      }
    }
 #endif
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

Per Matt's suggestion, we'll check for DataGpuEn before attempting to read the GpuAsyncCore version register. Previously the assumption was that reading registers from GpuAsyncCore when DataGpuEn=0 would always return 0. 
