### PR TITLE
common/driver: Expose UltraScale SysMon sensors to hwmon interface

### DIFF
--- a/common/driver/axi_hwmon.c
+++ b/common/driver/axi_hwmon.c
@@ -405,7 +405,6 @@ static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type,
    }
 
    raw = readl(device->base + pvt->axiSysmonOffset + offset);
-   dev_info(device->device, "readl(0x%lX + 0x%lX) = %u\n", pvt->axiSysmonOffset, offset, raw);
 
    // Do conversions if necessary
    if (sens->convFunc)

--- a/common/driver/axi_hwmon.c
+++ b/common/driver/axi_hwmon.c
@@ -18,6 +18,7 @@
 #include <linux/types.h>
 #include <linux/hwmon.h>
 #include <linux/math.h>
+#include <linux/slab.h>
 #include <axi_hwmon.h>
 #include <dma_common.h>
 

--- a/common/driver/axi_hwmon.c
+++ b/common/driver/axi_hwmon.c
@@ -15,14 +15,14 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
-#include "axi_hwmon.h"
-#include "dma_common.h"
 #include <linux/types.h>
 #include <linux/hwmon.h>
 #include <linux/math.h>
+#include <axi_hwmon.h>
+#include <dma_common.h>
 
 /**
- * Specific hardware types for the FPGA. This is used to choose specific ADC 
+ * Specific hardware types for the FPGA. This is used to choose specific ADC
  * conversion functions.
  */
 typedef enum {
@@ -46,17 +46,16 @@ static long convSYSMONE4_T(long raw);
 static long convSYSMONEx_T(struct AxiHwmonDrvPvt* pvt, long raw);
 static long convPS_ADC(struct AxiHwmonDrvPvt* pvt, long raw);
 
-static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type, 
+static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type,
                          u32 attr, int channel, long *val);
 static int AxiHwmon_ReadString(struct device *dev, enum hwmon_sensor_types type,
-		                         u32 attr, int channel, const char **str);
+                               u32 attr, int channel, const char **str);
 static umode_t AxiHwmon_IsVisible(const void *drvdata, enum hwmon_sensor_types type,
-			                         u32 attr, int channel);
+                                  u32 attr, int channel);
 
