### PR TITLE
Abort datadev probe when the AxiVersion uptime counter reads all-ones

### DIFF
--- a/common/driver/axi_version.c
+++ b/common/driver/axi_version.c
@@ -214,3 +214,20 @@ void AxiVersion_SetUserReset(__iomem void *base, bool state) {
 
    writel(val, &(reg->userReset));  // Write the value to the userReset register
 }
+
+/**
+ * AxiVersion_GetUpTime - Reads the AXI version uptime counter.
+ * @base: Pointer to the base address of the AXI Version register block.
+ *
+ * Reads the free-running counter that tracks the number of seconds since the
+ * FPGA left reset. Besides reporting uptime, this register doubles as a cheap
+ * liveness check on the register interface: all-ones is not a value real
+ * firmware can report, so it indicates the read never reached the FPGA.
+ *
+ * Return: the raw contents of the uptime counter register.
+ */
+uint32_t AxiVersion_GetUpTime(__iomem void *base) {
+   __iomem struct AxiVersion_Reg *reg = (__iomem struct AxiVersion_Reg *)base;
+
+   return readl(&(reg->upTimeCount));
+}

--- a/common/driver/axi_version.h
+++ b/common/driver/axi_version.h
@@ -89,5 +89,6 @@ int32_t AxiVersion_Get(struct DmaDevice *dev, __iomem void *base, uint64_t arg);
 void AxiVersion_Read(struct DmaDevice *dev, __iomem void *base, struct AxiVersion *aVer);
 void AxiVersion_Show(struct seq_file *s, struct DmaDevice *dev, struct AxiVersion *aVer);
 void AxiVersion_SetUserReset(__iomem void *base, bool state);
+uint32_t AxiVersion_GetUpTime(__iomem void *base);
 
 #endif  // __AXI__VERSION_H__

--- a/common/driver/data_dev_top.c
+++ b/common/driver/data_dev_top.c
@@ -273,6 +273,33 @@ int DataDev_Probe(struct pci_dev *pcidev, const struct pci_device_id *dev_id) {
       goto err_post_en;
    }
 
+   // Early PCIe liveness check, before any other register read or resource
+   // allocation. The AxiVersion uptime counter counts seconds since the FPGA
+   // left reset, so all-ones (2^32 - 1 seconds, roughly 136 years) is not a
+   // value real firmware can ever report. Reading it back means the PCIe read
+   // never reached the FPGA and was completed with an abort or a timeout
+   // instead. That is what happens when the FPGA is reprogrammed and neither a
+   // reboot nor a PCIe rescan was performed afterwards to bring the link back
+   // up. There is no point continuing: every register read past this point
+   // returns the same all-ones garbage, and the failure then surfaces far from
+   // its cause. AxiRegMap_Init() below would read 0xFF as the register map
+   // version and advise a driver upgrade, and a card that got past that would
+   // report a nonsensical DMA mask followed by a zero-sized descriptor ring
+   // allocation failing with -ENOMEM.
+   //
+   // Guarded by a bounds check because Dma_MapReg() ioremaps exactly baseSize
+   // bytes, and the emulator can shrink BAR0 under memory fragmentation.
+   if ( dev->baseSize >= (AVER_OFF + sizeof(struct AxiVersion_Reg)) ) {
+      if ( AxiVersion_GetUpTime(dev->base + AVER_OFF) == 0xFFFFFFFF ) {
+         dev_err(dev->device,
+                 "Init: AxiVersion uptime counter reads all-ones; the PCIe link to the "
+                 "FPGA is down. Reboot the host or rescan the PCIe bus to recover the "
+                 "link after reprogramming the FPGA.\n");
+         probeReturn = -EIO;
+         goto err_unmap;
+      }
+   }
+
    // Init the PCIe memory map
    if (AxiRegMap_Init(dev, dev->base + AVER_OFF) < 0) {
       probeReturn = -EINVAL;


### PR DESCRIPTION
### Description

The `datadev` probe now reads the AxiVersion uptime counter immediately after the register space is mapped and fails with `-EIO` if it reads all-ones. The uptime counter counts seconds since the FPGA left reset, so `0xFFFFFFFF` (2^32 - 1 seconds, roughly 136 years) is not a value real firmware can report. Reading it back means the PCIe read never reached the FPGA and was completed with an abort or a timeout instead, which is what happens when the FPGA is reprogrammed and neither a reboot nor a PCIe rescan was performed afterwards to bring the link back up.

Every register read past that point returns the same all-ones garbage, so without an early check the probe fails much later and for reasons that point away from the actual cause. The new failure message names the real problem and the recovery action:

```
datadev 0000:af:00.0: Init: AxiVersion uptime counter reads all-ones; the PCIe
link to the FPGA is down. Reboot the host or rescan the PCIe bus to recover the
link after reprogramming the FPGA.
```

Also adds `AxiVersion_GetUpTime()` so the counter offset stays expressed through `struct AxiVersion_Reg` rather than a bare constant.

### Details

This came out of a field report on `drp-neh-cmp018`, where a card in this state produced:

```
datadev 0000:af:00.0: Init: Using 255-bit DMA mask.
datadev 0000:af:00.0: Init: Using 255-bit coherent DMA mask.
datadev 0000:af:00.0: Init: dma_alloc_coherent failed for read ring (size=0).
datadev 0000:af:00.0: Init: Card-specific init failed: -12.
```

Both oddities trace back to all-ones register reads:

- `data_dev_top.c` computes `axiWidth = (readl(dev->reg + 0x34) >> 8) & 0xFF`, giving 255. `DMA_BIT_MASK(255)` shifts by more than the operand width, and on x86-64 the count is masked to 6 bits, yielding a 63-bit mask that `dma_set_mask()` accepts. The probe continued instead of stopping.
- `axis_gen2.c` computes `hwData->addrCount = (1 << readl(&(reg->addrWidth)))`. With 255, the 32-bit shift count is masked to 5 bits, giving `0x80000000`; multiplying by 16 for 128-bit descriptors overflows `uint32_t` to exactly 0. `dma_alloc_coherent(dev, 0, ...)` then returns NULL and reports `-ENOMEM`, which reads as a host memory problem rather than a dead link.

On this branch the first misleading symptom would instead come from `AxiRegMap_Init()`, which reads `0xFFFFFFFF & 0xFF` as the register map version and warns "Unsupported register map version 255. Maximum supported version is N / Please use a newer driver version", advising a driver upgrade for what is actually a link problem. The new check is placed between `Dma_MapReg()` and `AxiRegMap_Init()` so it runs before that.
uild_version`, would make it testable.