### PR TITLE
common/driver: Indicate unsupported GpuAsyncCore in procfs

### DIFF
--- a/common/driver/axis_gen2.c
+++ b/common/driver/axis_gen2.c
@@ -912,7 +912,10 @@ void AxisG2_SeqShow(struct seq_file *s, struct DmaDevice *dev) {
    seq_printf(s, "      Driver Load Count : %u\n", ((readl(&(reg->enableVer)))>>8)&0xFF);
    seq_printf(s, "               IRQ Hold : %u\n", (readl(&(reg->irqHoldOff))));
    seq_printf(s, "              BG Enable : 0x%x\n", hwData->bgEnable);
-   seq_printf(s, "           GPU Async En : %i\n", dev->gpuEn);
+   if (!dev->gpuEn && dev->gpuVer)  // Unsupported GpuAsyncCore version
+      seq_printf(s, "           GPU Async En : %i (Unsupported GpuAsyncCore Version: %d)\n", dev->gpuEn, dev->gpuVer);
+   else
+      seq_printf(s, "           GPU Async En : %i\n", dev->gpuEn);
    seq_printf(s, "            DMA Timeout : %u\n", readl(&(reg->timeout)));
 
    for ( x=0; x < 8; x++ ) {

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -140,6 +140,7 @@ struct DmaDevice {
 
    // GPU-capable flag
    uint8_t gpuEn;
+   uint8_t gpuVer;
 
    uint8_t version;
 

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -46,6 +46,7 @@ int32_t Gpu_Init(struct DmaDevice *dev, uint32_t offset) {
    uint8_t* gpuBase = dev->base + offset;
    uint8_t version = readGpuAsyncReg(gpuBase, &GpuAsyncReg_Version);
    dev->gpuEn = !!version;
+   dev->gpuVer = version;
 
    // GPU not enabled, avoid allocating GPU data */
    if (!dev->gpuEn)


### PR DESCRIPTION

<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

If using an unsupported GpuAsyncCore version, the procfs interface will indicate "GpuAsyncEn 0" which makes it seem like the fw has no GpuAsyncCore support at all.

This PR changes the procfs interface to indicate when a GpuAsyncCore version is unsupported, so you dont need to parse `dmesg` for warnings
