### PR TITLE
Small behavior changes and fix

### DIFF
--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -500,7 +500,6 @@ int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
       case GPU_Add_Nvidia_Memory:
       case GPU_Rem_Nvidia_Memory:
       case GPU_Set_Write_Enable:
-      case GPU_Get_Gpu_Async_Ver:
       case GPU_Get_Max_Buffers:
       case GPU_Enable_Rx:
       case GPU_Enable_Tx:
@@ -514,6 +513,12 @@ int32_t DataDev_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
          return dev->gpuEn ? 1 : 0;
 #else
          return 0;
+#endif
+      case GPU_Get_Gpu_Async_Ver:
+#ifdef DATA_GPU
+         return dev->gpuVer;
+#else
+         return -ENOTSUPP;
 #endif
       case AVER_Get:
          // AXI Version Read

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -138,10 +138,6 @@ int32_t Gpu_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
       case GPU_Set_Write_Enable:
          return Gpu_SetWriteEn(dev, arg);
 
-      // Get the async core version
-      case GPU_Get_Gpu_Async_Ver:
-         return Gpu_GetVersion(dev);
-
       // Get the max number of buffers
       case GPU_Get_Max_Buffers:
          return (int32_t)data->maxBuffers;
@@ -549,18 +545,6 @@ int32_t Gpu_SetWriteEn(struct DmaDevice *dev, uint64_t arg) {
 
    writel(0x1, data->base + offset);
 
-   return 0;
-}
-
-/**
- * Gpu_GetVersion - Get the version of GpuAsyncCore
- * @dev: Pointer to the DmaDevice structure
- * Return: the version, or 0 if not supported/disabled
- */
-int32_t Gpu_GetVersion(struct DmaDevice *dev) {
-   struct GpuData* data = (struct GpuData *)dev->utilData;
-   if (data)
-      return data->version;
    return 0;
 }
 

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -113,7 +113,6 @@ int32_t Gpu_RemNvidia(struct DmaDevice *dev, uint64_t arg);
 void Gpu_FreeNvidia(void * data);
 int32_t Gpu_SetWriteEn(struct DmaDevice *dev, uint64_t arg);
 void Gpu_Show(struct seq_file *s, struct DmaDevice *dev);
-int32_t Gpu_GetVersion(struct DmaDevice *dev);
 int32_t Gpu_EnableTx(struct DmaDevice *dev, uint64_t enable);
 int32_t Gpu_EnableRx(struct DmaDevice *dev, uint64_t enable);
 

--- a/data_dev/app/src/rdmaTest.cu
+++ b/data_dev/app/src/rdmaTest.cu
@@ -68,6 +68,7 @@ struct TestSession {
     int bufSize = 0;
     uint32_t dmaHeaderSize = 0;
     bool loopback = false;
+    int fd = -1;
 };
 
 static void runSimpleLoop(TestSession& s);
@@ -167,6 +168,7 @@ static int initSession(TestSession& s, const char* dev, int gpuIdx,
         return -1;
     }
     const int fd = s.dataGpu->fd();
+    s.fd = fd;
 
     if (!gpuIsGpuAsyncSupported(fd)) {
         fprintf(stderr, "Firmware or driver does not support GPUAsync\n");
@@ -280,9 +282,9 @@ static int initSession(TestSession& s, const char* dev, int gpuIdx,
 }
 
 static void cleanupSession(TestSession& s) {
-    if (s.coreRegs) {
-        s.coreRegs->setWriteEnable(0);
-        s.coreRegs->setReadEnable(0);
+    if (s.fd > 0) {
+        gpuEnableTx(s.fd, 0);
+        gpuEnableRx(s.fd, 0);
     }
 
     if (s.stream) {

--- a/include/GpuAsync.h
+++ b/include/GpuAsync.h
@@ -139,9 +139,9 @@ static inline bool gpuIsGpuAsyncSupported(int32_t fd) {
  * @param fd File descriptor for the device.
  *
  * @return On success, the version of GpuAsyncCore (@c >= 0).  On failure,
- *         @c -1 with @c errno set to indicate the cause (for example
- *         @c ENOTSUPP or @c ENOTTY if the driver was compiled without
- *         GPUAsync support, or another ioctl error).
+ *         @c -1 with @c errno set to indicate the cause.
+ *         @c ENOTSUPP or @c ENOTTY indicates that the driver was compiled without
+ *         GpuAsync support.
  *
  * @note The return type is @c ssize_t (signed) so the @c -1 failure case is
  *       representable without wraparound.  Callers must explicitly check


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

* Removes the remaining usage of setWriteEnable/setReadEnable in the rdmaTest
* Changes `gpuGetGpuAsyncVersion` to always return the GpuAsyncCore version even if gpuEn=0. This allows user space software to report the version of GpuAsyncCore that failed initting.

