### PR TITLE
fix(data_dev): stamp DKMS package version into the build

### DIFF
--- a/data_dev/driver/Makefile
+++ b/data_dev/driver/Makefile
@@ -59,6 +59,14 @@ endif
 # core.fsmonitor / pager / credential helper there cannot ride along.
 GIT := GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null git -c safe.directory='*'
 
+# Version frozen at package time by the `dkms` target below.  A packaged DKMS
+# source tree under /usr/src carries no git metadata, so the describe logic
+# below cannot work there; version.mk supplies GITV instead and short-circuits
+# it.  Absent in a git worktree, where describe applies as usual.
+# $(HOME)-qualified because kbuild re-reads this Makefile from a sub-make whose
+# working directory is $(KERNELDIR), where a bare relative path would miss.
+-include $(HOME)/version.mk
+
 # Automatically determine the git version
 ifndef GITV
     GITT := $(shell cd $(HOME); $(GIT) describe --tags 2>/dev/null)
@@ -66,7 +74,7 @@ ifndef GITV
         GITT := $(shell cd $(HOME); $(GIT) rev-parse --short HEAD 2>/dev/null)
     endif
     ifeq ($(GITT),)
-        GITT := emulator
+        GITT := unknown
     endif
     GITD := $(shell cd $(HOME); $(GIT) status --short -uno 2>/dev/null | wc -l)
     GITV := $(if $(filter $(GITD),0),$(GITT),$(GITT)-dirty)
@@ -119,6 +127,7 @@ define dkms_configure
 	$(if $(4),cp -vL $(4) $(1)/dkms_source_tree/)
 	cp -vL rc.local.in $(1)/dkms_source_tree/
 	echo "PACKAGE_VERSION=$(GITV)"	 					>> $(1)/dkms_source_tree/dkms.conf
+	echo "GITV := $(GITV)" 								 > $(1)/dkms_source_tree/version.mk
 	echo "$(NAME)" 										>> $(1)/dkms_source_tree/$(2)_load.conf
 	echo "#!/bin/bash" 									 > $(1)/dkms_source_tree/install.sh
 	echo "dkms add -m $(2)-dkms -v $(GITV)" 			>> $(1)/dkms_source_tree/install.sh


### PR DESCRIPTION
## Problem

The released 7.5.0 DKMS packages report the wrong driver version. On an rdsrv
node running `datadev-dkms/7.5.0`:

```
$ cat /proc/datadev_0
...
-------- DMA Kernel Driver General --------
 DMA Driver's Git Version : emulator
```

`emulator` is a real driver in this repo (the virtual-PCI CI harness), so the
output reads like the wrong module was loaded rather than "version could not be
determined". The same string is returned by the `DMA_Get_GITV` ioctl, so any
tool that logs the driver version records it too. That makes the field useless
for the one thing it exists for: confirming which driver build is resident when
correlating a DMA problem against a firmware image.

## Root cause

`GITV` is derived from git metadata at **compile** time, but DKMS splits
packaging from compilation:

1. **Package time**, in CI at the tag: `make -C data_dev/driver dkms` resolves
   `GITV` correctly and stamps it into the staged `dkms.conf` as
   `PACKAGE_VERSION`. This part works, the installed
   `/usr/src/datadev-dkms-7.5.0/dkms.conf` really does say `PACKAGE_VERSION=7.5.0`.
2. **Staging drops git.** `.dkms-common` copies only `src/`, `Makefile`,
   `datadev.conf`, and `rc.local.in`. No `.git` is included, and none could
   exist under `/usr/src` anyway.
3. **Compile time**, on the target host, when the package `postinst` runs
   `dkms build`. DKMS invokes `MAKE="make KVER=$kernelver"` from `dkms.conf`,
   which does not pass `GITV`.
4. The Makefile therefore re-derives `GITV` in the DKMS build dir, finds no git
   metadata, and falls through to `emulator`.

From the affected host's own DKMS log
(`/var/lib/dkms/datadev-dkms/7.5.0/6.8.0-136-generic/x86_64/log/make.log`):

```
-DGITV=\"emulator\"
Building with version: emulator
```

The correct version is already known at step 1 and simply is not carried across
the boundary into step 3.

## Fix

Freeze the packaging-time version into a generated `version.mk` that ships
inside the DKMS source tree, and `-include` it from the Makefile. Version
authority stays where it is genuinely known (CI, in a git checkout); the compile
step reads it instead of re-deriving it.

The include is qualified with `$(HOME)` rather than left relative, because
kbuild re-reads this Makefile from a sub-make whose working directory is
`$(KERNELDIR)`. A bare `-include version.mk` silently misses there and still
produces the fallback string. This is only observable in a real compile, not in
`make -n`.

Because `dkms_configure` is shared by the CPU and GPU targets, both package
flavors are stamped without touching `dkms.conf` or `dkms-gpu.conf`. Nothing
needs gitignoring: `version.mk` is written only into `.dkms-*/` staging dirs,
already covered by the root `.gitignore`.

Alternative considered and rejected: setting
`MAKE="make KVER=$kernelver GITV=$module_version"` in `dkms.conf`. It does work,
but `module_version` is an undocumented DKMS internal absent from DKMS's own
`dkms_conf_variables` allowlist, and it would leave the `rc.local.in` boot-time
`make clean; make` path still emitting the fallback. `version.mk` depends only
on make and covers every compile path (`postinst`, `%post`, generated
`install.sh`, and `rc.local`).

The fallback is also renamed `emulator` -> `unknown`. With this fix it should be
unreachable for packaged builds, so if it ever surfaces it should read as a
diagnostic instead of the name of another driver.

## Verification

Done on an Ubuntu 22.04 host against kernel 6.8.0-136-generic. The installed
7.5.0 package was deliberately left untouched, so all checks ran against
extracted tarballs and an isolated DKMS tree.

- **Both flavors stamped.** `version.mk` matches `PACKAGE_VERSION` in the CPU and
  GPU tarballs (`GITV := 7.5.0-dirty` in both).
- **The actual regression, fixed.** A git-less extracted tree now yields
  `-DGITV=\"7.5.0-dirty\"`; the same check against the installed
  `/usr/src/datadev-dkms-7.5.0` still prints `emulator`.
- **End to end through real DKMS.** `dkms build` into an isolated `--dkmstree`
  logged `Building with version: 7.5.0-dirty`, and the resulting `.ko` contains
  `DMA Driver's Git Version : 7.5.0-dirty` with zero occurrences of `emulator`.
- **Worktree builds unaffected.** With `version.mk` absent, a dirty tree still
  resolves `7.5.0-dirty` and a clean tree `7.5.0`, confirming the `-dirty`
  suffix still comes from git and is not pinned by the stamp.
- **Override precedence intact.** `make GITV=9.9.9` still wins, so the CI smoke
  tests that pass `GITV` explicitly are unaffected.
- **Fallback reachable only when intended.** With neither git metadata nor
  `version.mk`, the build yields `unknown`.

## Notes

- The fleet will not see this until a tagged release is cut; sdf-ansible picks up
  new versions from the GitHub release assets
  (slaclab/sdf-ansible#857), so no ansible change is needed.
- `emulator/driver/Makefile` and the `rce_*/driver/Makefile` files share the
  git-describe idiom but are not DKMS-packaged, so they are out of scope here.
- Worth considering a follow-up CI assertion that the staged `version.mk` matches
  `PACKAGE_VERSION`. The existing smoke tests pass `GITV` explicitly, so they
  would not have caught this.
