### PR TITLE
emulator: Replace irq_domain_add_linear with irq_domain_create_linear

### DIFF
--- a/emulator/driver/src/virt_irq.c
+++ b/emulator/driver/src/virt_irq.c
@@ -93,9 +93,11 @@ int emu_irq_create(struct emu_irq *irq)
 {
    irq->hwirq = 0;
 
-   /* Create a linear IRQ domain with no device-tree node */
-   irq->domain = irq_domain_add_linear(NULL, EMU_IRQ_COUNT,
-                                        &emu_irq_domain_ops, irq);
+   /* Create a linear IRQ domain with no firmware node. irq_domain_add_linear()
+    * was removed in Linux 7.x; irq_domain_create_linear() (4.7+) with a NULL
+    * fwnode is the equivalent call. */
+   irq->domain = irq_domain_create_linear(NULL, EMU_IRQ_COUNT,
+                                           &emu_irq_domain_ops, irq);
    if (irq->domain == NULL) {
       pr_err("emu: failed to create IRQ domain\n");
       return -ENOMEM;


### PR DESCRIPTION
Fixes the datadev_emulator build on fedora:rawhide, which moved to kernel 7.3.0-rc2 where irq_domain_add_linear() no longer exists.

- virt_irq.c now calls irq_domain_create_linear() with a NULL fwnode, identical to what the removed wrapper did
- Available since Linux 4.7, so no version guard is needed; virt_msi.c already uses it unconditionally and builds on Rocky 9 (5.14) and Ubuntu 22.04 (5.15)
- Failing run: https://github.com/slaclab/aes-stream-drivers/actions/runs/34667343501