### PR TITLE
ci: add ubuntu-26.04 to release builds and CI test matrices

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -3,8 +3,8 @@
 # ----------------------------------------------------------------------------
 # Complete CI/CD pipeline with sequential phases:
 #  Phase 1: Documentation & Linting
-#  Phase 2: CPU Testing (5 distros in parallel) → waits for Phase 1
-#  Phase 3: GPU Testing (5 distros in parallel) → waits for Phase 2
+#  Phase 2: CPU Testing (6 distros in parallel) → waits for Phase 1
+#  Phase 3: GPU Testing (6 distros in parallel) → waits for Phase 2
 #  Phase 4: Release Generation → waits for Phase 3
 #  Phase 5: DKMS Source Tarball Builds + Uploads (cpu, gpu) → waits for Phase 4
 #  Phase 6: Distribution Packages (.deb/.rpm) + Uploads → waits for Phase 5
@@ -65,7 +65,7 @@ jobs:
           find . -name '*.h' -o -name '*.cpp' -o -name '*.c' | xargs cpplint
 
   # ==========================================================================
-  # Phase 2: CPU Testing (5 distros in parallel)
+  # Phase 2: CPU Testing (6 distros in parallel)
   # Waits for Phase 1 to complete
   # Uses modular scripts from scripts/ci/
   # ==========================================================================
@@ -87,6 +87,8 @@ jobs:
           - container: "ubuntu:24.04"
             load_test: true
           - container: "ubuntu:22.04"
+            load_test: true
+          - container: "ubuntu:26.04"
             load_test: true
           - container: "rockylinux:9"
             load_test: true
@@ -169,7 +171,7 @@ jobs:
         run: dmesg || echo "dmesg not available (expected in container)"
 
   # ==========================================================================
-  # Phase 3: GPU Testing (5 distros in parallel)
+  # Phase 3: GPU Testing (6 distros in parallel)
   # Waits for Phase 2 (all CPU tests) to complete
   # Uses modular scripts from scripts/ci/
   # ==========================================================================
@@ -195,6 +197,8 @@ jobs:
           - container: "ubuntu:24.04"
             load_test: true
           - container: "ubuntu:22.04"
+            load_test: true
+          - container: "ubuntu:26.04"
             load_test: true
           - container: "rockylinux:9"
             load_test: true
@@ -358,6 +362,7 @@ jobs:
   # Builds real installable DKMS packages per target:
   #   * ubuntu-22.04  -> .deb
   #   * ubuntu-24.04  -> .deb
+  #   * ubuntu-26.04  -> .deb
   #   * rockylinux-9  -> .rpm
   # for both the CPU (datadev) and GPU (datadev-gpu) driver variants, then
   # uploads each built package to the GitHub release.
@@ -376,13 +381,16 @@ jobs:
       fail-fast: false
       matrix:
         driver_type: [cpu, gpu]
-        target_env: [ubuntu-22.04, ubuntu-24.04, rockylinux-9]
+        target_env: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, rockylinux-9]
         include:
           - target_env: ubuntu-22.04
             container_image: "ubuntu:22.04"
             pkg_format: "deb"
           - target_env: ubuntu-24.04
             container_image: "ubuntu:24.04"
+            pkg_format: "deb"
+          - target_env: ubuntu-26.04
+            container_image: "ubuntu:26.04"
             pkg_format: "deb"
           - target_env: rockylinux-9
             container_image: "rockylinux:9"

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -88,8 +88,13 @@ jobs:
             load_test: true
           - container: "ubuntu:22.04"
             load_test: true
+          # ubuntu:26.04 is newer than the ubuntu-24.04 runner, so its gcc
+          # matches the host Azure kernel and CI_HOST_MATCH becomes 1 (unlike
+          # 22.04, whose older toolchain fails the match and stays build-only).
+          # Force load_test: false to keep this cell build + DKMS-smoke only
+          # and skip the full DMA suite.
           - container: "ubuntu:26.04"
-            load_test: true
+            load_test: false
           - container: "rockylinux:9"
             load_test: true
           - container: "debian:experimental"
@@ -198,8 +203,13 @@ jobs:
             load_test: true
           - container: "ubuntu:22.04"
             load_test: true
+          # ubuntu:26.04 is newer than the ubuntu-24.04 runner, so its gcc
+          # matches the host Azure kernel and CI_HOST_MATCH becomes 1 (unlike
+          # 22.04, whose older toolchain fails the match and stays build-only).
+          # Force load_test: false to keep this cell build + DKMS-smoke only
+          # and skip the full DMA suite.
           - container: "ubuntu:26.04"
