### PR TITLE
rdmaTest offset fix

### DIFF
--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -634,7 +634,7 @@ void Gpu_Show(struct seq_file *s, struct DmaDevice *dev) {
       seq_printf(s, "       Min Read Buffers : %u\n", readGpuAsyncReg(data->base, &GpuAsyncReg_MinReadBuffer));
    }
    seq_printf(s, "   AXI Read Error Count : %u\n", readGpuAsyncReg(data->base, &GpuAsyncReg_AxiReadErrorCnt));
-   seq_printf(s, "         Owning Process : %lu\n", atomic64_read(&data->pid));
+   seq_printf(s, "         Owning Process : %llu\n", atomic64_read(&data->pid));
 
    for (i = 0; i < writeBuffCnt && writeEnable; ++i) {
       u32 wal, wah, ws;

--- a/data_dev/app/src/rdmaTest.cu
+++ b/data_dev/app/src/rdmaTest.cu
@@ -399,7 +399,8 @@ static void runSimpleLoop(TestSession& s) {
         if (dumpBytes != 0U) {
             const size_t maxCount = static_cast<size_t>(s.bufSize) +
                                     static_cast<size_t>(s.dmaHeaderSize);
-            size_t count = std::min(std::min(static_cast<size_t>(hdr.size),
+            size_t count = std::min(std::min(static_cast<size_t>(s.dmaHeaderSize) +
+                                             static_cast<size_t>(hdr.size),
                                              dumpBytes), maxCount);
             assertOk(cudaMemcpy(tmpbuf.data(), s.rxBuffers[curBuff], count,
                                 cudaMemcpyDeviceToHost));


### PR DESCRIPTION
This change includes the dmaHeaderSize in the byte count to cudaMemcpy for dumping the first N bytes of the DMA transfer.

### Description
The size reported in the DMA header is the size (in bytes) of the payload that was transferred to the GPU.  It does not include the size of the DMA header itself.  This change adjusts the number of bytes to copy from the GPU to the CPU for dumping the DMA header (rounded up to the DMA frame size) and the DMA payload to stdout.
