### PR TITLE
Exclusive Access of GpuAsyncCore

### DIFF
--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -447,7 +447,7 @@ static void Gpu_ClearBufferRegs(struct DmaDevice* dev) {
    // Reset the buffer counts
    data->writeBuffers.count = 0;
    data->readBuffers.count = 0;
-   
+
    // Release GpuAsyncCore to other processes
    atomic64_set(&data->pid, 0);
 

--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -96,6 +96,7 @@ int32_t Gpu_Init(struct DmaDevice *dev, uint32_t offset) {
    gpuData->offset = offset;
    gpuData->version = version;
    gpuData->maxBuffers = maxBuffers;
+   atomic64_set(&gpuData->pid, 0);
 
    dev_info(dev->device, "Gpu_Init: Configured for GpuAsyncCore version %d\n", version);
    return 0;
@@ -120,8 +121,8 @@ int32_t Gpu_Command(struct DmaDevice *dev, uint32_t cmd, uint64_t arg) {
     * device marked GPU-enabled while utilData stays NULL (e.g. the GpuData
     * allocation failed), so reject commands here instead of dereferencing a
     * NULL pointer in the handlers below. */
-   if (data == NULL) {
-      dev_err(dev->device, "Gpu_Command: GPU not initialized (utilData is NULL), cmd=%u\n", cmd);
+   if (unlikely(data == NULL)) {
+      BUG();
       return -1;
    }
 
@@ -188,7 +189,10 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
       return -1;
    }
 
-   if (!dat.size) return -EINVAL;
+   if (!dat.size) {
+      dev_warn(dev->device, "Gpu_AddNvidia: error: Buffer has size of 0 bytes\n");
+      return -EINVAL;
+   }
 
    if ((dat.size & ~GPU_BOUND_MASK) != 0) {
       dev_warn(dev->device, "Gpu_AddNvidia: error: memory size (%u) is not a multiple of GPU page size (%llu)\n",
@@ -196,16 +200,26 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
       return -EINVAL;
    }
 
+   // Check if another PID already owns this GpuAsyncCore state
+   pid_t pid = atomic64_cmpxchg(&data->pid, 0, current->pid);
+   if (pid != 0 && pid != current->pid) {
+      dev_warn(dev->device, "Gpu_AddNvidia: error: Calling PID (%d) GpuAsyncCore state already locked by PID %d\n",
+               current->pid, pid);
+      return -EBUSY;
+   }
+
    // Set buffer pointers based on the operation mode (write/read)
    if (dat.write) {
       if (data->writeBuffers.count >= data->maxBuffers) {
          dev_warn(dev->device, "Gpu_AddNvidia: Too many write buffers: max %u\n", data->maxBuffers);
+         atomic64_set(&data->pid, 0);
          return -EINVAL;
       }
       buffer = &(data->writeBuffers.list[data->writeBuffers.count]);
    } else {
       if (data->readBuffers.count >= data->maxBuffers) {
          dev_warn(dev->device, "Gpu_AddNvidia: Too many read buffers: max %u\n", data->maxBuffers);
+         atomic64_set(&data->pid, 0);
          return -EINVAL;
       }
       buffer = &(data->readBuffers.list[data->readBuffers.count]);
@@ -275,6 +289,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
             if (minSize > 1 && minSize != mapSize) {
                dev_warn(dev->device, "Gpu_AddNvidia: mapSize=%zu does not match last configured mapSize of %zu. Write buffers must all be identically sized\n",
                   minSize, mapSize);
+               atomic64_set(&data->pid, 0);
                return -EINVAL;
             }
 
@@ -309,6 +324,7 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
       }
    } else {
       dev_warn(dev->device, "Gpu_AddNvidia: failed to pin memory with address=0x%llx. ret=%i\n", dat.address, ret);
+      atomic64_set(&data->pid, 0);
       return -1;
    }
 
@@ -431,6 +447,9 @@ static void Gpu_ClearBufferRegs(struct DmaDevice* dev) {
    // Reset the buffer counts
    data->writeBuffers.count = 0;
    data->readBuffers.count = 0;
+   
+   // Release GpuAsyncCore to other processes
+   atomic64_set(&data->pid, 0);
 
    return;
 }
@@ -459,6 +478,14 @@ int32_t Gpu_RemNvidia(struct DmaDevice *dev, uint64_t arg) {
    data = (struct GpuData *)dev->utilData;
 
    dev_info(dev->device, "Gpu_RemNvidia: Called\n");
+
+   // Ensure the calling PID actually owns the state
+   pid_t pid = atomic64_cmpxchg(&data->pid, current->pid, 0);
+   if (pid != current->pid) {
+      dev_warn(dev->device, "Gpu_RemNvidia: Called by PID (%d) that doesn't own the GpuAsyncCore state!\n",
+               current->pid);
+      return -EBUSY;
+   }
 
    // Clear out FPGA state, disable DMAs
    Gpu_ClearBufferRegs(dev);
@@ -526,15 +553,23 @@ int32_t Gpu_SetWriteEn(struct DmaDevice *dev, uint64_t arg) {
 
    data = (struct GpuData *)dev->utilData;
 
+   // Check for calling process ownership. Unlocked GpuAsyncCore is OK
+   pid_t pid = atomic64_read(&data->pid);
+   if (pid && pid != current->pid) {
+      dev_warn(dev->device, "Gpu_SetWriteEn: Called by non-owner PID (%d)\n",
+               current->pid);
+      return -EBUSY;
+   }
+
    // Copy data from user space
    if ((ret = copy_from_user(&idx, (void *)arg, sizeof(uint32_t)))) {
       dev_warn(dev->device, "Gpu_SetWriteEn: copy_from_user failed. ret=%i, user=%p\n", ret, (void *)arg);
-      return -1;
+      return -EINVAL;
    }
 
    if ( idx >= data->writeBuffers.count ) {
       dev_warn(dev->device, "Gpu_SetWriteEn: Invalid write buffer index idx=%i, count=%i\n", idx, data->writeBuffers.count);
-      return -1;
+      return -EINVAL;
    }
 
    if (data->version < 4) {
@@ -556,6 +591,10 @@ int32_t Gpu_SetWriteEn(struct DmaDevice *dev, uint64_t arg) {
 void Gpu_Show(struct seq_file *s, struct DmaDevice *dev) {
    u32 i;
    struct GpuData* data = (struct GpuData*)dev->utilData;
+   if (unlikely(!data)) {
+      BUG();
+      return;
+   }
 
    u32 readBuffCnt = 0;
    u32 writeBuffCnt = 0;
@@ -595,6 +634,7 @@ void Gpu_Show(struct seq_file *s, struct DmaDevice *dev) {
       seq_printf(s, "       Min Read Buffers : %u\n", readGpuAsyncReg(data->base, &GpuAsyncReg_MinReadBuffer));
    }
    seq_printf(s, "   AXI Read Error Count : %u\n", readGpuAsyncReg(data->base, &GpuAsyncReg_AxiReadErrorCnt));
+   seq_printf(s, "         Owning Process : %lu\n", atomic64_read(&data->pid));
 
    for (i = 0; i < writeBuffCnt && writeEnable; ++i) {
       u32 wal, wah, ws;
@@ -638,6 +678,14 @@ void Gpu_Show(struct seq_file *s, struct DmaDevice *dev) {
 int32_t Gpu_EnableTx(struct DmaDevice *dev, uint64_t enable) {
    struct GpuData* data = (struct GpuData*)dev->utilData;
 
+   // Check for calling process ownership. Unlocked GpuAsyncCore is OK
+   pid_t pid = atomic64_read(&data->pid);
+   if (pid && pid != current->pid) {
+      dev_warn(dev->device, "Gpu_SetWriteEn: Called by non-owner PID (%d)\n",
+               current->pid);
+      return -EBUSY;
+   }
+
    const struct GpuAsyncRegister* theReg = NULL;
    if (data->version < 4) {
       theReg = &GpuAsyncReg_WriteEnableV1;
@@ -656,6 +704,14 @@ int32_t Gpu_EnableTx(struct DmaDevice *dev, uint64_t enable) {
  */
 int32_t Gpu_EnableRx(struct DmaDevice *dev, uint64_t enable) {
    struct GpuData* data = (struct GpuData*)dev->utilData;
+
+   // Check for calling process ownership. Unlocked GpuAsyncCore is OK
+   pid_t pid = atomic64_read(&data->pid);
+   if (pid && pid != current->pid) {
+      dev_warn(dev->device, "Gpu_SetWriteEn: Called by non-owner PID (%d)\n",
+               current->pid);
+      return -EBUSY;
+   }
 
    const struct GpuAsyncRegister* theReg = NULL;
    if (data->version < 4) {

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -101,6 +101,7 @@ struct GpuData {
    int32_t version;
    uint32_t maxBuffers;
    uint32_t disabled;
+   atomic64_t pid;
    struct GpuBuffers writeBuffers;
    struct GpuBuffers readBuffers;
 };

--- a/include/GpuAsync.h
+++ b/include/GpuAsync.h
@@ -110,7 +110,7 @@ static inline ssize_t gpuRemNvidiaMemory(int32_t fd) {
  * @param fd  File descriptor for the device.
  * @param idx Buffer index to enable.
  *
- * @return On success, returns 0. On failure, returns a negative error code and 
+ * @return On success, returns 0. On failure, returns a negative error code and
  *         sets errno:
  *          * ENOTSUPP if the firmware does not support GPUDirect.
  *          * EBUSY if the GpuAsyncCore state is locked by another process.

--- a/include/GpuAsync.h
+++ b/include/GpuAsync.h
@@ -61,14 +61,19 @@ struct GpuNvidiaData {
  * and "read enable" bits. Userspace must call gpuEnableRx/gpuEnableTx as needed
  * after adding memory with this function.
  *
+ * GpuAsyncCore state is exclusively owned by one process at a time. These IOCTLs
+ * will fail with EBUSY if GpuAsyncCore state is already being managed by another
+ * process.
+ *
  * @param fd       File descriptor for the device.
  * @param write    Write access flag (1 for write access, 0 for read-only).
  * @param address  Memory address of the GPU region to add.
  * @param size     Size of the memory region to add.  Must be a multiple of 64 KB.
  *
  * @return On success, returns the result of the ioctl call.  On failure,
- *         returns a negative error code.  Returns -ENOTSUPP if the firmware
- *         does not support GPUDirect.
+ *         returns a negative error code and sets errno:
+ *          * ENOTSUPP if the firmware does not support GPUDirect.
+ *          * EBUSY if the GpuAsyncCore state is locked by another process.
  **/
 static inline ssize_t gpuAddNvidiaMemory(int32_t fd, uint32_t write, uint64_t address, uint32_t size) {
    struct GpuNvidiaData dat;
@@ -89,8 +94,9 @@ static inline ssize_t gpuAddNvidiaMemory(int32_t fd, uint32_t write, uint64_t ad
  * @param fd File descriptor for the device.
  *
  * @return On success, returns the result of the ioctl call.  On failure,
- *         returns a negative error code.  Returns -ENOTSUPP if the firmware
- *         does not support GPUDirect.
+ *         returns a negative error code and sets errno:
+ *          * ENOTSUPP if the firmware does not support GPUDirect.
+ *          * EBUSY if the GpuAsyncCore state is locked by another process.
  **/
 static inline ssize_t gpuRemNvidiaMemory(int32_t fd) {
    return(ioctl(fd, GPU_Rem_Nvidia_Memory, 0));
@@ -104,8 +110,10 @@ static inline ssize_t gpuRemNvidiaMemory(int32_t fd) {
  * @param fd  File descriptor for the device.
  * @param idx Buffer index to enable.
  *
- * @return 0 on success, negative error code on failure.  Returns -ENOTSUPP
- *         if the firmware does not support GPUDirect.
+ * @return On success, returns 0. On failure, returns a negative error code and 
+ *         sets errno:
+ *          * ENOTSUPP if the firmware does not support GPUDirect.
+ *          * EBUSY if the GpuAsyncCore state is locked by another process.
  */
 static inline ssize_t gpuSetWriteEn(int32_t fd, uint32_t idx) {
    uint32_t lidx = idx;
@@ -122,7 +130,7 @@ static inline ssize_t gpuSetWriteEn(int32_t fd, uint32_t idx) {
  *         support and returns @c -ENOTSUPP, or when the ioctl itself fails
  *         with @c -1 and @c errno set, e.g. @c ENOTTY or @c ENOTSUPP).
  *         Callers should treat a @c false return as "not supported" without
- *         attempting any further GPU Async ioctls.
+ *         attempting any further GPU Async ioctls, except for gpuGetGpuAsyncVersion.
  *
  * @note The ioctl returns @c 1 (supported), @c 0 (not supported), or a
  *       negative errno on failure.  We must compare against @c >0 because
@@ -174,7 +182,9 @@ static inline ssize_t gpuGetMaxBuffers(int32_t fd) {
  * @param fd File descriptor for the device.
  * @param enable Disable tx if 0, enable tx if != 0
  *
- * @return On success, returns 0. On failure, returns -1 the sets errno.
+ * @return On success, returns 0. On failure, returns -1 the sets errno:
+ *          * ENOTSUPP if the firmware does not support GPUDirect.
+ *          * EBUSY if the GpuAsyncCore state is locked by another process.
  */
 static inline int32_t gpuEnableTx(int32_t fd, uint32_t enable) {
    return ioctl(fd, GPU_Enable_Tx, enable);
@@ -186,7 +196,9 @@ static inline int32_t gpuEnableTx(int32_t fd, uint32_t enable) {
  * @param fd File descriptor for the device.
  * @param enable Disable rx if 0, enable rx if != 0
  *
- * @return On success, returns 0. On failure, returns -1 and sets errno.
+ * @return On success, returns 0. On failure, returns -1 and sets errno:
+ *          * ENOTSUPP if the firmware does not support GPUDirect.
+ *          * EBUSY if the GpuAsyncCore state is locked by another process.
  */
 static inline int32_t gpuEnableRx(int32_t fd, uint32_t enable) {
    return ioctl(fd, GPU_Enable_Rx, enable);


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

Prior to this change, any userspace application could interact with the GpuAsyncCore state, leading to (what should be) UB in other applications.

At one point I accidentally launched two instances of rdmaTest on the same datadev device, which led to one calling `gpuRemNvidiaMemory` which then clobbered the GpuAsyncCore state under the nose of the other app.