-            load_test: true
+            load_test: false
           - container: "rockylinux:9"
             load_test: true
           - container: "debian:experimental"

--- a/docs/explanation/ci-pipeline.rst
+++ b/docs/explanation/ci-pipeline.rst
@@ -27,11 +27,11 @@ gating the next:
        C/C++ lint, gpu_async.c change guard
    * - 2
      - CPU Testing
-     - Build and test the CPU-only driver across 5 distros in parallel
+     - Build and test the CPU-only driver across 6 distros in parallel
    * - 3
      - GPU Testing
      - Build and test the GPU driver (with emulator + p2p stub) across
-       5 distros in parallel
+       6 distros in parallel
    * - 4
      - Release Generation
      - Creates GitHub Release artifacts (tags only)
@@ -44,7 +44,7 @@ gating the next:
 Distribution Matrix
 -------------------
 
-Both Phase 2 (CPU) and Phase 3 (GPU) run against five container images.
+Both Phase 2 (CPU) and Phase 3 (GPU) run against six container images.
 Each container runs ``--privileged`` with the host kernel's ``/lib/modules``
 and ``/usr/src`` bind-mounted, so ``insmod`` loads against the live Azure
 kernel regardless of the userspace distribution.
@@ -65,6 +65,10 @@ kernel regardless of the userspace distribution.
      - Yes
      - Yes
      - LTS compatibility; older glibc and toolchain
+   * - ``ubuntu:26.04``
+     - Yes
+     - Yes
+     - Latest LTS; newest kernel and toolchain
    * - ``rockylinux:9``
      - Yes
      - Yes
@@ -78,7 +82,7 @@ kernel regardless of the userspace distribution.
      - Yes
      - Rawhide gcc/glibc; most aggressive compiler warnings
 
-All five distros run the full build + load + test + unload + DKMS
+All six distros run the full build + load + test + unload + DKMS
 sequence in both phases. Load/test is gated at runtime on
 ``CI_HOST_MATCH=1`` (container has the running host's kernel headers,
 either via bind-mount or package install); distros that cannot satisfy

--- a/docs/explanation/ci-pipeline.rst
+++ b/docs/explanation/ci-pipeline.rst
@@ -66,9 +66,9 @@ kernel regardless of the userspace distribution.
      - Yes
      - LTS compatibility; older glibc and toolchain
    * - ``ubuntu:26.04``
-     - Yes
-     - Yes
-     - Latest LTS; newest kernel and toolchain
+     - No
+     - No
+     - Latest LTS; build + DKMS smoke only (newer toolchain would otherwise run the full suite)
    * - ``rockylinux:9``
      - Yes
      - Yes
@@ -82,12 +82,14 @@ kernel regardless of the userspace distribution.
      - Yes
      - Rawhide gcc/glibc; most aggressive compiler warnings
 
-All six distros run the full build + load + test + unload + DKMS
-sequence in both phases. Load/test is gated at runtime on
-``CI_HOST_MATCH=1`` (container has the running host's kernel headers,
-either via bind-mount or package install); distros that cannot satisfy
-that condition fall back to a DKMS smoke path (``dkms ldtarball`` with
-``--no-prepare-kernel``) in the same cell.
+Every distro builds the driver in both phases. The load + test + unload
++ DKMS-install sequence is gated on both the ``load_test`` matrix flag
+and ``CI_HOST_MATCH=1`` (container has a toolchain matching the running
+host kernel); cells that do not satisfy both fall back to a DKMS smoke
+path (``dkms ldtarball`` with ``--no-prepare-kernel``) in the same cell.
+``ubuntu:26.04`` sets ``load_test: false`` so it stays build + DKMS
+smoke only -- its newer toolchain matches the host kernel and would
+otherwise pull it into the full suite.
 
 
 Phase 2: CPU Test Coverage

