### PR TITLE
gpu_async: Make GpuAsyncCore ownership per process, not per thread

### DIFF
--- a/common/driver/gpu_async.c
+++ b/common/driver/gpu_async.c
@@ -201,10 +201,10 @@ int32_t Gpu_AddNvidia(struct DmaDevice *dev, uint64_t arg) {
    }
 
    // Check if another PID already owns this GpuAsyncCore state
-   pid_t pid = atomic64_cmpxchg(&data->pid, 0, current->pid);
-   if (pid != 0 && pid != current->pid) {
+   pid_t pid = atomic64_cmpxchg(&data->pid, 0, current->tgid);
+   if (pid != 0 && pid != current->tgid) {
       dev_warn(dev->device, "Gpu_AddNvidia: error: Calling PID (%d) GpuAsyncCore state already locked by PID %d\n",
-               current->pid, pid);
+               current->tgid, pid);
       return -EBUSY;
    }
 
@@ -480,10 +480,10 @@ int32_t Gpu_RemNvidia(struct DmaDevice *dev, uint64_t arg) {
    dev_info(dev->device, "Gpu_RemNvidia: Called\n");
 
    // Ensure the calling PID actually owns the state
-   pid_t pid = atomic64_cmpxchg(&data->pid, current->pid, 0);
-   if (pid != current->pid) {
+   pid_t pid = atomic64_cmpxchg(&data->pid, current->tgid, 0);
+   if (pid != current->tgid) {
       dev_warn(dev->device, "Gpu_RemNvidia: Called by PID (%d) that doesn't own the GpuAsyncCore state!\n",
-               current->pid);
+               current->tgid);
       return -EBUSY;
    }
 
@@ -555,9 +555,9 @@ int32_t Gpu_SetWriteEn(struct DmaDevice *dev, uint64_t arg) {
 
    // Check for calling process ownership. Unlocked GpuAsyncCore is OK
    pid_t pid = atomic64_read(&data->pid);
-   if (pid && pid != current->pid) {
+   if (pid && pid != current->tgid) {
       dev_warn(dev->device, "Gpu_SetWriteEn: Called by non-owner PID (%d)\n",
-               current->pid);
+               current->tgid);
       return -EBUSY;
    }
 
@@ -680,9 +680,9 @@ int32_t Gpu_EnableTx(struct DmaDevice *dev, uint64_t enable) {
 
    // Check for calling process ownership. Unlocked GpuAsyncCore is OK
    pid_t pid = atomic64_read(&data->pid);
-   if (pid && pid != current->pid) {
-      dev_warn(dev->device, "Gpu_SetWriteEn: Called by non-owner PID (%d)\n",
-               current->pid);
+   if (pid && pid != current->tgid) {
+      dev_warn(dev->device, "Gpu_EnableTx: Called by non-owner PID (%d)\n",
+               current->tgid);
       return -EBUSY;
    }
 
@@ -707,9 +707,9 @@ int32_t Gpu_EnableRx(struct DmaDevice *dev, uint64_t enable) {
 
    // Check for calling process ownership. Unlocked GpuAsyncCore is OK
    pid_t pid = atomic64_read(&data->pid);
-   if (pid && pid != current->pid) {
-      dev_warn(dev->device, "Gpu_SetWriteEn: Called by non-owner PID (%d)\n",
-               current->pid);
+   if (pid && pid != current->tgid) {
+      dev_warn(dev->device, "Gpu_EnableRx: Called by non-owner PID (%d)\n",
+               current->tgid);
       return -EBUSY;
    }
 

--- a/common/driver/gpu_async.h
+++ b/common/driver/gpu_async.h
@@ -101,7 +101,10 @@ struct GpuData {
    int32_t version;
    uint32_t maxBuffers;
    uint32_t disabled;
-   atomic64_t pid;
+   atomic64_t pid;              // TGID of the owning process, or 0 when unowned.
+                                // Compared against current->tgid, not current->pid:
+                                // ownership is per process, so that any thread may
+                                // issue the GpuAsyncCore ioctls.
    struct GpuBuffers writeBuffers;
    struct GpuBuffers readBuffers;
 };


### PR DESCRIPTION
Make GpuAsyncCore ownership per process, not per thread.

### Description
GpuAsync.h documents the GpuAsyncCore state as "exclusively owned by one process    at a time", but the ownership checks compare against current->pid, which in the kernel is the thread id; current->tgid is what userspace calls the PID.  A multithreaded process that claims ownership with gpuAddNvidiaMemory() on one thread therefore cannot call gpuSetWriteEn(), gpuEnableTx() or gpuEnableRx() from any other thread: the ioctl fails with EBUSY and the driver logs

      datadev 0000:04:00.0: Gpu_SetWriteEn: Called by non-owner PID (3417898)

even though 3417898 is a thread of the owning process.

This is how the LCLS-II GPU DRP is structured: MemPoolGpu's constructor registers the GPU buffers, while the per-device threads that rearm DMA buffers for writing call gpuSetWriteEn(), so every rearm is rejected.

Compare against current->tgid in all five ownership sites, which is what the documented contract calls for and lets any thread of the owning process issue the ioctls.  Also note the semantics at the field declaration, since it stores a TGID rather than the thread id its name suggests.

While here, Gpu_EnableTx() and Gpu_EnableRx() both logged their non-owner warning as "Gpu_SetWriteEn", which misdirects anyone diagnosing this; name the right function in each.