### PR TITLE
emulator: assert DataGpuEn (0x428) in BAR0 init for GPU test

### DIFF
--- a/emulator/driver/src/bar0_regs.c
+++ b/emulator/driver/src/bar0_regs.c
@@ -179,6 +179,10 @@ void emu_bar0_init_regs(struct emu_bar0 *bar, u32 max_buffers)
    /* userReset (0x010C): clear */
    iowrite32(0x00000000, base + EMU_AVER_OFF + 0x010C);
 
+   /* DataGpuEn (0x428, UserValues[10] bit 0): assert so the GPU-build
+    * driver's Gpu_Init gate (data_dev_top.c) takes the GPU path. */
+   iowrite32(EMU_REG_DATAGPU_EN_INIT, base + EMU_AVER_OFF + EMU_REG_DATAGPU_EN_OFF);
+
    /* --- GPU Async Core V4 registers (at base + EMU_GPU_ASYNC_OFF) ---
     *
     * Only two non-zero values are required so Gpu_Init (in

--- a/emulator/driver/src/bar0_regs.h
+++ b/emulator/driver/src/bar0_regs.h
@@ -144,6 +144,14 @@
 #define EMU_BUILD_VERSION  0
 #endif
 
+/* DataGpuEn (offset 0x428 = UserValues[10], bit 0): mirrors the firmware
+ * AxiVersion.UserValues(10)(0) = DATAGPU_EN_G generic.  The GPU-build
+ * datadev driver (data_dev_top.c, #ifdef DATA_GPU) gates Gpu_Init on this
+ * bit reading 1, so the emulator must assert it to present a GPU-capable
+ * device. */
+#define EMU_REG_DATAGPU_EN_OFF    0x428
+#define EMU_REG_DATAGPU_EN_INIT   0x00000001
+
 /* ----------------------------------------------------------------
  * GPU Async Core V4 initial register values (offsets relative to
  * EMU_GPU_ASYNC_OFF = 0x00028000)


### PR DESCRIPTION
## Problem

Phase 3 **GPU Test** fails on every container (Ubuntu 24.04, Debian experimental, Rocky 9), exit code 1 — e.g. [run #28413732606](https://github.com/slaclab/aes-stream-drivers/actions/runs/28413732606).

## Root cause

The GPU-build `datadev` driver now gates GPU init on the firmware `DataGpuEn` flag — `common/driver/data_dev_top.c` (`#ifdef DATA_GPU`):

```c
if (readl(dev->base + AVER_OFF + 0x428) == 1) {   // AxiVersion UserValues[10] bit 0
    probeReturn = Gpu_Init(dev, GPU_ASYNC_CORE_OFFSET);
    ...
```

This mirrors the FPGA, where `AxiVersion.UserValues(10)(0) = DATAGPU_EN_G` at offset `0x400 + 4*10 = 0x428` (see `axi-pcie-core` `AxiPcieReg.vhd` / `_PcieAxiVersion.py`).

The CI register emulator pre-populates AxiVersion + GPU-Async registers in `emu_bar0_init_regs()` (`emulator/driver/src/bar0_regs.c`) but **never wrote `EMU_AVER_OFF + 0x428`**. BAR0 is `__GFP_ZERO`, so `DataGpuEn` read back `0`, the driver skipped `Gpu_Init()`, `dev->gpuEn` stayed 0, and the Phase-3 assertions failed:

- `scripts/ci/load-modules-gpu.sh` never saw `"Configured for GpuAsyncCore version 4"`
- `tests/test_gpu_proc.sh` failed `GPUAsync Support : Enabled` / `GpuAsyncCore Version : 4`

## Fix

Emulator-only. Pre-populate `0x428 = 1` in `emu_bar0_init_regs()` so the emulator presents a GPU-capable device, matching the firmware `DATAGPU_EN_G` generic.

- `emulator/driver/src/bar0_regs.h` — add `EMU_REG_DATAGPU_EN_OFF` (0x428) / `EMU_REG_DATAGPU_EN_INIT` (1), matching the existing `EMU_REG_*_INIT` convention.
- `emulator/driver/src/bar0_regs.c` — write `DataGpuEn=1` in the AxiVersion block, right after the `userReset` clear.

No driver change: the gate is correct and matches firmware; the CPU build compiles it out via `#ifdef DATA_GPU`. Only the test emulator was stale.

## Verification

- Built in CI order (`nvidia_p2p_stub` → emulator) against kernel `6.8.0-124-generic`; `datadev_emulator.ko` compiles cleanly, no errors/warnings.
- Write lands at absolute BAR0 `0x20428` (`EMU_AVER_OFF 0x20000 + 0x428`) — exactly what the driver reads.
- Phase 1 gates pass locally: cpplint clean, no trailing whitespace/tabs.
- Phase 3 GPU Test is authoritative — see CI on this PR.