-enum AxiHwmonSensorInstance {   
-
+enum AxiHwmonSensorInstance {
    AXI_HWMON_CHIP = 0, /* Meta for hwmon, not real sensor */
-   
+
    /**
     * Temperature sensors.
     */
@@ -76,7 +75,7 @@ typedef enum {
    AXI_HWMON_TYPE_C, /* Chip */
    AXI_HWMON_TYPE_T, /* Temp */
    AXI_HWMON_TYPE_V, /* Voltage */
-   
+
    AXI_HWMON_TYPE_COUNT,
 } AxiHwmonSensorType_t;
 
@@ -97,7 +96,7 @@ typedef struct {
 /**
  * Sensor classes.
  */
-const static struct hwmon_channel_info* hwmon_ultrascale_channels[] = {
+static const struct hwmon_channel_info* hwmon_ultrascale_channels[] = {
    HWMON_CHANNEL_INFO(chip, HWMON_C_REGISTER_TZ | HWMON_C_UPDATE_INTERVAL),
    HWMON_CHANNEL_INFO(temp, AXI_HWMON_TEMP_FLAGS),
    HWMON_CHANNEL_INFO(in, AXI_HWMON_IN_FLAGS),
@@ -168,38 +167,22 @@ static const AxiHwmonSensor_t hwmon_ultrascale_sensors[][hwmon_max] = {
 };
 
 /**
- * @brief Maps a AxiHwmonSensorType_t to the equivalent hwmon subsystem type enum
- */
-static enum hwmon_sensor_types sensorTypeToHwmon(AxiHwmonSensorType_t type) {
-   switch(type) {
-   case AXI_HWMON_TYPE_C:
-      return hwmon_chip;
-   case AXI_HWMON_TYPE_T:
-      return hwmon_temp;
-   case AXI_HWMON_TYPE_V:
-      return hwmon_in;
-   default:
-      return hwmon_max;
-   }
-}
-
-/**
  * Initialize Hwmon sensors for this datadev device.
  * If the device is not supported, this prints a warning and returns. This function returns void
  * because it isn't considered critical in datadev initialization. We'll just eat the error and
  * continue anyways.
  * @param dev The datadev device to init for
  * @param axiVerOffset Offset of the AxiVersion register space
- * @param axiSysMonOffset Offset of the AxiSysMonUltrascale register space 
+ * @param axiSysMonOffset Offset of the AxiSysMonUltrascale register space
  */
 void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOffset) {
    AxiHwmonHwType_t hwtype;
 
    // Check for support
    switch (readl(dev->base + axiVerOffset + 0x40C)) {
-   case 0x0: // UltraScale/UltraScale+
+   case 0x0:  // UltraScale/UltraScale+
       break;
-   case 0x1: // 7SERIES (Unsupported)
+   case 0x1:  // 7SERIES (Unsupported)
       return;
    default:
       dev_info(dev->device, "AxiHwmon_Init: No SysMon IP block: hwmon integration will be disabled for this device\n");
@@ -207,7 +190,7 @@ void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOff
    }
 
    // Unfortunately need to case on this. 0x40C does not differentiate between US and US+
-   switch(readl(dev->base + axiVerOffset + 0x424)) {
+   switch (readl(dev->base + axiVerOffset + 0x424)) {
    case 0x00000006:  // XilinxAlveoU50
    case 0x00000007:  // XilinxAlveoU200
    case 0x00000008:  // XilinxAlveoU250
@@ -235,7 +218,7 @@ void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOff
 
    case 0x00000005:  // XilinxAc701
    case 0x0000000A:  // XilinxKc705
-      return; // Unsupported
+      return;  // Unsupported
 
    default:
       dev_warn(dev->device, "AxiHwmon_Init: Unknown PCIe hardware type\n");
@@ -259,8 +242,7 @@ void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOff
       "datadev",
       pvt,
       &hwmon_ultrascale_info,
-      NULL
-   );
+      NULL);
 
    // Check for error and clean up
    if (IS_ERR(pvt->hwmonDev)) {
@@ -363,7 +345,7 @@ static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type,
       dev_warn(dev, "AxiHwmon_Read: Invalid sensor: chan=%d, type=%d, attr=%d\n", channel, type, attr);
       return -ENOTSUPP;
    }
-   
+
    // Lookup the sensor based on the channel and type
    const AxiHwmonSensor_t* sens = &hwmon_ultrascale_sensors[type][channel];
 
@@ -388,7 +370,7 @@ static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type,
       needsHighest = (attr == hwmon_temp_highest);
       needsLowest = (attr == hwmon_temp_lowest);
       break;
-   case hwmon_in: // Voltage, despite the strange name
+   case hwmon_in:  // Voltage, despite the strange name
       needsValue = (attr == hwmon_in_input);
       needsMax = (attr == hwmon_in_max);
       needsCrit = (attr == hwmon_in_crit);
@@ -399,9 +381,9 @@ static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type,
       dev_warn(dev, "AxiHwmon_Read: Unknown sensor type\n");
       return -EOPNOTSUPP;
    }
-   
+
    offset = 0x0;
-   
+
    // Pick the correct offset
    if (needsValue)
       offset = sens->offset;
@@ -444,7 +426,7 @@ static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type,
  * @returns 0 on success, non-zero otherwise.
  */
 static int AxiHwmon_ReadString(struct device *dev, enum hwmon_sensor_types type,
-		                         u32 attr, int channel, const char **str)
+                               u32 attr, int channel, const char **str)
 {
    const char* ptr = NULL;
    const int typeCount = hwmon_ultrascale_chan_counts[type];
@@ -466,7 +448,7 @@ static int AxiHwmon_ReadString(struct device *dev, enum hwmon_sensor_types type,
    default:
       break;
    }
-   
+
    if (ptr)
       *str = ptr;
    else
@@ -479,7 +461,7 @@ static int AxiHwmon_ReadString(struct device *dev, enum hwmon_sensor_types type,
  * Always 0444 in our case because they're read-only.
  */
 static umode_t AxiHwmon_IsVisible(const void *drvdata, enum hwmon_sensor_types type,
-			                         u32 attr, int channel)
+                                  u32 attr, int channel)
 {
    return 0444;
 }

--- a/common/driver/axi_hwmon.c
+++ b/common/driver/axi_hwmon.c
@@ -58,8 +58,6 @@ static umode_t AxiHwmon_IsVisible(const void *drvdata, enum hwmon_sensor_types t
                                   u32 attr, int channel);
 
 enum AxiHwmonSensorInstance {
-   AXI_HWMON_CHIP = 0, /* Meta for hwmon, not real sensor */
-
    /**
     * Temperature sensors.
     */
@@ -93,7 +91,6 @@ typedef struct {
  * Sensor classes.
  */
 static const struct hwmon_channel_info* hwmon_ultrascale_channels[] = {
-   HWMON_CHANNEL_INFO(chip, HWMON_C_REGISTER_TZ),
    HWMON_CHANNEL_INFO(temp, AXI_HWMON_TEMP_FLAGS),
    HWMON_CHANNEL_INFO(in, AXI_HWMON_IN_FLAGS),
    NULL,

--- a/common/driver/axi_hwmon.c
+++ b/common/driver/axi_hwmon.c
@@ -1,0 +1,485 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ *-----------------------------------------------------------------------------
+ * Description: Linux hwmon interface for UltraScale devices implementing the
+ *  SysMon IP block. Once registered, it can be viewed with the 'sensors'
+ *  command (from lm-sensors), or in sysfs at /sys/class/hwmon/hwmonX
+ * ----------------------------------------------------------------------------
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#include "axi_hwmon.h"
+#include "dma_common.h"
+#include <linux/types.h>
+#include <linux/hwmon.h>
+#include <linux/math.h>
+
+/**
+ * Specific hardware types for the FPGA. This is used to choose specific ADC 
+ * conversion functions.
+ */
+typedef enum {
+   AXI_HWMON_HW_TYPE_ULTRASCALE,
+   AXI_HWMON_HW_TYPE_ULTRASCALEPLUS,
+} AxiHwmonHwType_t;
+
+/**
+ * @brief Private data used by the hwmon driver instance.
+ */
+struct AxiHwmonDrvPvt {
+   AxiHwmonHwType_t hwtype;
+   off_t axiVerOffset;
+   off_t axiSysmonOffset;
+   struct DmaDevice* dev;
+   struct device* hwmonDev;
+};
+
+static long convSYSMONE1_T(long raw);
+static long convSYSMONE4_T(long raw);
+static long convSYSMONEx_T(struct AxiHwmonDrvPvt* pvt, long raw);
+static long convPS_ADC(struct AxiHwmonDrvPvt* pvt, long raw);
+
+static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type, 
+                         u32 attr, int channel, long *val);
+static int AxiHwmon_ReadString(struct device *dev, enum hwmon_sensor_types type,
+		                         u32 attr, int channel, const char **str);
+static umode_t AxiHwmon_IsVisible(const void *drvdata, enum hwmon_sensor_types type,
+			                         u32 attr, int channel);
+
+enum AxiHwmonSensorInstance {   
+
+   AXI_HWMON_CHIP = 0, /* Meta for hwmon, not real sensor */
+   
+   /**
+    * Temperature sensors.
+    */
+   AXI_HWMON_TEMP = 0,
+   AXI_HWMON_TEMP_COUNT, /* Total number of temp sensors */
+
+   /**
+    * Voltage sensors.
+    */
+   AXI_HWMON_VCCINT = 0,
+   AXI_HWMON_VCCAUX,
+   AXI_HWMON_VCCBRAM,
+   AXI_HWMON_IN_COUNT,
+};
+
+typedef enum {
+   AXI_HWMON_TYPE_C, /* Chip */
+   AXI_HWMON_TYPE_T, /* Temp */
+   AXI_HWMON_TYPE_V, /* Voltage */
+   
+   AXI_HWMON_TYPE_COUNT,
+} AxiHwmonSensorType_t;
+
+typedef struct {
+   const char* label;
+   u32 offset;         /* Offset of the main register (from the IP block base addr) */
+   u32 maxOffset;      /* For max level/temp/etc. */
+   u32 critOffset;     /* For critical level/temp/etc. */
+   u32 highestOffset;  /* For highest recorded value */
+   u32 lowestOffset;   /* For lowest recorded value */
+   long(*convFunc)(struct AxiHwmonDrvPvt*, long);
+} AxiHwmonSensor_t;
+
+#define AXI_HWMON_IN_FLAGS (HWMON_I_INPUT | HWMON_I_LABEL | HWMON_I_HIGHEST | HWMON_I_LOWEST)
+#define AXI_HWMON_TEMP_FLAGS (HWMON_T_INPUT | HWMON_T_MAX | HWMON_T_CRIT | HWMON_T_LABEL \
+                              | HWMON_T_HIGHEST | HWMON_T_LOWEST)
+
+/**
+ * Sensor classes.
+ */
+const static struct hwmon_channel_info* hwmon_ultrascale_channels[] = {
+   HWMON_CHANNEL_INFO(chip, HWMON_C_REGISTER_TZ | HWMON_C_UPDATE_INTERVAL),
+   HWMON_CHANNEL_INFO(temp, AXI_HWMON_TEMP_FLAGS),
+   HWMON_CHANNEL_INFO(in, AXI_HWMON_IN_FLAGS),
+   NULL,
+};
+
+static const struct hwmon_ops hwmon_ultrascale_ops = {
+   .is_visible = AxiHwmon_IsVisible,
+   .read = AxiHwmon_Read,
+   .read_string = AxiHwmon_ReadString,
+};
+
+/**
+ * Chip info
+ */
+static const struct hwmon_chip_info hwmon_ultrascale_info = {
+   .ops = &hwmon_ultrascale_ops,
+   .info = hwmon_ultrascale_channels,
+};
+
+/**
+ * Number of channels for each sensor class.
+ */
+static const int hwmon_ultrascale_chan_counts[hwmon_max] = {
+   [hwmon_in] = AXI_HWMON_IN_COUNT,
+   [hwmon_temp] = AXI_HWMON_TEMP_COUNT,
+};
+
+/**
+ * Big Ol' array of sensors supported by this device.
+ * Nested based on sensor type, because the hwmon API is not amazing...
+ */
+static const AxiHwmonSensor_t hwmon_ultrascale_sensors[][hwmon_max] = {
+   [hwmon_in] = {
+      [AXI_HWMON_VCCINT] = {
+         .label = "VccInt",
+         .offset = 0x404,
+         .convFunc = convPS_ADC,
+         .highestOffset = 0x484,
+         .lowestOffset = 0x494,
+      },
+      [AXI_HWMON_VCCAUX] = {
+         .label = "VccAux",
+         .offset = 0x408,
+         .convFunc = convPS_ADC,
+         .highestOffset = 0x488,
+         .lowestOffset = 0x498,
+      },
+      [AXI_HWMON_VCCBRAM] = {
+         .label = "VccBRAM",
+         .offset = 0x418,
+         .convFunc = convPS_ADC,
+         .highestOffset = 0x48C,
+         .lowestOffset = 0x49C,
+      },
+   },
+   [hwmon_temp] = {
+      [AXI_HWMON_TEMP] = {
+         .label = "Temperature",
+         .offset = 0x400,
+         .maxOffset = 0x55C,
+         .critOffset = 0x54C,
+         .highestOffset = 0x480,
+         .lowestOffset = 0x490,
+         .convFunc = convSYSMONEx_T,
+      },
+   }
+};
+
+/**
+ * @brief Maps a AxiHwmonSensorType_t to the equivalent hwmon subsystem type enum
+ */
+static enum hwmon_sensor_types sensorTypeToHwmon(AxiHwmonSensorType_t type) {
+   switch(type) {
+   case AXI_HWMON_TYPE_C:
+      return hwmon_chip;
+   case AXI_HWMON_TYPE_T:
+      return hwmon_temp;
+   case AXI_HWMON_TYPE_V:
+      return hwmon_in;
+   default:
+      return hwmon_max;
+   }
+}
+
+/**
+ * Initialize Hwmon sensors for this datadev device.
+ * If the device is not supported, this prints a warning and returns. This function returns void
+ * because it isn't considered critical in datadev initialization. We'll just eat the error and
+ * continue anyways.
+ * @param dev The datadev device to init for
+ * @param axiVerOffset Offset of the AxiVersion register space
+ * @param axiSysMonOffset Offset of the AxiSysMonUltrascale register space 
+ */
+void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOffset) {
+   AxiHwmonHwType_t hwtype;
+
+   // Check for support
+   switch (readl(dev->base + axiVerOffset + 0x40C)) {
+   case 0x0: // UltraScale/UltraScale+
+      break;
+   case 0x1: // 7SERIES (Unsupported)
+      return;
+   default:
+      dev_info(dev->device, "AxiHwmon_Init: No SysMon IP block: hwmon integration will be disabled for this device\n");
+      return;
+   }
+
+   // Unfortunately need to case on this. 0x40C does not differentiate between US and US+
+   switch(readl(dev->base + axiVerOffset + 0x424)) {
+   case 0x00000006:  // XilinxAlveoU50
+   case 0x00000007:  // XilinxAlveoU200
+   case 0x00000008:  // XilinxAlveoU250
+   case 0x00000009:  // XilinxAlveoU280
+   case 0x0000000C:  // XilinxKcu116
+   case 0x0000000E:  // XilinxVcu128
+   case 0x0000000F:  // XilinxAlveoU55C
+   case 0x00000010:  // XilinxVariumC1100
+   case 0x00001010:  // XilinxVariumC1100Extended
+   case 0x00000012:  // AbacoPc821Ku115
+   case 0x00000013:  // BittWareXupVv8Vu9p
+   case 0x00000002:  // BittWareXupVv8Vu13p
+      hwtype = AXI_HWMON_HW_TYPE_ULTRASCALEPLUS;
+      break;
+
+   case 0x0000000B:  // XilinxKcu105
+   case 0x0000000D:  // XilinxKcu1500
+   case 0x0000100D:  // XilinxKcu1500Extended
+   case 0x00000011:  // AbacoPc821Ku085
+   case 0x00000001:  // AlphaDataKu3
+   case 0x00000003:  // SlacPgpCardG3
+   case 0x00000004:  // SlacPgpCardG4
+      hwtype = AXI_HWMON_HW_TYPE_ULTRASCALE;
+      break;
+
+   case 0x00000005:  // XilinxAc701
+   case 0x0000000A:  // XilinxKc705
+      return; // Unsupported
+
+   default:
+      dev_warn(dev->device, "AxiHwmon_Init: Unknown PCIe hardware type\n");
+      return;
+   }
+
+   // Allocate the hwmon driver private info
+   struct AxiHwmonDrvPvt* pvt = kzalloc(sizeof(struct AxiHwmonDrvPvt), GFP_KERNEL);
+   if (!pvt) {
+      dev_err(dev->device, "AxiHwmon_Init: Failed to allocate driver private data.\n");
+      return;
+   }
+
+   pvt->axiSysmonOffset = axiSysMonOffset;
+   pvt->axiVerOffset = axiVerOffset;
+   pvt->hwtype = hwtype;
+   pvt->dev = dev;
+
+   pvt->hwmonDev = hwmon_device_register_with_info(
+      dev->device,
+      "datadev",
+      pvt,
+      &hwmon_ultrascale_info,
+      NULL
+   );
+
+   // Check for error and clean up
+   if (IS_ERR(pvt->hwmonDev)) {
+      dev_err(dev->device, "AxiHwmon_Init: Failed to register hwmon device: %ld\n",
+              PTR_ERR(pvt->hwmonDev));
+      goto error_post_alloc;
+   }
+
+   dev_info(dev->device, "AxiHwmon_Init: Registered hwmon device\n");
+
+   dev->hwmonPrivate = pvt;
+
+   return;
+error_post_alloc:
+   kfree(pvt);
+   dev->hwmonPrivate = NULL;
+}
+
+/**
+ * Removes the hwmon driver instances for this datadevice,
+ * freeing any data we allocated along the way.
+ */
+void AxiHwmon_Remove(struct DmaDevice* dev) {
+   struct AxiHwmonDrvPvt* pvt = dev->hwmonPrivate;
+   if (!pvt)
+      return;
+
+   if (!IS_ERR(pvt->hwmonDev))
+      hwmon_device_unregister(pvt->hwmonDev);
+
+   memset(pvt, 0, sizeof(*pvt));
+   kfree(pvt);
+
+   dev->hwmonPrivate = NULL;
+}
+
+/**
+ * @brief SYSMONE1 temperature conversion function. Uses full 16-bit ADC value (not bit shifted).
+ * See UG520 equation 2-8.
+ * @note Float values have been converted to integers (by multiplication) due to FP being disabled in kernel space.
+ * @returns Temperature in mC
+ */
+static long convSYSMONE1_T(long raw) {
+   raw = (raw * 502910) / 65536;
+   return raw - 273820;
+}
+
+/**
+ * @brief SYSMONE4 temperature conversion function. Uses full 16-bit ADC value (not bit shifted).
+ * See UG520 equation 2-8
+ * @note Float values have been converted to integers (by multiplication) due to FP being disabled in kernel space.
+ * @returns Temperature in mC
+ */
+static long convSYSMONE4_T(long raw) {
+   raw = (raw * 507592) / 65536;
+   return raw - 279427;
+}
+
+/**
+ * @brief Uses the correct temperature conversion function based on hardware version
+ */
+static long convSYSMONEx_T(struct AxiHwmonDrvPvt* pvt, long raw) {
+   switch (pvt->hwtype) {
+   case AXI_HWMON_HW_TYPE_ULTRASCALE:
+      return convSYSMONE1_T(raw);
+   case AXI_HWMON_HW_TYPE_ULTRASCALEPLUS:
+      return convSYSMONE4_T(raw);
+   default:
+      return 0;
+   }
+}
+
+/**
+ * @brief 3 volt power supply ADC conversion. Uses full range 16-bit ADC value (not bit shifted).
+ * @returns Voltage in mV
+ */
+static long convPS_ADC(struct AxiHwmonDrvPvt* pvt, long raw) {
+   (void) pvt;
+   return ((raw * 3 * 1000) / 65536);
+}
+
+/**
+ * @brief Reads a hwmon channel for the datadev device
+ * @param dev Hwmon device structure
+ * @param type Sensor type
+ * @param attr The attribute (e.g. hwmon_temp_xxx)
+ * @param channel The channel index for the sensor type
+ * @param val The output value. This will be in mC or mV, depending on the type.
+ * @returns 0 on success, non-zero otherwise
+ */
+static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type,
+                         u32 attr, int channel, long *val)
+{
+   uint32_t value, raw;
+   uintptr_t offset;
+   int needsValue = 0, needsMax = 0, needsCrit = 0, needsHighest = 0, needsLowest = 0;
+
+   const int typeCount = hwmon_ultrascale_chan_counts[type];
+   if (typeCount == 0 || channel >= typeCount || channel < 0) {
+      dev_warn(dev, "AxiHwmon_Read: Invalid sensor: chan=%d, type=%d, attr=%d\n", channel, type, attr);
+      return -ENOTSUPP;
+   }
+   
+   // Lookup the sensor based on the channel and type
+   const AxiHwmonSensor_t* sens = &hwmon_ultrascale_sensors[type][channel];
+
+   struct AxiHwmonDrvPvt* pvt = dev->driver_data;
+   if (!pvt) {
+      dev_warn(dev, "AxiHwmon_Read: Invalid private data\n");
+      return -EINVAL;
+   }
+
+   struct DmaDevice* device = pvt->dev;
+   if (!device) {
+      dev_warn(dev, "AxiHwmon_Read: Invalid DmaDevice\n");
+      return -EINVAL;
+   }
+
+   // Determine what hwmon wants us to read
+   switch (type) {
+   case hwmon_temp:
+      needsValue = (attr == hwmon_temp_input);
+      needsMax = (attr == hwmon_temp_max);
+      needsCrit = (attr == hwmon_temp_crit);
+      needsHighest = (attr == hwmon_temp_highest);
+      needsLowest = (attr == hwmon_temp_lowest);
+      break;
+   case hwmon_in: // Voltage, despite the strange name
+      needsValue = (attr == hwmon_in_input);
+      needsMax = (attr == hwmon_in_max);
+      needsCrit = (attr == hwmon_in_crit);
+      needsHighest = (attr == hwmon_in_highest);
+      needsLowest = (attr == hwmon_in_lowest);
+      break;
+   default:
+      dev_warn(dev, "AxiHwmon_Read: Unknown sensor type\n");
+      return -EOPNOTSUPP;
+   }
+   
+   offset = 0x0;
+   
+   // Pick the correct offset
+   if (needsValue)
+      offset = sens->offset;
+   else if (needsMax)
+      offset = sens->maxOffset;
+   else if (needsCrit)
+      offset = sens->critOffset;
+   else if (needsLowest)
+      offset = sens->lowestOffset;
+   else if (needsHighest)
+      offset = sens->highestOffset;
+
+   // Reject invalid offsets
+   if (offset == 0x0) {
+      dev_warn(dev, "AxiHwmon_Read: Invalid offset for sensor type=%d, attr=%d, ch=%d\n",
+               type, attr, channel);
+      return -EINVAL;
+   }
+
+   raw = readl(device->base + pvt->axiSysmonOffset + offset);
+   dev_info(device->device, "readl(0x%lX + 0x%lX) = %u\n", pvt->axiSysmonOffset, offset, raw);
+
+   // Do conversions if necessary
+   if (sens->convFunc)
+      value = sens->convFunc(pvt, raw);
+   else
+      value = raw;
+
+   *val = value;
+   return 0;
+}
+
+/**
+ * @brief Reads a hwmon string attribute (only label in this case)
+ * @param dev The hwmon device to work on
+ * @param type Sensor type
+ * @param attr The attribute for this sensor type (again, only hwmon_xxx_label here)
+ * @param channel Channel index for this senso type
+ * @param str Pointer to a string holding the output. Set to NULL for none.
+ * @returns 0 on success, non-zero otherwise.
+ */
+static int AxiHwmon_ReadString(struct device *dev, enum hwmon_sensor_types type,
+		                         u32 attr, int channel, const char **str)
+{
+   const char* ptr = NULL;
+   const int typeCount = hwmon_ultrascale_chan_counts[type];
+   if (typeCount == 0 || channel >= typeCount || channel < 0) {
+      dev_warn(dev, "AxiHwmon_Read: Invalid sensor: chan=%d, type=%d, attr=%d\n", channel, type, attr);
+      return -ENOTSUPP;
+   }
+
+   const AxiHwmonSensor_t* sens = &hwmon_ultrascale_sensors[type][channel];
+   switch (type) {
+   case hwmon_temp:
+      if (attr == hwmon_temp_label)
+         ptr = sens->label;
+      break;
+   case hwmon_in:
+      if (attr == hwmon_in_label)
+         ptr = sens->label;
+      break;
+   default:
+      break;
+   }
+   
+   if (ptr)
+      *str = ptr;
+   else
+      return -EOPNOTSUPP;
+   return 0;
+}
+
+/**
+ * @brief Simply returns the access attributes for the hwmon instance.
+ * Always 0444 in our case because they're read-only.
+ */
+static umode_t AxiHwmon_IsVisible(const void *drvdata, enum hwmon_sensor_types type,
+			                         u32 attr, int channel)
+{
+   return 0444;
+}

--- a/common/driver/axi_hwmon.c
+++ b/common/driver/axi_hwmon.c
@@ -15,12 +15,15 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+#include <linux/version.h>
 #include <linux/types.h>
-#include <linux/hwmon.h>
-#include <linux/math.h>
-#include <linux/slab.h>
-#include <axi_hwmon.h>
 #include <dma_common.h>
+#include <axi_hwmon.h>
+#include <axi_version.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+#include <linux/hwmon.h>
+#include <linux/slab.h>
 
 /**
  * Specific hardware types for the FPGA. This is used to choose specific ADC
@@ -72,14 +75,6 @@ enum AxiHwmonSensorInstance {
    AXI_HWMON_IN_COUNT,
 };
 
-typedef enum {
-   AXI_HWMON_TYPE_C, /* Chip */
-   AXI_HWMON_TYPE_T, /* Temp */
-   AXI_HWMON_TYPE_V, /* Voltage */
-
-   AXI_HWMON_TYPE_COUNT,
-} AxiHwmonSensorType_t;
-
 typedef struct {
    const char* label;
    u32 offset;         /* Offset of the main register (from the IP block base addr) */
@@ -98,7 +93,7 @@ typedef struct {
  * Sensor classes.
  */
 static const struct hwmon_channel_info* hwmon_ultrascale_channels[] = {
-   HWMON_CHANNEL_INFO(chip, HWMON_C_REGISTER_TZ | HWMON_C_UPDATE_INTERVAL),
+   HWMON_CHANNEL_INFO(chip, HWMON_C_REGISTER_TZ),
    HWMON_CHANNEL_INFO(temp, AXI_HWMON_TEMP_FLAGS),
    HWMON_CHANNEL_INFO(in, AXI_HWMON_IN_FLAGS),
    NULL,
@@ -159,7 +154,7 @@ static const AxiHwmonSensor_t hwmon_ultrascale_sensors[][hwmon_max] = {
          .label = "Temperature",
          .offset = 0x400,
          .maxOffset = 0x55C,
-         .critOffset = 0x54C,
+         .critOffset = 0x540,
          .highestOffset = 0x480,
          .lowestOffset = 0x490,
          .convFunc = convSYSMONEx_T,
@@ -190,8 +185,11 @@ void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOff
       return;
    }
 
+   // Read hardware type and mask off bifurcation index.
+   uint32_t htype = readl(dev->base + axiVerOffset + 0x400 + 4 * AxiVersion_Usr_HardwareType_Offset) & 0xFFF;
+
    // Unfortunately need to case on this. 0x40C does not differentiate between US and US+
-   switch (readl(dev->base + axiVerOffset + 0x424)) {
+   switch (htype) {
    case 0x00000006:  // XilinxAlveoU50
    case 0x00000007:  // XilinxAlveoU200
    case 0x00000008:  // XilinxAlveoU250
@@ -200,8 +198,6 @@ void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOff
    case 0x0000000E:  // XilinxVcu128
    case 0x0000000F:  // XilinxAlveoU55C
    case 0x00000010:  // XilinxVariumC1100
-   case 0x00001010:  // XilinxVariumC1100Extended
-   case 0x00000012:  // AbacoPc821Ku115
    case 0x00000013:  // BittWareXupVv8Vu9p
    case 0x00000002:  // BittWareXupVv8Vu13p
       hwtype = AXI_HWMON_HW_TYPE_ULTRASCALEPLUS;
@@ -209,8 +205,8 @@ void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOff
 
    case 0x0000000B:  // XilinxKcu105
    case 0x0000000D:  // XilinxKcu1500
-   case 0x0000100D:  // XilinxKcu1500Extended
    case 0x00000011:  // AbacoPc821Ku085
+   case 0x00000012:  // AbacoPc821Ku115
    case 0x00000001:  // AlphaDataKu3
    case 0x00000003:  // SlacPgpCardG3
    case 0x00000004:  // SlacPgpCardG4
@@ -238,6 +234,8 @@ void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOff
    pvt->hwtype = hwtype;
    pvt->dev = dev;
 
+   dev->hwmonPrivate = pvt;
+
    pvt->hwmonDev = hwmon_device_register_with_info(
       dev->device,
       "datadev",
@@ -253,8 +251,6 @@ void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOff
    }
 
    dev_info(dev->device, "AxiHwmon_Init: Registered hwmon device\n");
-
-   dev->hwmonPrivate = pvt;
 
    return;
 error_post_alloc:
@@ -337,14 +333,15 @@ static long convPS_ADC(struct AxiHwmonDrvPvt* pvt, long raw) {
 static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type,
                          u32 attr, int channel, long *val)
 {
-   uint32_t value, raw;
+   long value;
+   uint32_t raw;
    uintptr_t offset;
    int needsValue = 0, needsMax = 0, needsCrit = 0, needsHighest = 0, needsLowest = 0;
 
    const int typeCount = hwmon_ultrascale_chan_counts[type];
    if (typeCount == 0 || channel >= typeCount || channel < 0) {
       dev_warn(dev, "AxiHwmon_Read: Invalid sensor: chan=%d, type=%d, attr=%d\n", channel, type, attr);
-      return -ENOTSUPP;
+      return -EOPNOTSUPP;
    }
 
    // Lookup the sensor based on the channel and type
@@ -373,8 +370,6 @@ static int AxiHwmon_Read(struct device *dev, enum hwmon_sensor_types type,
       break;
    case hwmon_in:  // Voltage, despite the strange name
       needsValue = (attr == hwmon_in_input);
-      needsMax = (attr == hwmon_in_max);
-      needsCrit = (attr == hwmon_in_crit);
       needsHighest = (attr == hwmon_in_highest);
       needsLowest = (attr == hwmon_in_lowest);
       break;
@@ -432,7 +427,7 @@ static int AxiHwmon_ReadString(struct device *dev, enum hwmon_sensor_types type,
    const int typeCount = hwmon_ultrascale_chan_counts[type];
    if (typeCount == 0 || channel >= typeCount || channel < 0) {
       dev_warn(dev, "AxiHwmon_Read: Invalid sensor: chan=%d, type=%d, attr=%d\n", channel, type, attr);
-      return -ENOTSUPP;
+      return -EOPNOTSUPP;
    }
 
    const AxiHwmonSensor_t* sens = &hwmon_ultrascale_sensors[type][channel];
@@ -465,3 +460,13 @@ static umode_t AxiHwmon_IsVisible(const void *drvdata, enum hwmon_sensor_types t
 {
    return 0444;
 }
+#else
+
+/**
+ * Stubs for older kernels.
+ */
+
+void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOffset) {}
+void AxiHwmon_Remove(struct DmaDevice* dev) {}
+
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)

--- a/common/driver/axi_hwmon.c
+++ b/common/driver/axi_hwmon.c
@@ -466,4 +466,4 @@ static umode_t AxiHwmon_IsVisible(const void *drvdata, enum hwmon_sensor_types t
 void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOffset) {}
 void AxiHwmon_Remove(struct DmaDevice* dev) {}
 
-#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)
+#endif  // LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)

--- a/common/driver/axi_hwmon.h
+++ b/common/driver/axi_hwmon.h
@@ -1,0 +1,25 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ *-----------------------------------------------------------------------------
+ * Description: Linux hwmon interface for UltraScale devices implementing the
+ *  SysMon IP block.
+ * ----------------------------------------------------------------------------
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef AXI_HWMON_H_
+#define AXI_HWMON_H_
+
+#include "dma_common.h"
+
+void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOffset);
+void AxiHwmon_Remove(struct DmaDevice* dev);
+
+#endif // AXI_HWMON_H_

--- a/common/driver/axi_hwmon.h
+++ b/common/driver/axi_hwmon.h
@@ -22,4 +22,4 @@
 void AxiHwmon_Init(struct DmaDevice* dev, off_t axiVerOffset, off_t axiSysMonOffset);
 void AxiHwmon_Remove(struct DmaDevice* dev);
 
-#endif // AXI_HWMON_H_
+#endif  // AXI_HWMON_H_

--- a/common/driver/axi_pcie_regmap.c
+++ b/common/driver/axi_pcie_regmap.c
@@ -85,7 +85,7 @@ int AxiRegMap_Init(struct DmaDevice* dev, __iomem void* axiVersion) {
       dev_warn(dev->device, "AxiRegMap_Init: Unsupported register map version %u. Maximum supported version is %d.\n",
                dev->regMapVersion, MAX_SUPPORTED_REG_VERSION);
       dev_warn(dev->device, "Please use a newer driver version, or contact a maintainer to update the software\n");
-      return -1;
+      return -EPFNOSUPPORT;
    }
    dev_info(dev->device, "AxiRegMap_Init: Using register map version %d\n", dev->regMapVersion);
    return 0;

--- a/common/driver/axi_pcie_regmap.c
+++ b/common/driver/axi_pcie_regmap.c
@@ -1,0 +1,124 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ *-----------------------------------------------------------------------------
+ * Description: Abstraction of the axi-pcie-core register mapping.
+ * ----------------------------------------------------------------------------
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#include <axi_pcie_regmap.h>
+#include <dma_common.h>
+#include <axi_version.h>
+
+struct reg_block {
+   struct {
+      uint32_t offset;
+      uint32_t size;
+   } regs[REG_COUNT];
+};
+
+/** Address map for device registers. */
+#define AGEN2_OFF_V0       0x00000000
+#define AGEN2_SIZE_V0      0x00010000
+#define PHY_OFF_V0         0x00010000
+#define PHY_SIZE_V0        0x00010000
+#define AVER_OFF_V0        0x00020000
+#define AVER_SIZE_V0       0x00010000
+#define PROM_OFF_V0        0x00030000
+#define PROM_SIZE_V0       0x00050000
+#define USER_OFF_V0        0x00800000
+#define USER_SIZE_V0       0x00800000
+#define GPU_ASYNC_OFF_V0   0x00028000
+#define GPU_ASYNC_SIZE_V0  0x00010000
+/* AxiSysMon is present in "V0", but only after ~2022 or so (I dont know the exact axi-pcie-core version).
+ * Thus, we'll pretend it's *not* present in V0 since it is not always there, depending on age. */
+#define ASYSMON_OFF_V0  INVALID_REG_OFFSET
+#define ASYSMON_SIZE_V0 0
+
+#define ASYSMON_OFF_V1  0x00024000
+#define ASYSMON_SIZE_V1 0x00004000
+
+static const struct reg_block register_map[MAX_SUPPORTED_REG_VERSION+1] = {
+   [0] = {  /* Version 0 */
+      .regs = {
+         [REG_AXIS_GEN2]      = {.offset = AGEN2_OFF_V0,       .size = AGEN2_SIZE_V0   },
+         [REG_PHY]            = {.offset = PHY_OFF_V0,         .size = PHY_SIZE_V0     },
+         [REG_AXI_VERSION]    = {.offset = AVER_OFF_V0,        .size = AVER_SIZE_V0    },
+         [REG_AXI_SYSMON]     = {.offset = ASYSMON_OFF_V0,     .size = ASYSMON_SIZE_V0 },
+         [REG_PROM]           = {.offset = PROM_OFF_V0,        .size = PROM_SIZE_V0    },
+         [REG_USER]           = {.offset = USER_OFF_V0,        .size = USER_SIZE_V0    },
+         [REG_GPU_ASYNC]      = {.offset = GPU_ASYNC_OFF_V0,   .size = GPU_ASYNC_SIZE_V0 }
+      }
+   },
+   [1] = {  /* Version 1: Most offsets unchanged. */
+      .regs = {
+         [REG_AXIS_GEN2]      = {.offset = AGEN2_OFF_V0,       .size = AGEN2_SIZE_V0   },
+         [REG_PHY]            = {.offset = PHY_OFF_V0,         .size = PHY_SIZE_V0     },
+         [REG_AXI_VERSION]    = {.offset = AVER_OFF_V0,        .size = AVER_SIZE_V0    },
+         [REG_AXI_SYSMON]     = {.offset = ASYSMON_OFF_V1,     .size = ASYSMON_SIZE_V1 },
+         [REG_PROM]           = {.offset = PROM_OFF_V0,        .size = PROM_SIZE_V0    },
+         [REG_USER]           = {.offset = USER_OFF_V0,        .size = USER_SIZE_V0    },
+         [REG_GPU_ASYNC]      = {.offset = GPU_ASYNC_OFF_V0,   .size = GPU_ASYNC_SIZE_V0 }
+      }
+   }
+};
+
+/**
+ * @brief Init the memory map for the device.
+ * Unfortunately this is a bit of a chicken-and-the-egg problem, since we need to read the map
+ * version from AxiVersion, which itself may be versioned by the mem map version.
+ * We have to assume that AxiVersion will not move, if it does, the caller of this function is
+ * responsible for giving us the right address :(
+ */
+int AxiRegMap_Init(struct DmaDevice* dev, __iomem void* axiVersion) {
+   __iomem struct AxiVersion_Reg *reg = (__iomem struct AxiVersion_Reg *)axiVersion;
+   dev->regMapVersion = readl(&reg->userValues[AxiVersion_Usr_MemoryMapVer_Offset]) & 0xFF;
+
+   if (dev->regMapVersion > MAX_SUPPORTED_REG_VERSION) {
+      dev_warn(dev->device, "AxiRegMap_Init: Unsupported register map version %u. Maximum supported version is %d.\n",
+               dev->regMapVersion, MAX_SUPPORTED_REG_VERSION);
+      dev_warn(dev->device, "Please use a newer driver version, or contact a maintainer to update the software\n");
+      return -1;
+   }
+   dev_info(dev->device, "AxiRegMap_Init: Using register map version %d\n", dev->regMapVersion);
+   return 0;
+}
+
+/**
+ * @brief Query the offset of a register block within axi-pcie-core
+ * @param dev The device.
+ * @param block The block index
+ * @returns Offset of the block, or INVALID_REG_OFFSET (UINT32_MAX) if invalid.
+ */
+uint32_t AxiRegMap_GetOffset(struct DmaDevice* dev, reg_block_index_t block) {
+   if (dev->regMapVersion > MAX_SUPPORTED_REG_VERSION)
+      return INVALID_REG_OFFSET;
+
+   const struct reg_block* bl = &register_map[dev->regMapVersion];
+   // This is pretty ugly, but if we forget to add an entry to register_map for the corresponding
+   // block, offset/size gets set to 0 (global scope static storage, anyway). offset=0 is valid, but size=0 is not.
+   if (bl->regs[block].size)
+      return bl->regs[block].offset;
+   return INVALID_REG_OFFSET;
+}
+
+/**
+ * @brief Query the size of a register block within axi-pcie-core
+ * @param dev The device.
+ * @param block The block index.
+ * @returns Size of the block, or 0 if invalid.
+ */
+uint32_t AxiRegMap_GetSize(struct DmaDevice* dev, reg_block_index_t block) {
+   if (dev->regMapVersion > MAX_SUPPORTED_REG_VERSION)
+      return 0;
+
+   const struct reg_block* bl = &register_map[dev->regMapVersion];
+   return bl->regs[block].size;
+}

--- a/common/driver/axi_pcie_regmap.h
+++ b/common/driver/axi_pcie_regmap.h
@@ -1,0 +1,49 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ *-----------------------------------------------------------------------------
+ * Description: Abstraction of the axi-pcie-core register mapping
+ * ----------------------------------------------------------------------------
+ * This file is part of the aes_stream_drivers package. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the aes_stream_drivers package, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef _AXI_PCIE_REGMAP_H_
+#define _AXI_PCIE_REGMAP_H_
+
+#include <linux/types.h>
+#include <dma_common.h>
+
+/** 
+ * Register block indices.
+ */
+typedef enum reg_block_index {
+   REG_AXIS_GEN2 = 0,
+   REG_PHY,
+   REG_AXI_VERSION,
+   REG_AXI_SYSMON,
+   REG_PROM,
+   REG_USER,
+   REG_GPU_ASYNC,
+
+   REG_COUNT,
+} reg_block_index_t;
+
+#define INVALID_REG_OFFSET 0xFFFFFFFF
+
+/**
+ * Maximum supported register map version. Make sure to bump this when you update
+ * the axi-pcie-core main register map.
+ */
+#define MAX_SUPPORTED_REG_VERSION 1
+
+int AxiRegMap_Init(struct DmaDevice* dev, __iomem void* axiVersion);
+uint32_t AxiRegMap_GetOffset(struct DmaDevice* dev, reg_block_index_t block);
+uint32_t AxiRegMap_GetSize(struct DmaDevice* dev, reg_block_index_t block);
+
+#endif  // _AXI_PCIE_REGMAP_H_

--- a/common/driver/axi_pcie_regmap.h
+++ b/common/driver/axi_pcie_regmap.h
@@ -19,7 +19,7 @@
 #include <linux/types.h>
 #include <dma_common.h>
 
-/** 
+/**
  * Register block indices.
  */
 typedef enum reg_block_index {

--- a/common/driver/axi_version.h
+++ b/common/driver/axi_version.h
@@ -26,6 +26,7 @@
 
 // Dword offset relative to the start of userValues
 static const int AxiVersion_Usr_HardwareType_Offset = 0x9;
+static const int AxiVersion_Usr_MemoryMapVer_Offset = 0xB;
 
 /**
  * struct AxiVersion_Reg - AXI Version register space

--- a/common/driver/axi_version.h
+++ b/common/driver/axi_version.h
@@ -26,7 +26,7 @@
 
 // Dword offset relative to the start of userValues
 static const int AxiVersion_Usr_HardwareType_Offset = 0x9;
-static const int AxiVersion_Usr_MemoryMapVer_Offset = 0xB;
+static const int AxiVersion_Usr_MemoryMapVer_Offset = 0x3F;
 
 /**
  * struct AxiVersion_Reg - AXI Version register space

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -85,6 +85,7 @@ static struct pci_device_id DataDev_Ids[] = {
 
 MODULE_LICENSE("GPL");
 MODULE_DEVICE_TABLE(pci, DataDev_Ids);
+MODULE_DESCRIPTION("Driver for FPGAs running the SLAC DMA engine");
 module_init(DataDev_Init);
 module_exit(DataDev_Exit);
 

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -21,6 +21,7 @@
 #include <data_dev_top.h>
 #include <AxiVersion.h>
 #include <axi_version.h>
+#include <axi_hwmon.h>
 #include <linux/module.h>
 #include <linux/moduleparam.h>
 #include <linux/types.h>
@@ -385,6 +386,9 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
       goto err_unmap;
    }
 
+   // Register hwmon interface
+   AxiHwmon_Init(dev, AVER_OFF, ASYSMON_OFF);
+
    // Log memory mapping information
    dev_info(dev->device, "Init: Reg space mapped to 0x%p.\n", dev->reg);
    dev_info(dev->device, "Init: User space mapped to 0x%p with size 0x%x.\n", dev->rwBase, dev->rwSize);
@@ -455,6 +459,9 @@ void DataDev_Remove(struct pci_dev *pcidev) {
 
    // Decrement count
    gDmaDevCount--;
+
+   // Remove hwmon interface
+   AxiHwmon_Remove(dev);
 
 #ifdef DATA_GPU
    // Free GPU utility data allocated by Gpu_Init. gpu_async.c

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -408,7 +408,7 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    }
 
    // Register hwmon interface, if supported.
-   if (axiSysMonOffset != INVALID_REG_OFFSET) {
+   if (axiSysMonOffset != INVALID_REG_OFFSET && readl(dev->base + AVER_OFF + 0x42C)) {
       AxiHwmon_Init(dev, AVER_OFF, axiSysMonOffset);
    }
 

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -177,7 +177,7 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    int32_t x;
    uint32_t axiWidth;
    int ret;
-   uint32_t axiGen2Offset, phyOffset, axiSysMonOffset, gpuAsyncCoreOffset;
+   uint32_t axiGen2Offset, phyOffset, axiSysMonOffset;
 
    // Validate buffer mode configuration
    if ( cfgMode != BUFF_COHERENT && cfgMode != BUFF_STREAM ) {
@@ -289,7 +289,6 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
 
    // Optional offsets
    axiSysMonOffset = AxiRegMap_GetOffset(dev, REG_AXI_SYSMON);
-   gpuAsyncCoreOffset = AxiRegMap_GetOffset(dev, REG_GPU_ASYNC);
 
    // Initialize device configuration parameters
    dev->cfgTxCount    = cfgTxCount;    // Transmit buffer count
@@ -356,6 +355,8 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    dev->rwSize = (2*USER_SIZE) - phyOffset;  // Read/Write region size
 
 #ifdef DATA_GPU
+   uint32_t gpuAsyncCoreOffset = AxiRegMap_GetOffset(dev, REG_GPU_ASYNC);
+
    // Skip GPU init if the module is not enabled
    if (readl(dev->base + AVER_OFF + 0x428) == 1 && gpuAsyncCoreOffset != INVALID_REG_OFFSET) {
       // GPU Init

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -34,6 +34,7 @@
 #include <linux/slab.h>
 #include <axis_gen2.h>
 #include <GpuAsync.h>
+#include <axi_pcie_regmap.h>
 
 #ifdef DATA_GPU
 #include <GpuAsyncRegs.h>
@@ -175,6 +176,7 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    int32_t x;
    uint32_t axiWidth;
    int ret;
+   uint32_t axiGen2Offset, phyOffset, axiSysMonOffset, gpuAsyncCoreOffset;
 
    // Validate buffer mode configuration
    if ( cfgMode != BUFF_COHERENT && cfgMode != BUFF_STREAM ) {
@@ -270,6 +272,24 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
       goto err_post_en;
    }
 
+   // Init the PCIe memory map
+   if (AxiRegMap_Init(dev, dev->base + AVER_OFF) < 0) {
+      probeReturn = -EINVAL;
+      goto err_unmap;
+   }
+
+   // Grab required offsets
+   phyOffset = AxiRegMap_GetOffset(dev, REG_PHY);
+   axiGen2Offset = AxiRegMap_GetOffset(dev, REG_AXIS_GEN2);
+   if (phyOffset == INVALID_REG_OFFSET || axiGen2Offset == INVALID_REG_OFFSET) {
+      probeReturn = -EINVAL;
+      goto err_unmap;
+   }
+
+   // Optional offsets
+   axiSysMonOffset = AxiRegMap_GetOffset(dev, REG_AXI_SYSMON);
+   gpuAsyncCoreOffset = AxiRegMap_GetOffset(dev, REG_GPU_ASYNC);
+
    // Initialize device configuration parameters
    dev->cfgTxCount    = cfgTxCount;    // Transmit buffer count
    dev->cfgRxCount    = cfgRxCount;    // Receive buffer count
@@ -330,15 +350,15 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
    dev->hwFunc = hfunc;           // Hardware function pointer
 
    // Initialize device memory regions
-   dev->reg    = dev->base + AGEN2_OFF;    // Register base address
-   dev->rwBase = dev->base + PHY_OFF;      // Read/Write base address
-   dev->rwSize = (2*USER_SIZE) - PHY_OFF;  // Read/Write region size
+   dev->reg    = dev->base + axiGen2Offset;  // Register base address
+   dev->rwBase = dev->base + phyOffset;      // Read/Write base address
+   dev->rwSize = (2*USER_SIZE) - phyOffset;  // Read/Write region size
 
 #ifdef DATA_GPU
    // Skip GPU init if the module is not enabled
-   if (readl(dev->base + AVER_OFF + 0x428) == 1) {
+   if (readl(dev->base + AVER_OFF + 0x428) == 1 && gpuAsyncCoreOffset != INVALID_REG_OFFSET) {
       // GPU Init
-      probeReturn = Gpu_Init(dev, GPU_ASYNC_CORE_OFFSET);
+      probeReturn = Gpu_Init(dev, gpuAsyncCoreOffset);
       if (probeReturn < 0) {
          dev_err(dev->device, "Init: Gpu_Init returned error %i.\n", probeReturn);
          goto err_unmap;
@@ -386,8 +406,10 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
       goto err_unmap;
    }
 
-   // Register hwmon interface
-   AxiHwmon_Init(dev, AVER_OFF, ASYSMON_OFF);
+   // Register hwmon interface, if supported.
+   if (axiSysMonOffset != INVALID_REG_OFFSET) {
+      AxiHwmon_Init(dev, AVER_OFF, axiSysMonOffset);
+   }
 
    // Log memory mapping information
    dev_info(dev->device, "Init: Reg space mapped to 0x%p.\n", dev->reg);

--- a/common/driver/data_dev_top.h
+++ b/common/driver/data_dev_top.h
@@ -32,16 +32,18 @@
 #define PCI_DEVICE_ID_DDEV 0x2030
 
 /** Address map for device registers. */
-#define AGEN2_OFF   0x00000000 /**< DMAv2 Engine Offset */
-#define AGEN2_SIZE  0x00010000 /**< DMAv2 Engine Size */
-#define PHY_OFF     0x00010000 /**< PCIe PHY Offset */
-#define PHY_SIZE    0x00010000 /**< PCIe PHY Size */
-#define AVER_OFF    0x00020000 /**< AxiVersion Offset */
-#define AVER_SIZE   0x00010000 /**< AxiVersion Size */
-#define PROM_OFF    0x00030000 /**< PROM Offset */
-#define PROM_SIZE   0x00050000 /**< PROM Size */
-#define USER_OFF    0x00800000 /**< User Space Offset */
-#define USER_SIZE   0x00800000 /**< User Space Size */
+#define AGEN2_OFF    0x00000000 /**< DMAv2 Engine Offset */
+#define AGEN2_SIZE   0x00010000 /**< DMAv2 Engine Size */
+#define PHY_OFF      0x00010000 /**< PCIe PHY Offset */
+#define PHY_SIZE     0x00010000 /**< PCIe PHY Size */
+#define AVER_OFF     0x00020000 /**< AxiVersion Offset */
+#define AVER_SIZE    0x00010000 /**< AxiVersion Size */
+#define ASYSMON_OFF  0x00024000 /**< AxiSysMonUltraScale Offset */
+#define ASYSMON_SIZE 0x00004000 /*<< AxiSysMonUltraScale Size */
+#define PROM_OFF     0x00030000 /**< PROM Offset */
+#define PROM_SIZE    0x00050000 /**< PROM Size */
+#define USER_OFF     0x00800000 /**< User Space Offset */
+#define USER_SIZE    0x00800000 /**< User Space Size */
 
 // Function prototypes
 int32_t DataDev_Init(void);

--- a/common/driver/data_dev_top.h
+++ b/common/driver/data_dev_top.h
@@ -31,19 +31,11 @@
 #define PCI_VENDOR_ID_SLAC 0x1a4a
 #define PCI_DEVICE_ID_DDEV 0x2030
 
-/** Address map for device registers. */
-#define AGEN2_OFF    0x00000000 /**< DMAv2 Engine Offset */
-#define AGEN2_SIZE   0x00010000 /**< DMAv2 Engine Size */
-#define PHY_OFF      0x00010000 /**< PCIe PHY Offset */
-#define PHY_SIZE     0x00010000 /**< PCIe PHY Size */
-#define AVER_OFF     0x00020000 /**< AxiVersion Offset */
-#define AVER_SIZE    0x00010000 /**< AxiVersion Size */
-#define ASYSMON_OFF  0x00024000 /**< AxiSysMonUltraScale Offset */
-#define ASYSMON_SIZE 0x00004000 /*<< AxiSysMonUltraScale Size */
-#define PROM_OFF     0x00030000 /**< PROM Offset */
-#define PROM_SIZE    0x00050000 /**< PROM Size */
-#define USER_OFF     0x00800000 /**< User Space Offset */
-#define USER_SIZE    0x00800000 /**< User Space Size */
+/** Offsets and sizes. These are needed during early initialization. */
+#define AVER_OFF     0x00020000  /** AxiVersion offset */
+#define AVER_SIZE    0x00010000  /** AxiVersion size */
+#define USER_OFF     0x00800000  /** User offset */
+#define USER_SIZE    0x00800000  /** User size */
 
 // Function prototypes
 int32_t DataDev_Init(void);

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -90,6 +90,7 @@ typedef uint32_t __poll_t;
  * @rxBuffers: List of receive buffers.
  * @tq: Transmit queue structure.
  * @regMapVersion: The register map version.
+ * @hwmonPrivate: Private data for the AXI Hwmon interface (axi_hwmon.c)
  *
  * This structure defines a DMA device, including its configuration,
  * memory regions, buffer management, and associated locks.
@@ -163,7 +164,6 @@ struct DmaDevice {
    // Transmit queue
    struct DmaQueue tq;
 
-   // For axi_hwmon.c
    void* hwmonPrivate;
 
    uint32_t regMapVersion;

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -161,6 +161,9 @@ struct DmaDevice {
 
    // Transmit queue
    struct DmaQueue tq;
+
+   // For axi_hwmon.c
+   void* hwmonPrivate;
 };
 
 /**

--- a/common/driver/dma_common.h
+++ b/common/driver/dma_common.h
@@ -89,6 +89,7 @@ typedef uint32_t __poll_t;
  * @txBuffers: List of transmit buffers.
  * @rxBuffers: List of receive buffers.
  * @tq: Transmit queue structure.
+ * @regMapVersion: The register map version.
  *
  * This structure defines a DMA device, including its configuration,
  * memory regions, buffer management, and associated locks.
@@ -164,6 +165,8 @@ struct DmaDevice {
 
    // For axi_hwmon.c
    void* hwmonPrivate;
+
+   uint32_t regMapVersion;
 };
 
 /**

--- a/data_dev/driver/Makefile
+++ b/data_dev/driver/Makefile
@@ -83,7 +83,7 @@ endif
 $(info $(ccflags-y))
 
 # Object files that make up the module
-$(NAME)-objs := src/dma_buffer.o src/dma_common.o
+$(NAME)-objs := src/dma_buffer.o src/dma_common.o src/axi_pcie_regmap.o
 $(NAME)-objs += src/axi_version.o src/axis_gen2.o src/data_dev_top.o src/axi_hwmon.o
 
 ifneq ($(NVIDIA_DRIVERS),)

--- a/data_dev/driver/Makefile
+++ b/data_dev/driver/Makefile
@@ -84,7 +84,7 @@ $(info $(ccflags-y))
 
 # Object files that make up the module
 $(NAME)-objs := src/dma_buffer.o src/dma_common.o
-$(NAME)-objs += src/axi_version.o src/axis_gen2.o src/data_dev_top.o
+$(NAME)-objs += src/axi_version.o src/axis_gen2.o src/data_dev_top.o src/axi_hwmon.o
 
 ifneq ($(NVIDIA_DRIVERS),)
 $(NAME)-objs += src/gpu_async.o

--- a/data_dev/driver/src/axi_hwmon.c
+++ b/data_dev/driver/src/axi_hwmon.c
@@ -1,0 +1,1 @@
+../../../common/driver/axi_hwmon.c

--- a/data_dev/driver/src/axi_hwmon.h
+++ b/data_dev/driver/src/axi_hwmon.h
@@ -1,0 +1,1 @@
+../../../common/driver/axi_hwmon.h

--- a/data_dev/driver/src/axi_pcie_regmap.c
+++ b/data_dev/driver/src/axi_pcie_regmap.c
@@ -1,0 +1,1 @@
+../../../common/driver/axi_pcie_regmap.c

--- a/data_dev/driver/src/axi_pcie_regmap.h
+++ b/data_dev/driver/src/axi_pcie_regmap.h
@@ -1,0 +1,1 @@
+../../../common/driver/axi_pcie_regmap.h


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

This makes some sensors in the UltraScale SysMon IP block appear under /sys/class/hwmon, and in commands such as 'sensors' (from the lm-sensors package).

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

Memory map versioning (here: https://github.com/slaclab/axi-pcie-core/pull/212) is used to determine if AxiSysMon is present or not. This versioning is compatible with older firmware versions, but assumes the sysmon IP block is not present because it was only added in ~2022 or so.

### JIRA
<!--- Optional. Provide a link to any relevant JIRA ticket here. Otherwise you can delete this section -->

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->