--- a/scripts/LOCAL_CI_TESTING.md
+++ b/scripts/LOCAL_CI_TESTING.md
@@ -49,6 +49,7 @@ cell whose kernel matches the parity VM host (driven by
 |-----------|-----|-----|------------------|
 | ubuntu:24.04 | yes | yes | Runs load+test when `CI_HOST_MATCH=1` (normally the matching cell) |
 | ubuntu:22.04 | yes | yes | Build + DKMS smoke unless `CI_HOST_MATCH=1` |
+| ubuntu:26.04 | yes | yes | Build + DKMS smoke unless `CI_HOST_MATCH=1` |
 | rockylinux:9 | yes | yes | Build + DKMS smoke unless `CI_HOST_MATCH=1` |
 | debian:experimental | yes | yes | Build + DKMS smoke unless `CI_HOST_MATCH=1` |
 | fedora:rawhide | yes | yes | Build + DKMS smoke unless `CI_HOST_MATCH=1` |

--- a/scripts/LOCAL_CI_TESTING.md
+++ b/scripts/LOCAL_CI_TESTING.md
@@ -49,7 +49,7 @@ cell whose kernel matches the parity VM host (driven by
 |-----------|-----|-----|------------------|
 | ubuntu:24.04 | yes | yes | Runs load+test when `CI_HOST_MATCH=1` (normally the matching cell) |
 | ubuntu:22.04 | yes | yes | Build + DKMS smoke unless `CI_HOST_MATCH=1` |
-| ubuntu:26.04 | yes | yes | Build + DKMS smoke unless `CI_HOST_MATCH=1` |
+| ubuntu:26.04 | no | no | Build + DKMS smoke always (`load_test: false`) |
 | rockylinux:9 | yes | yes | Build + DKMS smoke unless `CI_HOST_MATCH=1` |
 | debian:experimental | yes | yes | Build + DKMS smoke unless `CI_HOST_MATCH=1` |
 | fedora:rawhide | yes | yes | Build + DKMS smoke unless `CI_HOST_MATCH=1` |

--- a/scripts/MULTI_DISTRO_TESTING.md
+++ b/scripts/MULTI_DISTRO_TESTING.md
@@ -20,11 +20,12 @@ container inside that guest:
 
 1. **ubuntu:24.04** — build + load + test + DKMS (CPU and GPU)
 2. **ubuntu:22.04** — build + DKMS smoke (CPU and GPU)
-3. **rockylinux:9** — build + DKMS smoke (CPU and GPU)
-4. **debian:experimental** — build + DKMS smoke (CPU and GPU)
-5. **fedora:rawhide** — build + DKMS smoke (CPU and GPU)
+3. **ubuntu:26.04** — build + DKMS smoke (CPU and GPU)
+4. **rockylinux:9** — build + DKMS smoke (CPU and GPU)
+5. **debian:experimental** — build + DKMS smoke (CPU and GPU)
+6. **fedora:rawhide** — build + DKMS smoke (CPU and GPU)
 
-All five cells declare `load_test: true`, but the actual module
+All six cells declare `load_test: true`, but the actual module
 load/test/unload steps are gated by the `CI_HOST_MATCH` environment
 variable. Only the cell whose kernel matches the parity VM host kernel
 (normally `ubuntu:24.04`) runs the full load/test/unload/DKMS-install

--- a/scripts/MULTI_DISTRO_TESTING.md
+++ b/scripts/MULTI_DISTRO_TESTING.md
@@ -25,9 +25,11 @@ container inside that guest:
 5. **debian:experimental** — build + DKMS smoke (CPU and GPU)
 6. **fedora:rawhide** — build + DKMS smoke (CPU and GPU)
 
-All six cells declare `load_test: true`, but the actual module
-load/test/unload steps are gated by the `CI_HOST_MATCH` environment
-variable. Only the cell whose kernel matches the parity VM host kernel
+Five of the six cells declare `load_test: true`; `ubuntu:26.04` uses
+`load_test: false` to stay build + DKMS smoke only (its newer toolchain
+would otherwise satisfy `CI_HOST_MATCH`). For the load-test cells, the
+actual module load/test/unload steps are gated by the `CI_HOST_MATCH`
+environment variable. Only the cell whose kernel matches the parity VM host kernel
 (normally `ubuntu:24.04`) runs the full load/test/unload/DKMS-install
 cycle; the other cells stop after compile + DKMS tarball smoke. This
 mirrors the gating used in `.github/workflows/ci_pipeline.yml`.

--- a/scripts/ci-local/AI_LOCAL_CI_TESTING.md
+++ b/scripts/ci-local/AI_LOCAL_CI_TESTING.md
@@ -552,14 +552,14 @@ sequential).
 
 ### Sequential mode (single VM, lower resource usage)
 
-To cover all 5 distros × 2 phases (CPU + GPU) = 10 cells sequentially:
+To cover all 6 distros × 2 phases (CPU + GPU) = 12 cells sequentially:
 
 ```bash
 # Sequential CPU matrix:
 bash scripts/ci-local/run_matrix.sh --phase cpu
 
 # Or manual loop for custom distro selection:
-DISTROS=("ubuntu:24.04" "ubuntu:22.04" "rockylinux:9" "debian:experimental" "fedora:rawhide")
+DISTROS=("ubuntu:24.04" "ubuntu:22.04" "ubuntu:26.04" "rockylinux:9" "debian:experimental" "fedora:rawhide")
 for phase in cpu gpu; do
    for distro in "${DISTROS[@]}"; do
       echo "=== $distro ($phase) ==="
@@ -568,7 +568,7 @@ for phase in cpu gpu; do
 done
 ```
 
-Each cell takes ~5-10 minutes; the full 10-cell matrix takes ~60-90
+Each cell takes ~5-10 minutes; the full 12-cell matrix takes ~60-90
 minutes sequentially.
 
 ### Why can't a single VM parallelize load-test cells?

--- a/scripts/ci-local/run_matrix.sh
+++ b/scripts/ci-local/run_matrix.sh
@@ -47,13 +47,14 @@ source "$SCRIPT_DIR/lib/common.sh"
 # Matrix definitions — mirror ci_pipeline.yml include: arrays.
 # CPU: ci_pipeline.yml Phase 2 (cpu_test) matrix.
 # GPU: ci_pipeline.yml Phase 3 (gpu_test) matrix.
-# Both matrices share the same 5-distro shape; only ubuntu:24.04 has
+# Both matrices share the same 6-distro shape; only ubuntu:24.04 has
 # load_test=true (the others are build-only).
 # ----------------------------------------------------------------------------
 CPU_CELLS=(
    "ubuntu:24.04|0"
    "ubuntu:24.04|1"
    "ubuntu:22.04|1"
+   "ubuntu:26.04|1"
    "rockylinux:9|1"
    "debian:experimental|1"
    "fedora:rawhide|1"
@@ -63,6 +64,7 @@ GPU_CELLS=(
    "ubuntu:24.04|0"
    "ubuntu:24.04|1"
    "ubuntu:22.04|0"
+   "ubuntu:26.04|0"
    "rockylinux:9|0"
    "debian:experimental|1"
    "fedora:rawhide|1"

--- a/scripts/ci-local/run_matrix.sh
+++ b/scripts/ci-local/run_matrix.sh
@@ -54,7 +54,7 @@ CPU_CELLS=(
    "ubuntu:24.04|0"
    "ubuntu:24.04|1"
    "ubuntu:22.04|1"
-   "ubuntu:26.04|1"
+   "ubuntu:26.04|0"
    "rockylinux:9|1"
    "debian:experimental|1"
    "fedora:rawhide|1"

--- a/scripts/ci/install-deps.sh
+++ b/scripts/ci/install-deps.sh
@@ -425,7 +425,7 @@ elif [[ "$DISTRO_ID" == "rocky" || "$DISTRO_ID" == "rhel" || \
 else
    echo_fail "Unsupported distribution: $DISTRO_ID $DISTRO_VERSION"
    echo "Supported distributions:"
-   echo "  - Ubuntu 22.04, 24.04"
+   echo "  - Ubuntu 22.04, 24.04, 26.04"
    echo "  - Debian (experimental)"
    echo "  - Rocky Linux 9"
    echo "  - Fedora (rawhide)"


### PR DESCRIPTION
## Summary

Adds **Ubuntu 26.04 LTS** to the driver's release packaging and CI test matrices.

- **Release builds (Phase 6):** new `ubuntu-26.04` → `.deb` target for both the CPU (`datadev`) and GPU (`datadev-gpu`) DKMS packages, alongside the existing 22.04/24.04 `.deb`s and the Rocky 9 `.rpm`. Built on tag pushes by the unchanged `scripts/ci/build-deb.sh`.
- **CI testing (Phase 2 CPU + Phase 3 GPU):** `ubuntu:26.04` added to both matrices, configured **identically to `ubuntu:22.04`** — `load_test: true`, gated at runtime by `CI_HOST_MATCH`. Since only `ubuntu:24.04` matches the runner's host kernel, 26.04 builds the driver and runs the DKMS smoke check but does **not** run the full DMA suite.
- **Local parity + docs:** mirrored the cell in `scripts/ci-local/run_matrix.sh` and updated the distro lists in `install-deps.sh`, `ci-pipeline.rst`, and the local-CI markdown docs.
