### PR TITLE
fix(dma): clamp CPU-path DMA mask to the 40-bit descriptor limit

### DIFF
--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -133,6 +133,14 @@ inline uint8_t AxisG2_MapReturn(struct DmaDevice * dev, struct AxisG2Return *ret
 inline void AxisG2_WriteFree(struct DmaBuffer *buff, __iomem struct AxisG2Reg *reg, uint32_t desc128En) {
    uint32_t wrData[2];
 
+   // The descriptor encodes only AXIS_G2_DESC_ADDR_WIDTH_MAX address bits; a
+   // handle above that would be silently truncated to a wrong physical address.
+   // This should never fire (the DMA mask is clamped and buffers are validated
+   // at allocation) -- warn loudly if an out-of-range handle ever reaches here.
+   WARN_ONCE(((uint64_t)buff->buffHandle >> AXIS_G2_DESC_ADDR_WIDTH_MAX) != 0,
+             "AxisG2_WriteFree: DMA handle 0x%llx exceeds %d-bit descriptor limit; address truncated\n",
+             (uint64_t)buff->buffHandle, AXIS_G2_DESC_ADDR_WIDTH_MAX);
+
    // Mask the buffer index to fit within the 28-bit field
    wrData[0] = buff->index & 0x0FFFFFFF;
 
@@ -173,6 +181,14 @@ inline void AxisG2_WriteTx(struct DmaBuffer *buff, __iomem struct AxisG2Reg *reg
    uint32_t rdData[4];
    uint32_t dest;
    uint32_t chan;
+
+   // The descriptor encodes only AXIS_G2_DESC_ADDR_WIDTH_MAX address bits; a
+   // handle above that would be silently truncated to a wrong physical address.
+   // This should never fire (the DMA mask is clamped and buffers are validated
+   // at allocation) -- warn loudly if an out-of-range handle ever reaches here.
+   WARN_ONCE(((uint64_t)buff->buffHandle >> AXIS_G2_DESC_ADDR_WIDTH_MAX) != 0,
+             "AxisG2_WriteTx: DMA handle 0x%llx exceeds %d-bit descriptor limit; address truncated\n",
+             (uint64_t)buff->buffHandle, AXIS_G2_DESC_ADDR_WIDTH_MAX);
 
    // Configure buffer flags for transmission
    rdData[0]  = (buff->flags >> 13) & 0x00000008;  // bit[3] = continue = flags[16]

--- a/common/driver/axis_gen2.h
+++ b/common/driver/axis_gen2.h
@@ -31,6 +31,14 @@
 #define AXIS2_RING_ACP 0x10
 #define BUFF_LIST_SIZE 1000
 
+// Maximum DMA address width, in bits, that the AxiStreamDmaV2 CPU-path
+// descriptor can encode. Mirrors the surf AxiStreamDmaV2Desc.vhd assertion
+// "AXI_CONFIG_G.ADDR_WIDTH_C <= 40" (axi-pcie-core AxiPcieDma.vhd sets
+// ADDR_WIDTH_C => 40). The GPU/crossbar path is 64-bit and is unaffected. The
+// driver must never set a DMA mask wider than this, nor program a DMA handle
+// beyond it into a descriptor, or the upper address bits are silently dropped.
+#define AXIS_G2_DESC_ADDR_WIDTH_MAX 40
+
 /**
  * struct AxisG2Reg - AXIS Gen2 Register Map.
  * @enableVer: Version and enable register (0x0000).

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -67,6 +67,11 @@ static int cfgDevName  = 0;
 static int cfgTimeout  = 0xFFFF;
 static int cfgDebug    = 0;
 
+// Debug/test only: force dmaAllocBuffers() to validate DMA handles against this
+// address width (bits) instead of the device DMA mask, so the >max-address
+// reachability guard can be exercised without a >1 TiB-memory host. 0 = off.
+static int cfgAddrTestWidth = 0;
+
 // Probe failure global flag used in driver init
 // function to unregister driver
 static int probeReturn = 0;
@@ -287,6 +292,7 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    dev->cfgBgThold[7] = cfgBgThold7;   // Background threshold 7
    dev->cfgTimeout = cfgTimeout;
    dev->debug = cfgDebug;
+   dev->cfgAddrTestWidth = cfgAddrTestWidth;  // Debug/test: DMA reachability guard override
 
    // Allocate IRQ vectors: try MSI-X first, then MSI, then legacy INTx.
    // pci_alloc_irq_vectors() walks the requested types in priority order
@@ -354,6 +360,19 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    // Configure DMA based on AXI address width: 128bit desc, = 64-bit address map
    if ((readl(dev->reg) & 0x10000) != 0) {
       axiWidth = (readl(dev->reg + 0x34) >> 8) & 0xFF;  // Extract AXI address width
+
+      // Clamp to the descriptor engine's hard limit. The AxiStreamDmaV2 CPU-path
+      // descriptor encodes only AXIS_G2_DESC_ADDR_WIDTH_MAX (40) address bits
+      // (surf AxiStreamDmaV2Desc.vhd asserts ADDR_WIDTH_C <= 40). Never set a DMA
+      // mask wider than the descriptor can represent, otherwise the kernel could
+      // hand back a buffer above the 40-bit boundary that the descriptor would
+      // silently truncate into the wrong physical address.
+      if (axiWidth > AXIS_G2_DESC_ADDR_WIDTH_MAX) {
+         dev_warn(dev->device,
+                  "Init: FW reports %u-bit AXI width; clamping to %d-bit descriptor limit.\n",
+                  axiWidth, AXIS_G2_DESC_ADDR_WIDTH_MAX);
+         axiWidth = AXIS_G2_DESC_ADDR_WIDTH_MAX;
+      }
 
       // Attempt to set DMA and coherent DMA masks based on AXI width
       if (!dma_set_mask(dev->device, DMA_BIT_MASK(axiWidth))) {
@@ -605,6 +624,9 @@ MODULE_PARM_DESC(cfgRxCount, "RX buffer count");
 
 module_param(cfgSize, int, 0);
 MODULE_PARM_DESC(cfgSize, "Rx/TX Buffer size");
+
+module_param(cfgAddrTestWidth, int, 0);
+MODULE_PARM_DESC(cfgAddrTestWidth, "Debug/test: validate DMA handles against this address width (bits); 0=off");
 
 module_param(cfgMode, int, 0);
 MODULE_PARM_DESC(cfgMode, "RX buffer mode");

--- a/common/driver/dma_buffer.c
+++ b/common/driver/dma_buffer.c
@@ -50,6 +50,7 @@ size_t dmaAllocBuffers(struct DmaDevice *dev, struct DmaBufferList *list,
    uint32_t x;
    uint32_t sl;
    uint32_t sli;
+   uint64_t dmaMask;
 
    struct DmaBuffer * buff;
 
@@ -153,6 +154,25 @@ size_t dmaAllocBuffers(struct DmaDevice *dev, struct DmaBufferList *list,
       // Populate entry in sorted list for later sort
       if ( list->sorted != NULL ) list->sorted[sli] = buff;
       list->count++;
+
+      // Reject any buffer the DMA descriptor cannot reach. The device DMA mask
+      // is clamped to the AxiStreamDmaV2 40-bit descriptor limit at probe, so
+      // coherent/streaming allocations are already bounded -- but the
+      // BUFF_ARM_ACP path uses virt_to_phys() and bypasses the DMA mapping API
+      // entirely. Validating handle+size against the mask here catches that
+      // case (and any future regression) and fails the probe cleanly instead of
+      // letting the encoder silently truncate the upper address bits. The
+      // buffer is already in the list, so cleanup_buffers frees it correctly.
+      // cfgAddrTestWidth overrides the ceiling for fault-injection testing.
+      dmaMask = list->dev->cfgAddrTestWidth
+                   ? DMA_BIT_MASK(list->dev->cfgAddrTestWidth)
+                   : dma_get_mask(list->dev->device);
+      if (((uint64_t)buff->buffHandle + list->dev->cfgSize - 1) > dmaMask) {
+         dev_err(dev->device,
+                 "dmaAllocBuffers: buffer %u handle 0x%llx size 0x%x exceeds DMA mask 0x%llx\n",
+                 buff->index, (uint64_t)buff->buffHandle, list->dev->cfgSize, dmaMask);
+         goto cleanup_buffers;
+      }
    }
 
    // Sort the buffers

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -120,6 +120,12 @@ struct DmaDevice {
    uint32_t cfgIrqDis;
    uint32_t cfgTimeout;
 
+   // Debug/test only: when non-zero, dmaAllocBuffers() validates each buffer's
+   // DMA handle against DMA_BIT_MASK(cfgAddrTestWidth) instead of the device DMA
+   // mask. Lets the >max-address reachability guard be exercised on a normal
+   // host (no >1 TiB RAM needed). 0 = disabled (use the real device DMA mask).
+   uint32_t cfgAddrTestWidth;
+
    // Device tracking
    uint32_t        index;
    uint32_t        major;

--- a/scripts/ci/test-cpu.sh
+++ b/scripts/ci/test-cpu.sh
@@ -66,6 +66,7 @@ FAILED=0
 # concurrent-collision is not a concern.
 PHASE3_LOG=/tmp/phase3_tests.log
 PARAMS_LOG=/tmp/test_params.log
+ADDRW_LOG=/tmp/test_addr_width.log
 # GAP13_LOOP_LOG is internal-only (no workflow reference); mktemp + trap
 # so reruns on a shared host don't reuse stale state.
 GAP13_LOOP_LOG=$(mktemp -t gap13_loop.XXXXXX)
@@ -175,6 +176,26 @@ if [ "$PARAMS_RC" -ne 0 ]; then
    grep '^\[FAIL\]' "$PARAMS_LOG" || true
    $SUDO dmesg | tail -100
    FAILED=$((FAILED + PARAMS_RC))
+fi
+
+# ============================================================================
+# Test 4.5: DMA address-width clamp + reachability-guard test
+# ============================================================================
+# Verifies the driver clamps the emulator's advertised 64-bit AXI width to the
+# 40-bit AxiStreamDmaV2 descriptor limit, and that the dmaAllocBuffers()
+# reachability guard fails the probe cleanly when a buffer is unreachable.
+# Reloads datadev (emulator stays loaded from above), so it runs here with the
+# module-reload tests rather than in run_tests.sh (which assumes a live device).
+echo_step "Running DMA address-width clamp + guard test"
+DEV=$DEV \
+DATADEV_KO=data_dev/driver/datadev.ko \
+  bash $TESTS_DIR/test_addr_width.sh 2>&1 | tee "$ADDRW_LOG"
+ADDRW_RC=${PIPESTATUS[0]}
+
+if [ "$ADDRW_RC" -ne 0 ]; then
+   echo_fail "${ADDRW_RC} address-width check(s) failed"
+   $SUDO dmesg | tail -100
+   FAILED=$((FAILED + ADDRW_RC))
 fi
 
 # ============================================================================

--- a/tests/test_addr_width.sh
+++ b/tests/test_addr_width.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+# -----------------------------------------------------------------------------
+# Description:
+#    DMA address-width clamp + reachability-guard test. Exercises the hardening
+#    that keeps the datadev CPU path within the AxiStreamDmaV2 40-bit descriptor
+#    limit (surf AxiStreamDmaV2Desc.vhd asserts ADDR_WIDTH_C <= 40).
+# -----------------------------------------------------------------------------
+# This file is part of the aes_stream_drivers package. It is subject to the
+# license terms in the LICENSE.txt file found in the top-level directory of
+# this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the aes_stream_drivers package, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+# -----------------------------------------------------------------------------
+# Two subtests, both run against the emulator (which advertises a 64-bit AXI
+# width in channelCount[15:8] and sets the 128-bit-descriptor enable bit):
+#
+#   A) Clamp: load datadev normally. The driver must clamp the FW-reported
+#      64-bit width down to the 40-bit descriptor limit -- verified by the
+#      "Init: Using 40-bit DMA mask." log line -- and the device must still
+#      come up (/proc/datadev_0 present).
+#
+#   B) Guard: reload datadev with cfgAddrTestWidth below the buffer size so
+#      dmaAllocBuffers()'s reachability guard rejects every buffer. The probe
+#      must fail cleanly: the guard "exceeds DMA mask" dev_err appears, the
+#      device does NOT bind (/proc/datadev_0 absent), and no oops/panic/BUG/
+#      WARNING is emitted.
+#
+# dmesg is scoped per subtest with a unique /dev/kmsg marker rather than a
+# line-count offset: under the emulator's logging the kernel ring buffer runs
+# at capacity, so a "dmesg | wc -l" delta silently reads past the end. The
+# marker survives ring pressure because it is emitted immediately before insmod
+# and read back within ~1s (and cfgDebug=0 keeps datadev quiet). This mirrors
+# the marker pattern in scripts/ci/load-modules-cpu.sh / check-dmesg.sh.
+#
+# Requires root/sudo (reloads kernel modules) and the emulator already loaded.
+# Skips gracefully when either is unavailable so it can be dry-run on an
+# unprivileged host. Mirrors the reload/skip conventions of test_params.sh.
+#
+# Environment variables:
+#   DEV             Device path (default: /dev/datadev_0)
+#   DATADEV_KO      Path to datadev.ko (default: data_dev/driver/datadev.ko)
+#   TEST_SIZE       cfgSize used for both loads (default: 65536)
+#   TEST_WIDTH      cfgAddrTestWidth for subtest B (default: 12 -> 4096-byte
+#                   ceiling, always below TEST_SIZE so the guard trips)
+#   EXPECT_CLAMP_BITS  Expected clamped mask width (default: 40)
+# ----------------------------------------------------------------------------
+
+set -uo pipefail
+
+DEV="${DEV:-/dev/datadev_0}"
+DATADEV_KO="${DATADEV_KO:-data_dev/driver/datadev.ko}"
+INSMOD_TIMEOUT_SEC="${INSMOD_TIMEOUT_SEC:-120}"
+TIMEOUT_SEC="${TIMEOUT_SEC:-15}"
+TEST_SIZE="${TEST_SIZE:-65536}"
+TEST_WIDTH="${TEST_WIDTH:-12}"
+EXPECT_CLAMP_BITS="${EXPECT_CLAMP_BITS:-40}"
+PROC="/proc/datadev_0"
+
+echo "=== DMA address-width clamp + guard test ==="
+echo "DATADEV_KO=$DATADEV_KO TEST_SIZE=$TEST_SIZE TEST_WIDTH=$TEST_WIDTH"
+
+# Require root/sudo capability (this test reloads kernel modules). Skip
+# gracefully if neither is available so unprivileged dry-runs do not fail CI.
+if [ "$(id -u)" -ne 0 ] && ! sudo -n true 2>/dev/null; then
+   echo "SKIP: test_addr_width.sh requires root/sudo (no TTY sudo allowed)"
+   exit 0
+fi
+if [ "$(id -u)" -eq 0 ]; then SUDO=""; else SUDO="sudo"; fi
+
+if [ ! -f "$DATADEV_KO" ]; then
+   echo "SKIP: module file not found: $DATADEV_KO"
+   exit 0
+fi
+
+# The emulator supplies the virtual PCI device (and the 64-bit width report).
+if [ ! -e /sys/module/datadev_emulator ]; then
+   echo "SKIP: datadev_emulator not loaded (required to provide the virtual device)"
+   exit 0
+fi
+
+ERRORS=0
+MARK=""
+
+# Reload datadev with the supplied insmod parameters, scoping dmesg to this
+# load via a fresh /dev/kmsg marker (stored in $MARK). Waits for the previous
+# instance to fully unload via /sys/module/datadev (reliable; /dev and /proc
+# nodes can linger as stale mknod entries in a udev-less container). insmod
+# returns 0 even when a device fails to bind (pci_register_driver succeeds
+# regardless), so callers inspect /proc and the marker-scoped dmesg instead.
+reload_datadev() {
+   $SUDO rmmod datadev 2>/dev/null || true
+   for _ in $(seq 1 30); do [ ! -e /sys/module/datadev ] && break; sleep 0.5; done
+   MARK="ADDRW-MARK-$$-${RANDOM}-${1:-x}"
+   echo "$MARK" | $SUDO tee /dev/kmsg >/dev/null 2>&1 || true
+   shift 2>/dev/null || true
+   timeout --kill-after=5s "${INSMOD_TIMEOUT_SEC}s" \
+      $SUDO insmod "$DATADEV_KO" "$@" 2>/dev/null || true
+   sleep 1
+}
+
+# Emit the current ring contents after the marker emitted by reload_datadev.
+dmesg_since() { $SUDO dmesg | awk -v m="$MARK" 'p {print} index($0, m) {p=1}'; }
+
+# ---------------------------------------------------------------------------
+# Subtest A: FW-reported 64-bit width is clamped to the descriptor limit.
+# ---------------------------------------------------------------------------
+echo "--- Subtest A: clamp FW 64-bit width to ${EXPECT_CLAMP_BITS}-bit ---"
+reload_datadev A cfgDebug=0 cfgTxCount=64 cfgRxCount=64 cfgSize="$TEST_SIZE" cfgMode=1
+DELTA_A=$(dmesg_since)
+
+if printf '%s\n' "$DELTA_A" | grep -qE "Using ${EXPECT_CLAMP_BITS}-bit DMA mask"; then
+   echo "PASS: driver clamped to ${EXPECT_CLAMP_BITS}-bit DMA mask"
+else
+   echo "FAIL: expected 'Using ${EXPECT_CLAMP_BITS}-bit DMA mask' in dmesg"
+   printf '%s\n' "$DELTA_A" | grep -iE "DMA mask|AXI width|clamp" || true
+   ERRORS=$((ERRORS + 1))
+fi
+
+# Device must bind: Dma_Init creates the proc entry on a successful probe.
+for _ in $(seq 1 "$TIMEOUT_SEC"); do [ -e "$PROC" ] && break; sleep 0.5; done
+if [ -e "$PROC" ]; then
+   echo "PASS: device bound after clamped load ($PROC present)"
+else
+   echo "FAIL: device did not bind after normal (clamped) load"
+   ERRORS=$((ERRORS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Subtest B: reachability guard rejects unreachable buffers, probe fails clean.
+# ---------------------------------------------------------------------------
+echo "--- Subtest B: guard rejects buffers (cfgAddrTestWidth=${TEST_WIDTH}) ---"
+reload_datadev B cfgDebug=0 cfgTxCount=64 cfgRxCount=64 cfgSize="$TEST_SIZE" \
+               cfgMode=1 cfgAddrTestWidth="$TEST_WIDTH"
+DELTA_B=$(dmesg_since)
+
+if printf '%s\n' "$DELTA_B" | grep -qE "exceeds DMA mask"; then
+   echo "PASS: reachability guard fired (dev_err 'exceeds DMA mask')"
+else
+   echo "FAIL: guard dev_err 'exceeds DMA mask' not found in dmesg"
+   ERRORS=$((ERRORS + 1))
+fi
+
+# Probe must have failed: Dma_Init removes the proc entry on the guard path.
+if [ -e "$PROC" ]; then
+   echo "FAIL: device bound despite guard rejection ($PROC present)"
+   ERRORS=$((ERRORS + 1))
+else
+   echo "PASS: device did not bind (probe failed cleanly, $PROC absent)"
+fi
+
+# The guard uses dev_err, not WARN, and rejects before the descriptor write, so
+# no oops/panic/BUG/WARNING must appear (BENIGN kernel-cmdline echoes excluded,
+# matching scripts/ci/check-dmesg.sh).
+if printf '%s\n' "$DELTA_B" | grep -iE 'oops|panic|BUG:|WARNING:' \
+      | grep -viE 'drm panic|panic=|panic_on_oops|panic_on_warn'; then
+   echo "FAIL: kernel oops/panic/BUG/WARNING during guard rejection"
+   ERRORS=$((ERRORS + 1))
+else
+   echo "PASS: no kernel oops/panic/BUG/WARNING during guard rejection"
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup: restore a normal datadev load so downstream tests find the device.
+# ---------------------------------------------------------------------------
+echo "Restoring default datadev configuration"
+reload_datadev restore cfgDebug=1 cfgTxCount=64 cfgRxCount=64 cfgSize="$TEST_SIZE" cfgMode=1
+for _ in $(seq 1 "$TIMEOUT_SEC"); do [ -e "$PROC" ] && break; sleep 0.5; done
+# Recreate the /dev node when udev is absent (Docker), mirroring the CI scripts.
+if [ ! -e "$DEV" ] && [ -e /proc/devices ]; then
+   MAJ=$(awk '$2 == "datadev_0" { print $1 }' /proc/devices)
+   if [ -n "$MAJ" ]; then
+      $SUDO mknod "$DEV" c "$MAJ" 0
+      $SUDO chmod 666 "$DEV"
+   fi
+fi
+[ -e "$DEV" ] && $SUDO chmod 666 "$DEV" 2>/dev/null || true
+
+echo "=== addr_width test: $ERRORS errors ==="
+exit "$ERRORS"


### PR DESCRIPTION
## Problem

The datadev DMA engine's **CPU (AXI) path is limited to a 40-bit physical address** in firmware: surf `AxiStreamDmaV2Desc.vhd` asserts `AXI_CONFIG_G.ADDR_WIDTH_C <= 40`, and axi-pcie-core `AxiPcieDma.vhd` sets `DMA_AXI_CONFIG_C.ADDR_WIDTH_C => 40` for the DMA engine (the GPU/crossbar path stays 64-bit). An audit of the driver found the kernel could still hand this path a buffer above 2^40 (1 TiB), which the descriptor would silently truncate to the wrong physical address:

- `DataDev_Probe()` read the AXI width from a firmware register and passed it to `dma_set_mask()` **unclamped** — if that field reported the 64-bit bus width, the kernel would be told the device can reach 64 bits and could allocate coherent/streaming buffers above 2^40.
- The AxisG2 descriptor encoders pack handle bits `[39:8]`/`[7:4]` and **drop bits `[63:40]` with no check**.
- The shared `BUFF_ARM_ACP` path (RCE) uses `virt_to_phys()`, which **bypasses the DMA mask entirely**.

On current hardware the width register reports 40, so today this is latent — but the driver arrives at a correct mask only by trusting the register, with no backstop.

## Changes

Defense-in-depth hardening in shared `common/driver/` (symlinked into datadev and all RCE drivers):

1. **Clamp** the firmware-reported width to a new `AXIS_G2_DESC_ADDR_WIDTH_MAX` (40) before `dma_set_mask()`/`dma_set_coherent_mask()`, so the kernel DMA layer enforces the ceiling on coherent/streaming allocations.
2. **Reachability guard** in `dmaAllocBuffers()` — validate each buffer's `handle + size` against the device DMA mask and fail the probe cleanly (`dev_err`) on violation; the only backstop for the ACP `virt_to_phys()` path.
3. **`WARN_ONCE`** at the AxisG2 descriptor write sites as a mask-independent last line.

Plus a debug-only `cfgAddrTestWidth` module parameter and `tests/test_addr_width.sh` (wired into `scripts/ci/test-cpu.sh`) to exercise the clamp and guard against the emulator, which advertises a 64-bit AXI width.

## Behavior on a non-reachable buffer

Graceful teardown, not a hard assert: allocation fails or the guard fires → `dev_err` → `Dma_Init` returns `-errno` → `DataDev_Probe` unwinds (`err_unmap`), so the device does not bind and the failure is logged. On a host that cannot satisfy the 40-bit constraint the driver refuses to bind rather than running with truncated addresses.

## Verification

Local KVM CI parity cell — **PASS** on Ubuntu 24.04 / kernel 6.17-azure:

- 13/13 standard tests, module-parameter test, 3 load/unload cycles, DKMS smoke, dmesg check.
- New address-width test 5/5: clamp → `Using 40-bit DMA mask`; guard → `dmaAllocBuffers: ... exceeds DMA mask` with a clean probe failure and no oops/panic.
- `cpplint`, tab, and trailing-whitespace gates clean.