### PR TITLE
fix(data_dev): build DKMS module against target kernel, not running kernel

### DIFF
--- a/data_dev/driver/dkms-gpu.conf
+++ b/data_dev/driver/dkms-gpu.conf
@@ -1,6 +1,6 @@
 PRE_BUILD="./build-nvidia.sh -s $source_tree -v $kernelver"
-CLEAN="make clean"
-MAKE="make"
+CLEAN="make clean KVER=$kernelver"
+MAKE="make KVER=$kernelver"
 BUILT_MODULE_NAME=datadev
 BUILT_MODULE_LOCATION=.
 DEST_MODULE_LOCATION="/kernel/modules/misc"

--- a/data_dev/driver/dkms.conf
+++ b/data_dev/driver/dkms.conf
@@ -1,5 +1,5 @@
-MAKE="make"
-CLEAN="make clean"
+MAKE="make KVER=$kernelver"
+CLEAN="make clean KVER=$kernelver"
 BUILT_MODULE_NAME=datadev
 BUILT_MODULE_LOCATION=.
 DEST_MODULE_LOCATION="/kernel/modules/misc"


### PR DESCRIPTION
## Problem

`data_dev/driver/dkms.conf` (and `dkms-gpu.conf`) set `MAKE="make"` with no kernel argument. The module Makefile then falls back to:

```make
KVER ?= $(shell uname -r)                # line 35
KERNELDIR := /lib/modules/$(KVER)/build  # line 45
```

So a DKMS build compiles `datadev.ko` against **whatever kernel is currently booted**, not the kernel DKMS is actually targeting.

On a host where a new kernel is installed via `apt` while still booted on the old one, `dkms autoinstall` fires with the **old** `uname -r` and bakes the old `vermagic` into the module placed in the **new** kernel's tree. After rebooting into the new kernel, the module is rejected:

```
datadev: disagrees about version of symbol module_layout
```

and never loads — so `/dev/datadev_0` and `/proc/datadev_0` are absent even though `dkms status` reports `installed` (DKMS only checks that a `.ko` landed in the tree, not its vermagic).

Observed in the field on an Ubuntu 22.04 HWE host: running `6.8.0-136-generic`, but the module in `/lib/modules/6.8.0-136-generic/updates/dkms/datadev.ko` had `vermagic: 6.8.0-124-generic`. All three per-kernel trees held the identical `6.8.0-124`-stamped `.ko`, and every `make.log` showed `Entering directory '/usr/src/linux-headers-6.8.0-124-generic'`.

## Fix

Pass `KVER=$kernelver` (DKMS expands `$kernelver` to the target kernel) in `MAKE` and `CLEAN` for both the CPU and GPU configs. The Makefile already honors a `KVER` override — no Makefile change needed. `KERNELDIR` then resolves to `/lib/modules/$kernelver/build` and each per-kernel build gets the correct vermagic.

`dkms-gpu.conf` already uses `$kernelver` in its `PRE_BUILD`, confirming DKMS substitutes the variable in these configs.

## Verification

Dry-run confirms `KVER` correctly redirects `KERNELDIR` to the target kernel's build tree:

```
$ make -n KVER=6.8.0-124-generic | grep -m1 -- '-C /lib/modules'
make ARCH=x86_64 CROSS_COMPILE= -C /lib/modules/6.8.0-124-generic/build M=... modules
```

(Without the override it uses the running kernel `6.8.0-136-generic`.)

The existing `test-dkms-cpu.sh` / `test-dkms-gpu.sh` build+install tests exercise this path in CI.