### PR TITLE
datadev: Apply patch to NVIDIA drivers to fix panic-on-exit

### DIFF
--- a/data_dev/driver/comp_and_load_drivers.sh
+++ b/data_dev/driver/comp_and_load_drivers.sh
@@ -8,7 +8,8 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 # Change directory to where this script is
-cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+SCRIPTDIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+cd "${SCRIPTDIR}" || exit 1
 
 # Determine the Linux distribution
 if [ -f /etc/os-release ]; then
@@ -71,6 +72,13 @@ done
 
 # Go to nvidia path and build Nvidia driver
 cd "$NVIDIA_PATH" || { echo "Error: Failed to change directory to $NVIDIA_PATH"; exit 1; }
+
+# Apply nvidia driver patches -- probably need a better way to manage this
+for p in "${SCRIPTDIR}/patches/"*-nvidia-*.patch ; do
+    echo "Attempting to apply ${p}"
+    patch -N -p1 --verbose < "${p}" || true
+done
+
 # Clean previous builds
 make clean
 # Build Nvidia driver

--- a/data_dev/driver/patches/0001-nvidia-driver-fix-crash.patch
+++ b/data_dev/driver/patches/0001-nvidia-driver-fix-crash.patch
@@ -1,0 +1,77 @@
+diff --git a/kernel-open/nvidia-uvm/uvm_hmm.c b/kernel-open/nvidia-uvm/uvm_hmm.c
+index 68d661fe..263d76c2 100644
+--- a/kernel-open/nvidia-uvm/uvm_hmm.c
++++ b/kernel-open/nvidia-uvm/uvm_hmm.c
+@@ -344,41 +344,43 @@ void uvm_hmm_unregister_gpu(uvm_va_space_t *va_space, uvm_gpu_t *gpu, struct mm_
+     if (!uvm_hmm_is_enabled(va_space))
+         return;
+ 
+-    devmem_start = gpu->parent->devmem->pagemap.range.start + gpu->mem_info.phys_start;
+-    devmem_end = devmem_start + gpu->mem_info.size;
+-
+     if (mm)
+         uvm_assert_mmap_lock_locked(mm);
+     uvm_assert_rwsem_locked_write(&va_space->lock);
+ 
+-    // There could be pages with page->zone_device_data pointing to the va_space
+-    // which may be about to be freed. Migrate those back to the CPU so we don't
+-    // fault on them. Normally infinite retries are bad, but we don't have any
+-    // option here. Device-private pages can't be pinned so migration should
+-    // eventually succeed. Even if we did eventually bail out of the loop we'd
+-    // just stall in memunmap_pages() anyway.
+-    do {
+-        retry = false;
+-
+-        for (pfn = __phys_to_pfn(devmem_start); pfn <= __phys_to_pfn(devmem_end); pfn++) {
+-            struct page *page = pfn_to_page(pfn);
+-
+-            // No need to keep scanning if no HMM pages are allocated for this
+-            // va_space.
+-            if (!atomic64_read(&va_space->hmm.allocated_page_count))
+-                break;
++    if (gpu->parent->devmem) {
++        devmem_start = gpu->parent->devmem->pagemap.range.start + gpu->mem_info.phys_start;
++        devmem_end = devmem_start + gpu->mem_info.size;
++
++        // There could be pages with page->zone_device_data pointing to the va_space
++        // which may be about to be freed. Migrate those back to the CPU so we don't
++        // fault on them. Normally infinite retries are bad, but we don't have any
++        // option here. Device-private pages can't be pinned so migration should
++        // eventually succeed. Even if we did eventually bail out of the loop we'd
++        // just stall in memunmap_pages() anyway.
++        do {
++            retry = false;
++
++            for (pfn = __phys_to_pfn(devmem_start); pfn <= __phys_to_pfn(devmem_end); pfn++) {
++                struct page *page = pfn_to_page(pfn);
++
++                // No need to keep scanning if no HMM pages are allocated for this
++                // va_space.
++                if (!atomic64_read(&va_space->hmm.allocated_page_count))
++                    break;
+ 
+-            UVM_ASSERT(is_device_private_page(page));
++                UVM_ASSERT(is_device_private_page(page));
+ 
+-            // This check is racy because nothing stops the page being freed and
+-            // even reused. That doesn't matter though - worst case the
+-            // migration fails, we retry and find the va_space doesn't match.
+-            if (uvm_pmm_devmem_page_to_va_space(page) == va_space) {
+-                if (uvm_hmm_pmm_gpu_evict_pfn(pfn) != NV_OK)
+-                    retry = true;
++                // This check is racy because nothing stops the page being freed and
++                // even reused. That doesn't matter though - worst case the
++                // migration fails, we retry and find the va_space doesn't match.
++                if (uvm_pmm_devmem_page_to_va_space(page) == va_space) {
++                    if (uvm_hmm_pmm_gpu_evict_pfn(pfn) != NV_OK)
++                        retry = true;
++                }
+             }
+-        }
+-    } while (retry);
++        } while (retry);
++    }
+ 
+     uvm_range_tree_for_each(node, &va_space->hmm.blocks) {
+         va_block = hmm_va_block_from_node(node);
+


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

This fixes the crash Mudit was seeing (for real this time...). The previous PR apparently only improved the behavior I guess.

It seems like if you free all p2p pages (as you're supposed to...) the `devmem` struct can get freed by nvidia-uvm and set to NULL. Normally I wouldn't apply a simple NULL check like this, since it is rarely the fix, however the 610 series also adds a NULL check here. So that was indeed the bug.

Unfortunately we only have up to 595 from NVIDIA's own RPM repo right now, so this patch has been included in the meantime. Alternatively, we could check out a 610 version to /usr/local/src and always build with NVIDIA_PATH=/usr/local/src/... while we wait.

The especially strange thing is it seems like this crash is pretty sensitive to *how* the application is killed. For example, if I spin up 6 instances of rdmaTest in the same shell as jobs, and kill them with `kill PID`, no crash. But if I have two login shells each with one instance of rdmaTest, killing either one with ctrl+c (or letting it exit normally) will kill the system.

